### PR TITLE
fix: remove broken field prefix from S2 citations/references client

### DIFF
--- a/src/scholar_mcp/_s2_client.py
+++ b/src/scholar_mcp/_s2_client.py
@@ -162,7 +162,7 @@ class S2Client:
         return await self._get(
             f"/paper/{paper_id}/citations",
             retry=retry,
-            fields=f"citingPaper.{fields}",
+            fields=fields,
             limit=limit,
             offset=offset,
             year=year,
@@ -194,7 +194,7 @@ class S2Client:
         return await self._get(
             f"/paper/{paper_id}/references",
             retry=retry,
-            fields=f"citedPaper.{fields}",
+            fields=fields,
             limit=limit,
             offset=offset,
         )


### PR DESCRIPTION
## Summary

- The S2 client was prefixing fields with `citingPaper.`/`citedPaper.` for the citations and references endpoints (`f"citingPaper.{fields}"`), but this only prefixed the **first** field in the comma-separated string
- The S2 API accepts plain field names for these endpoints — it applies them to the nested object automatically
- Result: `citingPaper.title,year,venue,citationCount,paperId` → only `citingPaper.title` gets prefixed (unrecognized), while `year`, `citationCount` etc. are returned as context-level fields not paper-level
- This caused `title: null` on all expanded citation/reference nodes, and incorrect `citationCount` values that made `min_citations` filtering appear broken

Root cause of both bugs reported post-PR #32.

## Test plan

- [x] All 144 existing tests pass (test mocks return correct data regardless of query params, so the bug was invisible in tests)
- [x] Manual verification needed against live S2 API to confirm field values are now populated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)