### PR TITLE
fix: paginate S2 citations for min_citations filter

### DIFF
--- a/src/scholar_mcp/_tools_graph.py
+++ b/src/scholar_mcp/_tools_graph.py
@@ -130,6 +130,9 @@ def register_graph_tools(mcp: FastMCP) -> None:
                         exhausted = True
                         break
 
+                # When exhausted is True, S2 has no more data — an
+                # empty slice here simply means the offset is beyond
+                # the available filtered results (not a truncation).
                 result: dict[str, object] = {"data": filtered[offset : offset + limit]}
                 if (
                     not exhausted
@@ -331,7 +334,10 @@ def register_graph_tools(mcp: FastMCP) -> None:
                             else fetch_limit
                         )
                         s2_off = 0
-                        while s2_off < scan_cap:
+                        while (
+                            s2_off < scan_cap
+                            and len(nodes) + len(new_nodes) < max_nodes
+                        ):
                             batch = min(
                                 _S2_PAGE_SIZE
                                 if min_citations is not None

--- a/tests/test_tools_graph.py
+++ b/tests/test_tools_graph.py
@@ -1773,3 +1773,110 @@ async def test_get_citation_graph_citations_paginates_with_min_citations(
     node_ids = {n["id"] for n in data["nodes"]}
     assert "bgv" in node_ids, "High-citation paper on page 2 should be found"
     assert data["stats"]["total_edges"] >= 1
+
+
+@pytest.mark.respx(base_url=S2_BASE)
+async def test_get_citations_min_citations_warning_on_scan_cap(
+    respx_mock: respx.MockRouter, mcp: FastMCP, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """get_citations includes a warning when the upstream scan cap is
+    reached without finding enough qualifying results."""
+    import scholar_mcp._tools_graph as tg
+
+    monkeypatch.setattr(tg, "_MAX_UPSTREAM_SCAN", 20)
+    monkeypatch.setattr(tg, "_S2_PAGE_SIZE", 10)
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        # Always return a full page of low-citation papers
+        limit = int(request.url.params.get("limit", 10))
+        return httpx.Response(
+            200,
+            json={
+                "data": [
+                    {
+                        "citingPaper": {
+                            "paperId": f"low{i}",
+                            "title": f"Low {i}",
+                            "year": 2024,
+                            "citationCount": 1,
+                        }
+                    }
+                    for i in range(limit)
+                ]
+            },
+        )
+
+    respx_mock.get("/paper/p1/citations").mock(side_effect=_handler)
+
+    async with Client(mcp) as client:
+        result = await client.call_tool(
+            "get_citations",
+            {"identifier": "p1", "min_citations": 500, "limit": 5},
+        )
+    data = json.loads(result.content[0].text)
+    assert data["data"] == []
+    assert "warning" in data
+    assert "20" in data["warning"]
+
+
+@pytest.mark.respx(base_url=S2_BASE)
+async def test_get_citation_graph_bfs_stops_paginating_at_max_nodes(
+    respx_mock: respx.MockRouter, mcp: FastMCP
+) -> None:
+    """BFS pagination stops once max_nodes is saturated, avoiding
+    unnecessary API calls."""
+    respx_mock.post("/paper/batch").mock(
+        return_value=httpx.Response(
+            200,
+            json=[
+                {
+                    "paperId": "seed",
+                    "title": "Seed",
+                    "year": 2020,
+                    "citationCount": 100,
+                }
+            ],
+        )
+    )
+    call_count = 0
+
+    def _cit_handler(request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        limit = int(request.url.params.get("limit", 1000))
+        offset = int(request.url.params.get("offset", 0))
+        # Return a full page of qualifying papers every time
+        return httpx.Response(
+            200,
+            json={
+                "data": [
+                    {
+                        "citingPaper": {
+                            "paperId": f"c{offset + i}",
+                            "title": f"Citer {offset + i}",
+                            "year": 2022,
+                            "citationCount": 500,
+                        }
+                    }
+                    for i in range(limit)
+                ]
+            },
+        )
+
+    respx_mock.get("/paper/seed/citations").mock(side_effect=_cit_handler)
+
+    async with Client(mcp) as client:
+        result = await client.call_tool(
+            "get_citation_graph",
+            {
+                "seed_ids": ["seed"],
+                "direction": "citations",
+                "depth": 1,
+                "max_nodes": 5,
+                "min_citations": 100,
+            },
+        )
+    data = json.loads(result.content[0].text)
+    # 5 nodes = 1 seed + 4 expanded; should NOT fetch 5 pages of 1000
+    assert data["stats"]["total_nodes"] <= 5
+    assert call_count == 1


### PR DESCRIPTION
## Summary

- **Bug 1 (`get_citations`):** When `min_citations` is set, the tool now paginates through up to 10,000 upstream S2 results (in pages of 1,000) instead of fetching a single capped batch of ~1,000. This fixes empty results for heavily-cited papers like Gentry 2009 (~7k citations) where qualifying high-citation papers are older and sit deep in S2's newest-first ordering.
- **Bug 2 (`get_citation_graph`):** BFS citation expansion now paginates through up to 5,000 results per node when `min_citations` is set, fixing the tool returning only the seed node with no edges.
- Adds a `warning` field to `get_citations` responses when the scan cap is reached without satisfying the request.
- Behaviour without `min_citations` is unchanged (single fetch, same as before).

## Test plan

- [x] New test: `test_get_citations_min_citations_paginates_to_find_results` — first page has no qualifying papers, second page does → both found
- [x] New test: `test_get_citations_min_citations_stops_when_enough_results` — stops paginating after 1 API call when enough results on first page
- [x] New test: `test_get_citation_graph_citations_paginates_with_min_citations` — BFS finds high-citation paper on second page
- [x] All 227 existing tests pass, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)