### PR TITLE
feat: add alternative PDF source resolution and fetch_pdf_by_url tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A [FastMCP](https://github.com/jlowin/fastmcp) server providing structured acade
 - **Citation generation** -- format paper metadata as BibTeX, CSL-JSON, or RIS citations with automatic entry type inference, author name parsing, and OpenAlex venue enrichment
 - **OpenAlex enrichment** -- augment paper metadata with open-access URLs, affiliations, funders, concepts, and OA status
 - **Patent search** -- search and retrieve patents via [EPO Open Patent Services](https://www.epo.org/en/searching-for-patents/data/web-services/ops) covering 100+ patent offices; EPO credentials are optional -- paper search works without them
-- **PDF conversion** -- download open-access PDFs and convert to Markdown via [docling-serve](https://github.com/DS4SD/docling-serve), with optional VLM enrichment for formulas and figures
+- **PDF conversion** -- download open-access PDFs and convert to Markdown via [docling-serve](https://github.com/DS4SD/docling-serve), with optional VLM enrichment for formulas and figures; automatic fallback to ArXiv, PubMed Central, and Unpaywall when Semantic Scholar has no OA link; direct URL download for PDFs found elsewhere
 - **Intelligent caching** -- SQLite-backed cache with per-table TTLs (30 days for papers/authors, 7 days for citations/references) and identifier aliasing
 - **Authentication** -- bearer token, OIDC (OAuth 2.1), or both simultaneously (multi-auth)
 - **Multi-transport** -- stdio (Claude Desktop), HTTP (streamable-http), and SSE transports
@@ -103,9 +103,9 @@ All settings are controlled via environment variables with the `SCHOLAR_MCP_` pr
 | Variable | Default | Description |
 |---|---|---|
 | `SCHOLAR_MCP_S2_API_KEY` | -- | Semantic Scholar API key ([request one](https://www.semanticscholar.org/product/api#api-key-form)); optional but recommended for higher rate limits |
-| `SCHOLAR_MCP_READ_ONLY` | `true` | If `true`, write-tagged tools (`fetch_paper_pdf`, `convert_pdf_to_markdown`, `fetch_and_convert`) are hidden |
+| `SCHOLAR_MCP_READ_ONLY` | `true` | If `true`, write-tagged tools (`fetch_paper_pdf`, `convert_pdf_to_markdown`, `fetch_and_convert`, `fetch_pdf_by_url`) are hidden |
 | `SCHOLAR_MCP_CACHE_DIR` | `/data/scholar-mcp` | Directory for the SQLite cache database and downloaded PDFs |
-| `SCHOLAR_MCP_CONTACT_EMAIL` | -- | Included in the OpenAlex User-Agent for [polite pool](https://docs.openalex.org/how-to-use-the-api/rate-limits-and-authentication#the-polite-pool) access (faster rate limits) |
+| `SCHOLAR_MCP_CONTACT_EMAIL` | -- | Included in the OpenAlex User-Agent for [polite pool](https://docs.openalex.org/how-to-use-the-api/rate-limits-and-authentication#the-polite-pool) access (faster rate limits); also enables Unpaywall PDF lookups |
 | `SCHOLAR_MCP_LOG_LEVEL` | `INFO` | Logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
 
 ### PDF Conversion (optional)
@@ -186,9 +186,10 @@ All settings are controlled via environment variables with the `SCHOLAR_MCP_` pr
 
 | Tool | Description |
 |---|---|
-| `fetch_paper_pdf` | Download open-access PDF for a paper. |
+| `fetch_paper_pdf` | Download PDF for a paper (S2 open-access, then ArXiv/PMC/Unpaywall fallback). |
 | `convert_pdf_to_markdown` | Convert a local PDF to Markdown via docling-serve. |
-| `fetch_and_convert` | Full pipeline: fetch OA PDF, convert to Markdown, return both. |
+| `fetch_and_convert` | Full pipeline: fetch PDF (with fallback), convert to Markdown, return both. |
+| `fetch_pdf_by_url` | Download a PDF from any URL and optionally convert to Markdown. |
 
 > PDF tools are write-tagged and hidden when `SCHOLAR_MCP_READ_ONLY=true` (the default).
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,7 +9,7 @@ All settings are controlled via environment variables with the `SCHOLAR_MCP_` pr
 | `SCHOLAR_MCP_S2_API_KEY` | -- | [Semantic Scholar API key](https://www.semanticscholar.org/product/api#api-key-form). Optional, but strongly recommended: unauthenticated requests are limited to ~1 req/s while authenticated requests get ~10 req/s. |
 | `SCHOLAR_MCP_READ_ONLY` | `true` | When `true`, all write-tagged tools are hidden. Set to `false` to enable PDF download and conversion. |
 | `SCHOLAR_MCP_CACHE_DIR` | `/data/scholar-mcp` | Directory for the SQLite cache database (`cache.db`) and downloaded PDFs (`pdfs/`, `md/`). |
-| `SCHOLAR_MCP_CONTACT_EMAIL` | -- | Included in the OpenAlex `User-Agent` header. Setting this gives you access to the [polite pool](https://docs.openalex.org/how-to-use-the-api/rate-limits-and-authentication#the-polite-pool) with higher rate limits. |
+| `SCHOLAR_MCP_CONTACT_EMAIL` | -- | Included in the OpenAlex `User-Agent` header for [polite pool](https://docs.openalex.org/how-to-use-the-api/rate-limits-and-authentication#the-polite-pool) access. Also enables [Unpaywall](https://unpaywall.org/products/api) lookups as a PDF fallback source when a paper has no open-access URL in Semantic Scholar. |
 | `SCHOLAR_MCP_LOG_LEVEL` | `INFO` | Python logging level: `DEBUG`, `INFO`, `WARNING`, or `ERROR`. |
 
 ## PDF Conversion

--- a/docs/guides/pdf-conversion.md
+++ b/docs/guides/pdf-conversion.md
@@ -36,13 +36,14 @@ INFO scholar_mcp._server_deps: docling_configured url=http://localhost:5001
 
 ## Tools
 
-Three tools are available once configured:
+Four tools are available once configured:
 
 | Tool | What it does |
 |---|---|
-| `fetch_paper_pdf` | Downloads the open-access PDF for a paper |
+| `fetch_paper_pdf` | Downloads the PDF for a paper (tries OA, then ArXiv/PMC/Unpaywall) |
 | `convert_pdf_to_markdown` | Converts a local PDF file to Markdown |
 | `fetch_and_convert` | Full pipeline: find paper, download PDF, convert to Markdown |
+| `fetch_pdf_by_url` | Downloads a PDF from any URL and optionally converts to Markdown |
 
 PDFs are stored in `$SCHOLAR_MCP_CACHE_DIR/pdfs/` and Markdown files in `$SCHOLAR_MCP_CACHE_DIR/md/`.
 
@@ -114,8 +115,23 @@ Use `get_task_result` with the `task_id` to poll for completion. PDF task result
 
 The only exception is `convert_pdf_to_markdown` when the markdown output file already exists locally — in that case, the cached result is returned directly.
 
+## Alternative PDF sources
+
+When a paper has no open-access PDF URL in Semantic Scholar, `fetch_paper_pdf` and `fetch_and_convert` automatically try alternative sources:
+
+1. **ArXiv** — If the paper has an `externalIds.ArXiv` field, the PDF is fetched from `arxiv.org/pdf/<id>.pdf`.
+2. **PubMed Central** — If the paper has a `PubMedCentral` external ID, the PDF is fetched from NCBI.
+3. **Unpaywall** — If the paper has a DOI and `SCHOLAR_MCP_CONTACT_EMAIL` is set, the [Unpaywall API](https://unpaywall.org/products/api) is queried for an OA PDF location.
+
+The `source` field in the response indicates where the PDF came from: `s2_oa`, `arxiv`, `pmc`, or `unpaywall`.
+
+For PDFs found through other means (author homepages, institutional repositories, etc.), use `fetch_pdf_by_url` with the direct URL.
+
+!!! tip "Enable Unpaywall"
+    Set `SCHOLAR_MCP_CONTACT_EMAIL` to your email address to enable Unpaywall lookups. This is also used for the OpenAlex polite pool.
+
 ## Limitations
 
-- **Open-access only**: `fetch_paper_pdf` uses the `openAccessPdf.url` field from Semantic Scholar. Papers without an OA URL cannot be downloaded.
+- **Paywalled papers**: Alternative resolution only finds openly available versions. Truly paywalled papers require manual download followed by `convert_pdf_to_markdown`, or use `fetch_pdf_by_url` if you find a link.
 - **Conversion quality varies**: OCR quality depends on the PDF source. Scanned papers produce lower-quality results than born-digital PDFs.
 - **docling-serve polling**: Conversion is asynchronous internally. The server polls docling-serve for completion with a timeout of ~10 minutes (200 polls at 3-second intervals). This happens in the background task, so the MCP client is not blocked.

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ Scholar MCP exposes 15 tools that let LLM-powered applications search, explore, 
 - **Citation graph** -- traverse forward citations, backward references, build citation graphs, discover bridge papers between fields
 - **Recommendations** -- get paper suggestions from positive and negative examples
 - **OpenAlex enrichment** -- augment Semantic Scholar metadata with affiliations, funders, OA status, and concepts
-- **PDF conversion** -- download open-access PDFs and convert to Markdown via [docling-serve](https://github.com/DS4SD/docling-serve), with optional VLM enrichment for formulas and figures
+- **PDF conversion** -- download PDFs and convert to Markdown via [docling-serve](https://github.com/DS4SD/docling-serve), with optional VLM enrichment for formulas and figures; automatic fallback to ArXiv, PubMed Central, and Unpaywall; direct URL download for alternative versions
 - **Async task queue** -- long-running operations return immediately with a task ID; poll for results with `get_task_result`
 
 Results are cached in a local SQLite database with per-table TTLs to minimize API calls and speed up repeated lookups.

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ A [FastMCP](https://github.com/jlowin/fastmcp) server providing structured acade
 
 ## What it does
 
-Scholar MCP exposes 15 tools that let LLM-powered applications search, explore, and retrieve academic papers:
+Scholar MCP exposes 19 tools that let LLM-powered applications search, explore, and retrieve academic papers:
 
 - **Search & retrieval** -- find papers by keyword, look up by DOI/arXiv/S2 ID, search authors
 - **Citation graph** -- traverse forward citations, backward references, build citation graphs, discover bridge papers between fields

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -1,6 +1,6 @@
 # Tools
 
-Scholar MCP provides 18 tools across eight categories. All tools return JSON.
+Scholar MCP provides 19 tools across eight categories. All tools return JSON.
 
 All tools include [MCP tool annotations](https://spec.modelcontextprotocol.io/specification/2025-03-26/server/tools/#annotations):
 
@@ -356,16 +356,18 @@ Sections are fetched concurrently where possible (cache lookups run in parallel;
 
 ### `fetch_paper_pdf`
 
-Download the open-access PDF for a paper.
+Download the PDF for a paper. Tries the Semantic Scholar open-access URL first, then falls back to alternative sources: ArXiv (from `externalIds`), PubMed Central, and Unpaywall (by DOI, requires `SCHOLAR_MCP_CONTACT_EMAIL`).
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `identifier` | string | *(required)* | Paper ID (DOI, S2 ID, etc.) |
 
-**Returns:** `{"path": "/data/scholar-mcp/pdfs/<id>.pdf"}` or an error:
+**Returns:** `{"path": "/data/scholar-mcp/pdfs/<id>.pdf", "source": "s2_oa"}` or an error:
 
-- `{"error": "no_oa_pdf"}` -- paper has no open-access PDF URL
+- `{"error": "no_oa_pdf"}` -- no PDF URL found from any source
 - `{"error": "download_failed"}` -- HTTP error downloading the PDF
+
+The `source` field indicates where the PDF was obtained: `s2_oa`, `arxiv`, `pmc`, or `unpaywall`.
 
 ---
 
@@ -393,7 +395,7 @@ Requires `SCHOLAR_MCP_DOCLING_URL` to be set. VLM enrichment additionally requir
 
 ### `fetch_and_convert`
 
-Full pipeline: resolve paper, download PDF, convert to Markdown.
+Full pipeline: resolve paper, download PDF, convert to Markdown. Uses the same alternative source fallback as `fetch_paper_pdf`.
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
@@ -408,16 +410,42 @@ Full pipeline: resolve paper, download PDF, convert to Markdown.
   "markdown": "# Paper Title\n...",
   "pdf_path": "/data/scholar-mcp/pdfs/<id>.pdf",
   "md_path": "/data/scholar-mcp/md/<id>.md",
+  "pdf_source": "s2_oa",
   "vlm_used": false
 }
 ```
 
-Partial results are returned if a later stage fails (e.g. metadata + error if no OA PDF is available). When VLM is requested but not configured, the response includes `vlm_skip_reason`.
+Partial results are returned if a later stage fails (e.g. metadata + error if no OA PDF is available). The `pdf_source` field indicates the download source. When VLM is requested but not configured, the response includes `vlm_skip_reason`.
 
 !!! tip "Start without VLM"
     Same advice as `convert_pdf_to_markdown` — try standard first, add VLM only if formulas or figures are missing. VLM and standard conversions are cached separately (`<id>.md` vs `<id>_vlm.md`).
 
 See [PDF Conversion guide](../guides/pdf-conversion.md) for setup instructions.
+
+---
+
+### `fetch_pdf_by_url`
+
+Download a PDF from any URL and optionally convert to Markdown. Use this when you have found an alternative PDF link (e.g. from an author's homepage, a preprint server, or an institutional repository).
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `url` | string | *(required)* | Direct URL to a PDF file |
+| `filename` | string | -- | Filename stem for caching (e.g. `"smith2024_attention"`). Derived from the URL if omitted. |
+| `use_vlm` | bool | `false` | Enable VLM enrichment for formulas and figures |
+
+**Returns:** On success (with docling configured):
+
+```json
+{
+  "pdf_path": "/data/scholar-mcp/pdfs/<filename>.pdf",
+  "markdown": "# Paper Title\n...",
+  "md_path": "/data/scholar-mcp/md/<filename>.md",
+  "vlm_used": false
+}
+```
+
+Without docling, only `pdf_path` is returned. The PDF is cached by filename, so subsequent calls with the same filename return immediately.
 
 ---
 

--- a/src/scholar_mcp/_pdf_url_resolver.py
+++ b/src/scholar_mcp/_pdf_url_resolver.py
@@ -1,0 +1,124 @@
+"""Resolve alternative PDF URLs when openAccessPdf is unavailable.
+
+Tries multiple sources in order:
+1. ArXiv — construct URL from externalIds.ArXiv
+2. PubMed Central — construct URL from externalIds.PubMedCentral
+3. Unpaywall — query by DOI (requires contact_email config)
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_UNPAYWALL_BASE = "https://api.unpaywall.org/v2"
+
+
+@dataclass
+class ResolvedPdf:
+    """A resolved PDF URL with provenance information.
+
+    Attributes:
+        url: Direct URL to the PDF.
+        source: Where the URL was found (e.g. ``"arxiv"``, ``"pmc"``,
+            ``"unpaywall"``).
+    """
+
+    url: str
+    source: str
+
+
+def _try_arxiv(paper: dict[str, Any]) -> ResolvedPdf | None:
+    """Build arXiv PDF URL from externalIds.ArXiv."""
+    ext = paper.get("externalIds") or {}
+    arxiv_id = ext.get("ArXiv")
+    if arxiv_id:
+        return ResolvedPdf(
+            url=f"https://arxiv.org/pdf/{arxiv_id}.pdf",
+            source="arxiv",
+        )
+    return None
+
+
+def _try_pmc(paper: dict[str, Any]) -> ResolvedPdf | None:
+    """Build PMC PDF URL from externalIds.PubMedCentral."""
+    ext = paper.get("externalIds") or {}
+    pmc_id = ext.get("PubMedCentral")
+    if pmc_id:
+        return ResolvedPdf(
+            url=(f"https://www.ncbi.nlm.nih.gov/pmc/articles/PMC{pmc_id}/pdf/"),
+            source="pmc",
+        )
+    return None
+
+
+async def _try_unpaywall(paper: dict[str, Any], email: str) -> ResolvedPdf | None:
+    """Query Unpaywall API for an OA PDF location by DOI."""
+    ext = paper.get("externalIds") or {}
+    doi = ext.get("DOI")
+    if not doi:
+        return None
+    try:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            r = await client.get(
+                f"{_UNPAYWALL_BASE}/{doi}",
+                params={"email": email},
+            )
+            if r.status_code != 200:
+                return None
+            data = r.json()
+            best = data.get("best_oa_location") or {}
+            pdf_url = best.get("url_for_pdf")
+            if pdf_url:
+                return ResolvedPdf(url=pdf_url, source="unpaywall")
+    except (httpx.HTTPError, Exception):
+        logger.debug("unpaywall_lookup_failed doi=%s", doi, exc_info=True)
+    return None
+
+
+async def resolve_alternative_pdf(
+    paper: dict[str, Any],
+    *,
+    contact_email: str | None = None,
+) -> ResolvedPdf | None:
+    """Try alternative sources for a PDF URL.
+
+    Called when ``openAccessPdf`` is absent from Semantic Scholar metadata.
+    Checks ArXiv and PMC synchronously (URL construction only), then
+    queries Unpaywall if a DOI and contact email are available.
+
+    Args:
+        paper: Semantic Scholar paper metadata dict (must include
+            ``externalIds``).
+        contact_email: Email for the Unpaywall polite pool. Unpaywall
+            is skipped when not set.
+
+    Returns:
+        A :class:`ResolvedPdf` if a URL was found, else None.
+    """
+    # Fast, no-network checks first
+    result = _try_arxiv(paper)
+    if result:
+        logger.info("alt_pdf_resolved source=arxiv paper=%s", paper.get("paperId"))
+        return result
+
+    result = _try_pmc(paper)
+    if result:
+        logger.info("alt_pdf_resolved source=pmc paper=%s", paper.get("paperId"))
+        return result
+
+    # Network call — only if email configured
+    if contact_email:
+        result = await _try_unpaywall(paper, contact_email)
+        if result:
+            logger.info(
+                "alt_pdf_resolved source=unpaywall paper=%s", paper.get("paperId")
+            )
+            return result
+
+    return None

--- a/src/scholar_mcp/_pdf_url_resolver.py
+++ b/src/scholar_mcp/_pdf_url_resolver.py
@@ -51,32 +51,49 @@ def _try_pmc(paper: dict[str, Any]) -> ResolvedPdf | None:
     pmc_id = ext.get("PubMedCentral")
     if pmc_id:
         return ResolvedPdf(
-            url=(f"https://www.ncbi.nlm.nih.gov/pmc/articles/PMC{pmc_id}/pdf/"),
+            url=f"https://www.ncbi.nlm.nih.gov/pmc/articles/PMC{pmc_id}/pdf",
             source="pmc",
         )
     return None
 
 
-async def _try_unpaywall(paper: dict[str, Any], email: str) -> ResolvedPdf | None:
-    """Query Unpaywall API for an OA PDF location by DOI."""
+async def _try_unpaywall(
+    paper: dict[str, Any],
+    email: str,
+    http_client: httpx.AsyncClient | None = None,
+) -> ResolvedPdf | None:
+    """Query Unpaywall API for an OA PDF location by DOI.
+
+    Args:
+        paper: Paper metadata dict with ``externalIds.DOI``.
+        email: Contact email for the Unpaywall polite pool.
+        http_client: Optional shared httpx client for connection pooling.
+            A temporary client is created if not provided.
+    """
     ext = paper.get("externalIds") or {}
     doi = ext.get("DOI")
     if not doi:
         return None
     try:
-        async with httpx.AsyncClient(timeout=15.0) as client:
-            r = await client.get(
+        if http_client is not None:
+            r = await http_client.get(
                 f"{_UNPAYWALL_BASE}/{doi}",
                 params={"email": email},
             )
-            if r.status_code != 200:
-                return None
-            data = r.json()
-            best = data.get("best_oa_location") or {}
-            pdf_url = best.get("url_for_pdf")
-            if pdf_url:
-                return ResolvedPdf(url=pdf_url, source="unpaywall")
-    except (httpx.HTTPError, Exception):
+        else:
+            async with httpx.AsyncClient(timeout=15.0) as client:
+                r = await client.get(
+                    f"{_UNPAYWALL_BASE}/{doi}",
+                    params={"email": email},
+                )
+        if r.status_code != 200:
+            return None
+        data = r.json()
+        best = data.get("best_oa_location") or {}
+        pdf_url = best.get("url_for_pdf")
+        if pdf_url:
+            return ResolvedPdf(url=pdf_url, source="unpaywall")
+    except Exception:
         logger.debug("unpaywall_lookup_failed doi=%s", doi, exc_info=True)
     return None
 
@@ -85,6 +102,7 @@ async def resolve_alternative_pdf(
     paper: dict[str, Any],
     *,
     contact_email: str | None = None,
+    http_client: httpx.AsyncClient | None = None,
 ) -> ResolvedPdf | None:
     """Try alternative sources for a PDF URL.
 
@@ -97,6 +115,7 @@ async def resolve_alternative_pdf(
             ``externalIds``).
         contact_email: Email for the Unpaywall polite pool. Unpaywall
             is skipped when not set.
+        http_client: Optional shared httpx client for Unpaywall requests.
 
     Returns:
         A :class:`ResolvedPdf` if a URL was found, else None.
@@ -114,7 +133,7 @@ async def resolve_alternative_pdf(
 
     # Network call — only if email configured
     if contact_email:
-        result = await _try_unpaywall(paper, contact_email)
+        result = await _try_unpaywall(paper, contact_email, http_client)
         if result:
             logger.info(
                 "alt_pdf_resolved source=unpaywall paper=%s", paper.get("paperId")

--- a/src/scholar_mcp/_tools_pdf.py
+++ b/src/scholar_mcp/_tools_pdf.py
@@ -11,6 +11,7 @@ import httpx
 from fastmcp import FastMCP
 from fastmcp.dependencies import Depends
 
+from ._pdf_url_resolver import resolve_alternative_pdf
 from ._rate_limiter import RateLimitedError
 from ._server_deps import ServiceBundle, get_bundle
 
@@ -38,21 +39,36 @@ def register_pdf_tools(mcp: FastMCP) -> None:
         identifier: str,
         bundle: ServiceBundle = Depends(get_bundle),
     ) -> str:
-        """Download the open-access PDF of a paper.
+        """Download the PDF of a paper.
 
-        Only works for papers with an open-access PDF URL in Semantic Scholar.
+        Tries the Semantic Scholar open-access URL first. When that is
+        unavailable, automatically checks alternative sources: ArXiv
+        (from externalIds), PubMed Central, and Unpaywall (by DOI,
+        requires ``SCHOLAR_MCP_CONTACT_EMAIL``).
+
         Skips download if the file already exists locally.
 
         Args:
             identifier: Paper identifier (DOI, S2 ID, ARXIV:, etc.).
 
         Returns:
-            JSON ``{"path": "..."}`` on success, or a structured error dict.
+            JSON ``{"path": "...", "source": "..."}`` on success, or a
+            structured error dict. The ``source`` field indicates where the
+            PDF was obtained (``s2_oa``, ``arxiv``, ``pmc``, ``unpaywall``).
         """
 
         async def _download(paper_data: dict) -> str:  # type: ignore[type-arg]
             oa = paper_data.get("openAccessPdf") or {}
             dl_url = oa.get("url")
+            pdf_source = "s2_oa"
+            if not dl_url:
+                alt = await resolve_alternative_pdf(
+                    paper_data,
+                    contact_email=bundle.config.contact_email,
+                )
+                if alt:
+                    dl_url = alt.url
+                    pdf_source = alt.source
             if not dl_url:
                 return json.dumps(
                     {
@@ -76,14 +92,19 @@ def register_pdf_tools(mcp: FastMCP) -> None:
                         {"error": "download_failed", "detail": str(dl_exc)}
                     )
             await asyncio.to_thread(dl_path.write_bytes, r.content)
-            logger.info("pdf_downloaded path=%s bytes=%d", dl_path, len(r.content))
-            return json.dumps({"path": str(dl_path)})
+            logger.info(
+                "pdf_downloaded path=%s bytes=%d source=%s",
+                dl_path,
+                len(r.content),
+                pdf_source,
+            )
+            return json.dumps({"path": str(dl_path), "source": pdf_source})
 
         # Resolve metadata to check local cache before queuing
         try:
             paper = await bundle.s2.get_paper(
                 identifier,
-                fields="paperId,openAccessPdf,title",
+                fields="paperId,openAccessPdf,externalIds,title",
                 retry=False,
             )
         except RateLimitedError:
@@ -129,13 +150,21 @@ def register_pdf_tools(mcp: FastMCP) -> None:
         oa_pdf = paper.get("openAccessPdf") or {}
         url = oa_pdf.get("url")
         if not url:
-            return json.dumps(
-                {
-                    "error": "no_oa_pdf",
-                    "paper_id": paper.get("paperId"),
-                    "title": paper.get("title"),
-                }
+            # Try alternative sources before giving up — but these may
+            # involve a network call (Unpaywall), so queue the work.
+            alt = await resolve_alternative_pdf(
+                paper,
+                contact_email=bundle.config.contact_email,
             )
+            if not alt:
+                return json.dumps(
+                    {
+                        "error": "no_oa_pdf",
+                        "paper_id": paper.get("paperId"),
+                        "title": paper.get("title"),
+                    }
+                )
+            # Alternative found — fall through to cache check / queue
 
         paper_id = paper.get("paperId", identifier.replace("/", "_"))
         pdf_dir = bundle.config.cache_dir / "pdfs"
@@ -146,7 +175,7 @@ def register_pdf_tools(mcp: FastMCP) -> None:
             logger.info("pdf_already_exists path=%s", pdf_path)
             return json.dumps({"path": str(pdf_path)})
 
-        # PDF not cached — queue the download
+        # PDF not cached — queue the download (resolver runs again inside)
         task_id = bundle.tasks.submit(
             _download(paper), ttl=_PDF_TASK_TTL, tool="fetch_paper_pdf"
         )
@@ -264,10 +293,12 @@ def register_pdf_tools(mcp: FastMCP) -> None:
         use_vlm: bool = False,
         bundle: ServiceBundle = Depends(get_bundle),
     ) -> str:
-        """Resolve a paper, download its OA PDF, and convert to Markdown.
+        """Resolve a paper, download its PDF, and convert to Markdown.
 
-        Each stage fails gracefully: metadata is always returned if the paper
-        resolves, even if PDF download or conversion fails.
+        Tries the Semantic Scholar open-access URL first, then alternative
+        sources (ArXiv, PubMed Central, Unpaywall). Each stage fails
+        gracefully: metadata is always returned if the paper resolves,
+        even if PDF download or conversion fails.
 
         Tip: start with ``use_vlm=false`` (the default). Standard conversion
         handles most papers well. Only retry with ``use_vlm=true`` when the
@@ -304,6 +335,15 @@ def register_pdf_tools(mcp: FastMCP) -> None:
 
             oa_pdf = paper.get("openAccessPdf") or {}
             url = oa_pdf.get("url")
+            pdf_source = "s2_oa"
+            if not url:
+                alt = await resolve_alternative_pdf(
+                    paper,
+                    contact_email=bundle.config.contact_email,
+                )
+                if alt:
+                    url = alt.url
+                    pdf_source = alt.source
             if not url:
                 return json.dumps({"metadata": paper, "error": "no_oa_pdf"})
 
@@ -324,6 +364,7 @@ def register_pdf_tools(mcp: FastMCP) -> None:
                                 "metadata": paper,
                                 "error": "download_failed",
                                 "detail": str(exc),
+                                "pdf_source": pdf_source,
                             }
                         )
 
@@ -362,6 +403,7 @@ def register_pdf_tools(mcp: FastMCP) -> None:
                 "markdown": markdown,
                 "pdf_path": str(pdf_path),
                 "md_path": str(md_path),
+                "pdf_source": pdf_source,
                 "vlm_used": vlm_used,
             }
             skip_reason = bundle.docling.vlm_skip_reason(use_vlm)
@@ -374,4 +416,140 @@ def register_pdf_tools(mcp: FastMCP) -> None:
         )
         return json.dumps(
             {"queued": True, "task_id": task_id, "tool": "fetch_and_convert"}
+        )
+
+    @mcp.tool(
+        tags={"write"},
+        annotations={
+            "readOnlyHint": False,
+            "destructiveHint": False,
+            "openWorldHint": True,
+        },
+    )
+    async def fetch_pdf_by_url(
+        url: str,
+        filename: str | None = None,
+        use_vlm: bool = False,
+        bundle: ServiceBundle = Depends(get_bundle),
+    ) -> str:
+        """Download a PDF from a URL and optionally convert to Markdown.
+
+        Use this when you have found an alternative PDF link (e.g. from an
+        author's homepage, a preprint server, or an institutional repository)
+        that is not listed in Semantic Scholar's openAccessPdf field.
+
+        The PDF is saved locally and, if docling-serve is configured,
+        converted to Markdown automatically.
+
+        Args:
+            url: Direct URL to a PDF file.
+            filename: Optional filename stem for caching (e.g.
+                ``"smith2024_attention"``). Derived from the URL if omitted.
+            use_vlm: Use VLM enrichment for formulas and figures.
+
+        Returns:
+            JSON with ``pdf_path`` and optionally ``markdown`` / ``md_path``.
+        """
+        import re
+        from urllib.parse import urlparse
+
+        # Derive a safe filename stem
+        if filename:
+            stem = re.sub(r"[^\w\-]", "_", filename)
+        else:
+            path_part = urlparse(url).path.rsplit("/", 1)[-1]
+            stem = Path(path_part).stem or "download"
+            stem = re.sub(r"[^\w\-]", "_", stem)
+
+        pdf_dir = bundle.config.cache_dir / "pdfs"
+        pdf_dir.mkdir(parents=True, exist_ok=True)
+        pdf_path = pdf_dir / f"{stem}.pdf"
+
+        if pdf_path.exists():
+            logger.info("pdf_by_url_cached path=%s", pdf_path)
+            # Still convert if docling available and markdown not cached
+            if bundle.docling is not None:
+                vlm_suffix = "_vlm" if use_vlm and bundle.docling.vlm_available else ""
+                md_dir = bundle.config.cache_dir / "md"
+                md_path = md_dir / f"{stem}{vlm_suffix}.md"
+                if md_path.exists():
+                    markdown = await asyncio.to_thread(
+                        md_path.read_text, encoding="utf-8"
+                    )
+                    result: dict[str, object] = {
+                        "pdf_path": str(pdf_path),
+                        "markdown": markdown,
+                        "md_path": str(md_path),
+                        "vlm_used": bool(vlm_suffix),
+                    }
+                    skip_reason = bundle.docling.vlm_skip_reason(use_vlm)
+                    if skip_reason:
+                        result["vlm_skip_reason"] = skip_reason
+                    return json.dumps(result)
+            else:
+                return json.dumps({"pdf_path": str(pdf_path)})
+
+        async def _execute() -> str:
+            # Download
+            if not pdf_path.exists():
+                async with httpx.AsyncClient(timeout=120.0) as client:
+                    try:
+                        r = await client.get(url, follow_redirects=True)
+                        r.raise_for_status()
+                    except httpx.HTTPError as exc:
+                        return json.dumps(
+                            {"error": "download_failed", "detail": str(exc)}
+                        )
+                await asyncio.to_thread(pdf_path.write_bytes, r.content)
+                logger.info(
+                    "pdf_by_url_downloaded path=%s bytes=%d",
+                    pdf_path,
+                    len(r.content),
+                )
+
+            # Convert if docling available
+            if bundle.docling is None:
+                return json.dumps({"pdf_path": str(pdf_path)})
+
+            vlm_suffix = "_vlm" if use_vlm and bundle.docling.vlm_available else ""
+            md_dir = bundle.config.cache_dir / "md"
+            md_dir.mkdir(parents=True, exist_ok=True)
+            md_path = md_dir / f"{stem}{vlm_suffix}.md"
+
+            if md_path.exists():
+                markdown = await asyncio.to_thread(md_path.read_text, encoding="utf-8")
+            else:
+                try:
+                    pdf_bytes = await asyncio.to_thread(pdf_path.read_bytes)
+                    markdown = await bundle.docling.convert(
+                        pdf_bytes, pdf_path.name, use_vlm=use_vlm
+                    )
+                except Exception as exc:
+                    logger.exception("docling_convert_failed path=%s", pdf_path)
+                    return json.dumps(
+                        {
+                            "pdf_path": str(pdf_path),
+                            "error": "conversion_failed",
+                            "detail": str(exc),
+                        }
+                    )
+                await asyncio.to_thread(md_path.write_text, markdown, encoding="utf-8")
+
+            vlm_used = use_vlm and bundle.docling.vlm_available
+            result: dict[str, object] = {
+                "pdf_path": str(pdf_path),
+                "markdown": markdown,
+                "md_path": str(md_path),
+                "vlm_used": vlm_used,
+            }
+            skip_reason = bundle.docling.vlm_skip_reason(use_vlm)
+            if skip_reason:
+                result["vlm_skip_reason"] = skip_reason
+            return json.dumps(result)
+
+        task_id = bundle.tasks.submit(
+            _execute(), ttl=_PDF_TASK_TTL, tool="fetch_pdf_by_url"
+        )
+        return json.dumps(
+            {"queued": True, "task_id": task_id, "tool": "fetch_pdf_by_url"}
         )

--- a/src/scholar_mcp/_tools_pdf.py
+++ b/src/scholar_mcp/_tools_pdf.py
@@ -61,6 +61,7 @@ def register_pdf_tools(mcp: FastMCP) -> None:
             paper_data: dict,  # type: ignore[type-arg]
             resolved: ResolvedPdf | None = None,
         ) -> str:
+            dl_url: str | None
             if resolved:
                 dl_url = resolved.url
                 pdf_source = resolved.source

--- a/src/scholar_mcp/_tools_pdf.py
+++ b/src/scholar_mcp/_tools_pdf.py
@@ -11,7 +11,7 @@ import httpx
 from fastmcp import FastMCP
 from fastmcp.dependencies import Depends
 
-from ._pdf_url_resolver import resolve_alternative_pdf
+from ._pdf_url_resolver import ResolvedPdf, resolve_alternative_pdf
 from ._rate_limiter import RateLimitedError
 from ._server_deps import ServiceBundle, get_bundle
 
@@ -57,18 +57,25 @@ def register_pdf_tools(mcp: FastMCP) -> None:
             PDF was obtained (``s2_oa``, ``arxiv``, ``pmc``, ``unpaywall``).
         """
 
-        async def _download(paper_data: dict) -> str:  # type: ignore[type-arg]
-            oa = paper_data.get("openAccessPdf") or {}
-            dl_url = oa.get("url")
-            pdf_source = "s2_oa"
-            if not dl_url:
-                alt = await resolve_alternative_pdf(
-                    paper_data,
-                    contact_email=bundle.config.contact_email,
-                )
-                if alt:
-                    dl_url = alt.url
-                    pdf_source = alt.source
+        async def _download(
+            paper_data: dict,  # type: ignore[type-arg]
+            resolved: ResolvedPdf | None = None,
+        ) -> str:
+            if resolved:
+                dl_url = resolved.url
+                pdf_source = resolved.source
+            else:
+                oa = paper_data.get("openAccessPdf") or {}
+                dl_url = oa.get("url")
+                pdf_source = "s2_oa"
+                if not dl_url:
+                    alt = await resolve_alternative_pdf(
+                        paper_data,
+                        contact_email=bundle.config.contact_email,
+                    )
+                    if alt:
+                        dl_url = alt.url
+                        pdf_source = alt.source
             if not dl_url:
                 return json.dumps(
                     {
@@ -82,7 +89,7 @@ def register_pdf_tools(mcp: FastMCP) -> None:
             dl_dir.mkdir(parents=True, exist_ok=True)
             dl_path = dl_dir / f"{pid}.pdf"
             if dl_path.exists():
-                return json.dumps({"path": str(dl_path)})
+                return json.dumps({"path": str(dl_path), "source": pdf_source})
             async with httpx.AsyncClient(timeout=120.0) as client:
                 try:
                     r = await client.get(dl_url, follow_redirects=True)
@@ -112,7 +119,8 @@ def register_pdf_tools(mcp: FastMCP) -> None:
             async def _execute_full() -> str:
                 try:
                     p = await bundle.s2.get_paper(
-                        identifier, fields="paperId,openAccessPdf,title"
+                        identifier,
+                        fields="paperId,openAccessPdf,externalIds,title",
                     )
                 except httpx.HTTPStatusError as exc:
                     if exc.response.status_code == 404:
@@ -149,9 +157,8 @@ def register_pdf_tools(mcp: FastMCP) -> None:
 
         oa_pdf = paper.get("openAccessPdf") or {}
         url = oa_pdf.get("url")
+        alt: ResolvedPdf | None = None
         if not url:
-            # Try alternative sources before giving up — but these may
-            # involve a network call (Unpaywall), so queue the work.
             alt = await resolve_alternative_pdf(
                 paper,
                 contact_email=bundle.config.contact_email,
@@ -164,7 +171,6 @@ def register_pdf_tools(mcp: FastMCP) -> None:
                         "title": paper.get("title"),
                     }
                 )
-            # Alternative found — fall through to cache check / queue
 
         paper_id = paper.get("paperId", identifier.replace("/", "_"))
         pdf_dir = bundle.config.cache_dir / "pdfs"
@@ -173,11 +179,15 @@ def register_pdf_tools(mcp: FastMCP) -> None:
 
         if pdf_path.exists():
             logger.info("pdf_already_exists path=%s", pdf_path)
-            return json.dumps({"path": str(pdf_path)})
+            source = alt.source if alt else "s2_oa"
+            return json.dumps({"path": str(pdf_path), "source": source})
 
-        # PDF not cached — queue the download (resolver runs again inside)
+        # PDF not cached — queue the download, passing resolved alt to
+        # avoid a duplicate Unpaywall lookup inside _download.
         task_id = bundle.tasks.submit(
-            _download(paper), ttl=_PDF_TASK_TTL, tool="fetch_paper_pdf"
+            _download(paper, resolved=alt),
+            ttl=_PDF_TASK_TTL,
+            tool="fetch_paper_pdf",
         )
         return json.dumps(
             {"queued": True, "task_id": task_id, "tool": "fetch_paper_pdf"}
@@ -450,16 +460,21 @@ def register_pdf_tools(mcp: FastMCP) -> None:
         Returns:
             JSON with ``pdf_path`` and optionally ``markdown`` / ``md_path``.
         """
+        import hashlib
         import re
         from urllib.parse import urlparse
 
-        # Derive a safe filename stem
+        # Derive a safe filename stem.  When no explicit filename is
+        # given, incorporate a short URL hash to avoid collisions when
+        # different URLs share the same path component.
         if filename:
             stem = re.sub(r"[^\w\-]", "_", filename)
         else:
             path_part = urlparse(url).path.rsplit("/", 1)[-1]
-            stem = Path(path_part).stem or "download"
-            stem = re.sub(r"[^\w\-]", "_", stem)
+            base = Path(path_part).stem or "download"
+            base = re.sub(r"[^\w\-]", "_", base)
+            url_hash = hashlib.sha256(url.encode()).hexdigest()[:8]
+            stem = f"{base}_{url_hash}"
 
         pdf_dir = bundle.config.cache_dir / "pdfs"
         pdf_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_pdf_url_resolver.py
+++ b/tests/test_pdf_url_resolver.py
@@ -8,7 +8,6 @@ import respx
 
 from scholar_mcp._pdf_url_resolver import (
     _UNPAYWALL_BASE,
-    ResolvedPdf,
     _try_arxiv,
     _try_pmc,
     _try_unpaywall,
@@ -40,6 +39,7 @@ def test_try_pmc_with_id() -> None:
     assert result is not None
     assert result.source == "pmc"
     assert "PMC9876543" in result.url
+    assert not result.url.endswith("/")  # no trailing slash — direct PDF endpoint
 
 
 def test_try_pmc_missing() -> None:
@@ -111,3 +111,23 @@ async def test_resolve_skips_unpaywall_without_email() -> None:
     # No network mock — Unpaywall should be skipped entirely
     result = await resolve_alternative_pdf(paper, contact_email=None)
     assert result is None
+
+
+@pytest.mark.respx(base_url=_UNPAYWALL_BASE)
+async def test_try_unpaywall_with_shared_client(
+    respx_mock: respx.MockRouter,
+) -> None:
+    """_try_unpaywall accepts an optional shared httpx client."""
+    respx_mock.get("/10.1234/shared").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "best_oa_location": {"url_for_pdf": "https://example.com/shared.pdf"}
+            },
+        )
+    )
+    paper = {"externalIds": {"DOI": "10.1234/shared"}}
+    async with httpx.AsyncClient(timeout=15.0) as shared:
+        result = await _try_unpaywall(paper, "test@example.com", http_client=shared)
+    assert result is not None
+    assert result.url == "https://example.com/shared.pdf"

--- a/tests/test_pdf_url_resolver.py
+++ b/tests/test_pdf_url_resolver.py
@@ -1,0 +1,113 @@
+"""Tests for _pdf_url_resolver — alternative PDF URL resolution."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from scholar_mcp._pdf_url_resolver import (
+    _UNPAYWALL_BASE,
+    ResolvedPdf,
+    _try_arxiv,
+    _try_pmc,
+    _try_unpaywall,
+    resolve_alternative_pdf,
+)
+
+# ---------------------------------------------------------------------------
+# Unit tests for individual resolvers
+# ---------------------------------------------------------------------------
+
+
+def test_try_arxiv_with_id() -> None:
+    paper = {"externalIds": {"ArXiv": "2301.12345"}}
+    result = _try_arxiv(paper)
+    assert result is not None
+    assert result.source == "arxiv"
+    assert result.url == "https://arxiv.org/pdf/2301.12345.pdf"
+
+
+def test_try_arxiv_missing() -> None:
+    assert _try_arxiv({"externalIds": {"DOI": "10.1234/foo"}}) is None
+    assert _try_arxiv({"externalIds": None}) is None
+    assert _try_arxiv({}) is None
+
+
+def test_try_pmc_with_id() -> None:
+    paper = {"externalIds": {"PubMedCentral": "9876543"}}
+    result = _try_pmc(paper)
+    assert result is not None
+    assert result.source == "pmc"
+    assert "PMC9876543" in result.url
+
+
+def test_try_pmc_missing() -> None:
+    assert _try_pmc({"externalIds": {}}) is None
+
+
+@pytest.mark.respx(base_url=_UNPAYWALL_BASE)
+async def test_try_unpaywall_success(respx_mock: respx.MockRouter) -> None:
+    respx_mock.get("/10.1234/test").mock(
+        return_value=httpx.Response(
+            200,
+            json={"best_oa_location": {"url_for_pdf": "https://example.com/paper.pdf"}},
+        )
+    )
+    paper = {"externalIds": {"DOI": "10.1234/test"}}
+    result = await _try_unpaywall(paper, "test@example.com")
+    assert result is not None
+    assert result.source == "unpaywall"
+    assert result.url == "https://example.com/paper.pdf"
+
+
+@pytest.mark.respx(base_url=_UNPAYWALL_BASE)
+async def test_try_unpaywall_no_doi(respx_mock: respx.MockRouter) -> None:
+    result = await _try_unpaywall({"externalIds": {}}, "test@example.com")
+    assert result is None
+
+
+@pytest.mark.respx(base_url=_UNPAYWALL_BASE)
+async def test_try_unpaywall_404(respx_mock: respx.MockRouter) -> None:
+    respx_mock.get("/10.1234/missing").mock(return_value=httpx.Response(404))
+    paper = {"externalIds": {"DOI": "10.1234/missing"}}
+    result = await _try_unpaywall(paper, "test@example.com")
+    assert result is None
+
+
+@pytest.mark.respx(base_url=_UNPAYWALL_BASE)
+async def test_try_unpaywall_no_pdf_url(respx_mock: respx.MockRouter) -> None:
+    respx_mock.get("/10.1234/nopdf").mock(
+        return_value=httpx.Response(
+            200, json={"best_oa_location": {"url_for_pdf": None}}
+        )
+    )
+    paper = {"externalIds": {"DOI": "10.1234/nopdf"}}
+    result = await _try_unpaywall(paper, "test@example.com")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Integration tests for resolve_alternative_pdf
+# ---------------------------------------------------------------------------
+
+
+async def test_resolve_prefers_arxiv_over_unpaywall() -> None:
+    """ArXiv is checked first, no network call to Unpaywall."""
+    paper = {"externalIds": {"ArXiv": "2301.00001", "DOI": "10.1234/x"}}
+    result = await resolve_alternative_pdf(paper, contact_email="test@example.com")
+    assert result is not None
+    assert result.source == "arxiv"
+
+
+async def test_resolve_returns_none_when_nothing_available() -> None:
+    paper = {"externalIds": {}}
+    result = await resolve_alternative_pdf(paper, contact_email=None)
+    assert result is None
+
+
+async def test_resolve_skips_unpaywall_without_email() -> None:
+    paper = {"externalIds": {"DOI": "10.1234/x"}}
+    # No network mock — Unpaywall should be skipped entirely
+    result = await resolve_alternative_pdf(paper, contact_email=None)
+    assert result is None

--- a/tests/test_tools_pdf.py
+++ b/tests/test_tools_pdf.py
@@ -108,7 +108,14 @@ async def test_fetch_paper_pdf_no_oa(
 ) -> None:
     """fetch_paper_pdf returns no_oa_pdf directly when paper has no OA URL."""
     respx_mock.get("/paper/p1").mock(
-        return_value=httpx.Response(200, json={"paperId": "p1", "openAccessPdf": None})
+        return_value=httpx.Response(
+            200,
+            json={
+                "paperId": "p1",
+                "openAccessPdf": None,
+                "externalIds": {},
+            },
+        )
     )
     async with Client(mcp_no_docling) as client:
         result = await client.call_tool("fetch_paper_pdf", {"identifier": "p1"})
@@ -208,6 +215,7 @@ async def test_fetch_paper_pdf_cache_hit(
     data = json.loads(result.content[0].text)
     assert "queued" not in data
     assert data["path"] == str(pdf_path)
+    assert data["source"] == "s2_oa"
 
 
 async def test_convert_cached_markdown(
@@ -399,6 +407,55 @@ async def test_fetch_paper_pdf_rate_limited_then_succeeds(
     pdf_path = Path(inner["path"])
     assert pdf_path.exists()
     assert pdf_path.read_bytes() == b"%PDF rate limited ok"
+
+
+@pytest.mark.respx(assert_all_called=False)
+async def test_fetch_paper_pdf_rate_limited_arxiv_fallback(
+    bundle: ServiceBundle,
+) -> None:
+    """Rate-limited path fetches externalIds and uses ArXiv fallback."""
+    arxiv_pdf_url = "https://arxiv.org/pdf/2301.55555.pdf"
+    paper_json = {
+        "paperId": "rl_arx",
+        "openAccessPdf": None,
+        "externalIds": {"ArXiv": "2301.55555"},
+        "title": "Rate Limited ArXiv Paper",
+    }
+
+    call_count = 0
+
+    def s2_side_effect(request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return httpx.Response(429)
+        return httpx.Response(200, json=paper_json)
+
+    with respx.mock(assert_all_called=False) as router:
+        router.get(f"{S2_BASE}/paper/rl_arx").mock(side_effect=s2_side_effect)
+        router.get(arxiv_pdf_url).mock(
+            return_value=httpx.Response(200, content=b"%PDF arxiv rl")
+        )
+
+        @asynccontextmanager
+        async def lifespan(app: FastMCP):  # type: ignore[type-arg]
+            yield {"bundle": bundle}
+
+        app = FastMCP("test", lifespan=lifespan)
+        register_pdf_tools(app)
+        register_task_tools(app)
+
+        async with Client(app) as client:
+            result = await client.call_tool("fetch_paper_pdf", {"identifier": "rl_arx"})
+            queued = json.loads(result.content[0].text)
+            assert queued["queued"] is True
+
+            task_data = await _poll_task(client, queued["task_id"])
+
+    assert task_data["status"] == "completed"
+    inner = json.loads(task_data["result"])
+    assert inner["source"] == "arxiv"
+    assert Path(inner["path"]).exists()
 
 
 @pytest.mark.respx(assert_all_called=False)

--- a/tests/test_tools_pdf.py
+++ b/tests/test_tools_pdf.py
@@ -448,3 +448,201 @@ async def test_fetch_and_convert_success(
     assert inner["pdf_path"].endswith("fc1.pdf")
     assert inner["md_path"].endswith("fc1.md")
     assert inner["vlm_used"] is False
+    assert inner["pdf_source"] == "s2_oa"
+
+
+# ---------------------------------------------------------------------------
+# Alternative PDF resolution tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.respx(base_url=S2_BASE)
+async def test_fetch_paper_pdf_arxiv_fallback(
+    respx_mock: respx.MockRouter,
+    bundle: ServiceBundle,
+) -> None:
+    """fetch_paper_pdf falls back to arXiv when openAccessPdf is null."""
+    arxiv_pdf_url = "https://arxiv.org/pdf/2301.12345.pdf"
+    paper_json = {
+        "paperId": "arx1",
+        "openAccessPdf": None,
+        "externalIds": {"ArXiv": "2301.12345"},
+        "title": "ArXiv Fallback Test",
+    }
+
+    with respx.mock(assert_all_called=False) as router:
+        router.get(f"{S2_BASE}/paper/arx1").mock(
+            return_value=httpx.Response(200, json=paper_json)
+        )
+        router.get(arxiv_pdf_url).mock(
+            return_value=httpx.Response(200, content=b"%PDF arxiv content")
+        )
+
+        @asynccontextmanager
+        async def lifespan(app: FastMCP):  # type: ignore[type-arg]
+            yield {"bundle": bundle}
+
+        app = FastMCP("test", lifespan=lifespan)
+        register_pdf_tools(app)
+        register_task_tools(app)
+
+        async with Client(app) as client:
+            result = await client.call_tool("fetch_paper_pdf", {"identifier": "arx1"})
+            queued = json.loads(result.content[0].text)
+            assert queued["queued"] is True
+
+            task_data = await _poll_task(client, queued["task_id"])
+
+    assert task_data["status"] == "completed"
+    inner = json.loads(task_data["result"])
+    assert "path" in inner
+    assert inner["source"] == "arxiv"
+    assert Path(inner["path"]).exists()
+
+
+@pytest.mark.respx(base_url=S2_BASE)
+async def test_fetch_and_convert_arxiv_fallback(
+    bundle_with_docling: ServiceBundle,
+) -> None:
+    """fetch_and_convert uses arXiv fallback and reports pdf_source."""
+    arxiv_pdf_url = "https://arxiv.org/pdf/2301.99999.pdf"
+    paper_json = {
+        "paperId": "fca1",
+        "openAccessPdf": None,
+        "externalIds": {"ArXiv": "2301.99999"},
+        "title": "Fetch and Convert ArXiv Test",
+    }
+
+    bundle_with_docling.docling.convert = AsyncMock(  # type: ignore[union-attr]
+        return_value="# ArXiv Paper\n\nContent."
+    )
+
+    with respx.mock(assert_all_called=False) as router:
+        router.get(f"{S2_BASE}/paper/fca1").mock(
+            return_value=httpx.Response(200, json=paper_json)
+        )
+        router.get(arxiv_pdf_url).mock(
+            return_value=httpx.Response(200, content=b"%PDF arxiv fc")
+        )
+
+        @asynccontextmanager
+        async def lifespan(app: FastMCP):  # type: ignore[type-arg]
+            yield {"bundle": bundle_with_docling}
+
+        app = FastMCP("test", lifespan=lifespan)
+        register_pdf_tools(app)
+        register_task_tools(app)
+
+        async with Client(app) as client:
+            result = await client.call_tool("fetch_and_convert", {"identifier": "fca1"})
+            queued = json.loads(result.content[0].text)
+            task_data = await _poll_task(client, queued["task_id"])
+
+    assert task_data["status"] == "completed"
+    inner = json.loads(task_data["result"])
+    assert inner["pdf_source"] == "arxiv"
+    assert "# ArXiv Paper" in inner["markdown"]
+
+
+# ---------------------------------------------------------------------------
+# fetch_pdf_by_url tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.respx(assert_all_called=False)
+async def test_fetch_pdf_by_url_download_and_convert(
+    bundle_with_docling: ServiceBundle,
+) -> None:
+    """fetch_pdf_by_url downloads a PDF and converts to markdown."""
+    pdf_url = "https://example.com/custom/paper.pdf"
+
+    bundle_with_docling.docling.convert = AsyncMock(  # type: ignore[union-attr]
+        return_value="# Custom Paper\n\nFrom URL."
+    )
+
+    with respx.mock(assert_all_called=False) as router:
+        router.get(pdf_url).mock(
+            return_value=httpx.Response(200, content=b"%PDF custom")
+        )
+
+        @asynccontextmanager
+        async def lifespan(app: FastMCP):  # type: ignore[type-arg]
+            yield {"bundle": bundle_with_docling}
+
+        app = FastMCP("test", lifespan=lifespan)
+        register_pdf_tools(app)
+        register_task_tools(app)
+
+        async with Client(app) as client:
+            result = await client.call_tool(
+                "fetch_pdf_by_url",
+                {"url": pdf_url, "filename": "custom_paper"},
+            )
+            queued = json.loads(result.content[0].text)
+            assert queued["queued"] is True
+            assert queued["tool"] == "fetch_pdf_by_url"
+
+            task_data = await _poll_task(client, queued["task_id"])
+
+    assert task_data["status"] == "completed"
+    inner = json.loads(task_data["result"])
+    assert inner["pdf_path"].endswith("custom_paper.pdf")
+    assert "# Custom Paper" in inner["markdown"]
+    assert inner["vlm_used"] is False
+
+
+@pytest.mark.respx(assert_all_called=False)
+async def test_fetch_pdf_by_url_no_docling(
+    bundle: ServiceBundle,
+) -> None:
+    """fetch_pdf_by_url without docling returns just the pdf_path."""
+    pdf_url = "https://example.com/nodocling.pdf"
+
+    with respx.mock(assert_all_called=False) as router:
+        router.get(pdf_url).mock(
+            return_value=httpx.Response(200, content=b"%PDF no docling")
+        )
+
+        @asynccontextmanager
+        async def lifespan(app: FastMCP):  # type: ignore[type-arg]
+            yield {"bundle": bundle}
+
+        app = FastMCP("test", lifespan=lifespan)
+        register_pdf_tools(app)
+        register_task_tools(app)
+
+        async with Client(app) as client:
+            result = await client.call_tool("fetch_pdf_by_url", {"url": pdf_url})
+            queued = json.loads(result.content[0].text)
+            task_data = await _poll_task(client, queued["task_id"])
+
+    assert task_data["status"] == "completed"
+    inner = json.loads(task_data["result"])
+    assert "pdf_path" in inner
+    assert "markdown" not in inner
+
+
+async def test_fetch_pdf_by_url_cached(
+    bundle: ServiceBundle,
+) -> None:
+    """fetch_pdf_by_url returns cached path immediately."""
+    pdf_dir = bundle.config.cache_dir / "pdfs"
+    pdf_dir.mkdir(parents=True, exist_ok=True)
+    cached = pdf_dir / "cached_paper.pdf"
+    cached.write_bytes(b"%PDF cached")
+
+    @asynccontextmanager
+    async def lifespan(app: FastMCP):  # type: ignore[type-arg]
+        yield {"bundle": bundle}
+
+    app = FastMCP("test", lifespan=lifespan)
+    register_pdf_tools(app)
+
+    async with Client(app) as client:
+        result = await client.call_tool(
+            "fetch_pdf_by_url",
+            {"url": "https://example.com/cached_paper.pdf", "filename": "cached_paper"},
+        )
+    data = json.loads(result.content[0].text)
+    assert "queued" not in data
+    assert data["pdf_path"] == str(cached)


### PR DESCRIPTION
When openAccessPdf is unavailable from Semantic Scholar, fetch_paper_pdf
and fetch_and_convert now automatically try ArXiv, PubMed Central, and
Unpaywall (requires SCHOLAR_MCP_CONTACT_EMAIL) before returning no_oa_pdf.

New fetch_pdf_by_url tool accepts any direct PDF URL, downloads it, and
optionally converts to Markdown via docling — useful when the LLM finds
alternative versions on author homepages or institutional repositories.

https://claude.ai/code/session_01HJa2hs1jDKBETTmTvCDMwd