### PR TITLE
feat: enrich ISBN book results with authors from work metadata (#74)

### DIFF
--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -291,6 +291,7 @@ When `get_paper`, `get_citations`, `get_references`, or `get_citation_graph` ret
 | `description` | Work description, if available |
 | `subjects` | List of subject strings |
 | `page_count` | Page count, if known |
+| `authors` | List of author name strings (resolved from Open Library work metadata) |
 
 Enrichment failures are silently skipped — if Open Library is unreachable or the ISBN is not found, the paper record is returned without `book_metadata`. Up to 5 concurrent Open Library requests are made per batch.
 

--- a/src/scholar_mcp/_book_enrichment.py
+++ b/src/scholar_mcp/_book_enrichment.py
@@ -100,6 +100,7 @@ def _to_enrichment_dict(book: BookRecord) -> dict[str, Any]:
         "description": book.get("description"),
         "subjects": book.get("subjects") or [],
         "page_count": book.get("page_count"),
+        "authors": book.get("authors") or [],
     }
 
 

--- a/src/scholar_mcp/_book_enrichment.py
+++ b/src/scholar_mcp/_book_enrichment.py
@@ -29,9 +29,7 @@ async def _resolve_author_keys(
     """
     # Strip path prefix — get_author expects short IDs like "OL239963A"
     ids = [k.rsplit("/", 1)[-1] for k in author_keys]
-    results = await asyncio.gather(
-        *(bundle.openlibrary.get_author(aid) for aid in ids)
-    )
+    results = await asyncio.gather(*(bundle.openlibrary.get_author(aid) for aid in ids))
     return [a["name"] for a in results if a and a.get("name")]
 
 

--- a/src/scholar_mcp/_book_enrichment.py
+++ b/src/scholar_mcp/_book_enrichment.py
@@ -15,6 +15,71 @@ from ._server_deps import ServiceBundle
 logger = logging.getLogger(__name__)
 
 
+async def _resolve_author_keys(
+    author_keys: list[str], bundle: ServiceBundle
+) -> list[str]:
+    """Resolve Open Library author keys to author names.
+
+    Args:
+        author_keys: List of Open Library author keys (e.g. ``/authors/OL239963A``).
+        bundle: Service bundle with openlibrary client.
+
+    Returns:
+        List of resolved author name strings.
+    """
+    # Strip path prefix — get_author expects short IDs like "OL239963A"
+    ids = [k.rsplit("/", 1)[-1] for k in author_keys]
+    results = await asyncio.gather(
+        *(bundle.openlibrary.get_author(aid) for aid in ids)
+    )
+    return [a["name"] for a in results if a and a.get("name")]
+
+
+def _extract_author_keys(work: dict[str, Any]) -> list[str]:
+    """Extract author keys from a work record.
+
+    Args:
+        work: Open Library work dict.
+
+    Returns:
+        List of author key strings.
+    """
+    keys: list[str] = []
+    for entry in work.get("authors") or []:
+        if isinstance(entry, dict):
+            author = entry.get("author")
+            if isinstance(author, dict) and author.get("key"):
+                keys.append(author["key"])
+    return keys
+
+
+async def enrich_authors_from_work(book: BookRecord, bundle: ServiceBundle) -> None:
+    """Enrich book in-place with authors from its work record.
+
+    Best-effort: failures are logged and silently skipped.
+
+    Args:
+        book: Book record to enrich in-place.
+        bundle: Service bundle with openlibrary client.
+    """
+    if book.get("authors"):
+        return
+    work_id = book.get("openlibrary_work_id")
+    if not work_id:
+        return
+    try:
+        work = await bundle.openlibrary.get_work(work_id)
+        if work is None:
+            return
+        author_keys = _extract_author_keys(work)
+        if author_keys:
+            names = await _resolve_author_keys(author_keys, bundle)
+            if names:
+                book["authors"] = names
+    except Exception:
+        logger.debug("author_enrichment_failed work_id=%s", work_id, exc_info=True)
+
+
 def _needs_book_enrichment(paper: dict[str, Any]) -> bool:
     """Check whether a paper should be enriched with book metadata.
 
@@ -66,6 +131,7 @@ async def _enrich_one(paper: dict[str, Any], bundle: ServiceBundle) -> None:
             return
 
         book: BookRecord = normalize_book(edition, source="edition")
+        await enrich_authors_from_work(book, bundle)
         await bundle.cache.set_book_by_isbn(isbn, book)
         work_id = book.get("openlibrary_work_id")
         if work_id:

--- a/src/scholar_mcp/_openlibrary_client.py
+++ b/src/scholar_mcp/_openlibrary_client.py
@@ -213,26 +213,6 @@ class OpenLibraryClient:
             logger.warning("openlibrary_edition_error edition_id=%s", edition_id)
             return None
 
-    async def get_author(self, author_key: str) -> dict[str, Any] | None:
-        """Fetch author metadata by key.
-
-        Args:
-            author_key: Open Library author key (e.g. ``/authors/OL34184A``).
-
-        Returns:
-            Author dict with ``name`` field, or None if not found.
-        """
-        await self._limiter.acquire()
-        try:
-            r = await self._client.get(f"{author_key}.json")
-            if r.status_code == 404:
-                return None
-            r.raise_for_status()
-            return r.json()  # type: ignore[no-any-return]
-        except httpx.HTTPStatusError:
-            logger.warning("openlibrary_author_error key=%s", author_key)
-            return None
-
     async def aclose(self) -> None:
         """Close the underlying HTTP client."""
         await self._client.aclose()

--- a/src/scholar_mcp/_openlibrary_client.py
+++ b/src/scholar_mcp/_openlibrary_client.py
@@ -213,6 +213,26 @@ class OpenLibraryClient:
             logger.warning("openlibrary_edition_error edition_id=%s", edition_id)
             return None
 
+    async def get_author(self, author_key: str) -> dict[str, Any] | None:
+        """Fetch author metadata by key.
+
+        Args:
+            author_key: Open Library author key (e.g. ``/authors/OL34184A``).
+
+        Returns:
+            Author dict with ``name`` field, or None if not found.
+        """
+        await self._limiter.acquire()
+        try:
+            r = await self._client.get(f"{author_key}.json")
+            if r.status_code == 404:
+                return None
+            r.raise_for_status()
+            return r.json()  # type: ignore[no-any-return]
+        except httpx.HTTPStatusError:
+            logger.warning("openlibrary_author_error key=%s", author_key)
+            return None
+
     async def aclose(self) -> None:
         """Close the underlying HTTP client."""
         await self._client.aclose()

--- a/src/scholar_mcp/_tools_books.py
+++ b/src/scholar_mcp/_tools_books.py
@@ -62,9 +62,7 @@ def _extract_author_keys(work: dict[str, Any]) -> list[str]:
     return keys
 
 
-async def _enrich_authors_from_work(
-    book: BookRecord, bundle: ServiceBundle
-) -> None:
+async def _enrich_authors_from_work(book: BookRecord, bundle: ServiceBundle) -> None:
     """Enrich book in-place with authors from its work record.
 
     Best-effort: failures are logged and silently skipped.
@@ -88,9 +86,7 @@ async def _enrich_authors_from_work(
             if names:
                 book["authors"] = names
     except Exception:
-        logger.debug(
-            "author_enrichment_failed work_id=%s", work_id, exc_info=True
-        )
+        logger.debug("author_enrichment_failed work_id=%s", work_id, exc_info=True)
 
 
 def register_book_tools(mcp: FastMCP) -> None:

--- a/src/scholar_mcp/_tools_books.py
+++ b/src/scholar_mcp/_tools_books.py
@@ -30,18 +30,18 @@ async def _resolve_author_keys(
     """Resolve Open Library author keys to author names.
 
     Args:
-        author_keys: List of Open Library author keys (e.g. ``/authors/OL34184A``).
+        author_keys: List of Open Library author keys (e.g. ``/authors/OL239963A``).
         bundle: Service bundle with openlibrary client.
 
     Returns:
         List of resolved author name strings.
     """
-    names: list[str] = []
-    for key in author_keys:
-        author_data = await bundle.openlibrary.get_author(key)
-        if author_data and author_data.get("name"):
-            names.append(author_data["name"])
-    return names
+    # Strip path prefix — get_author expects short IDs like "OL239963A"
+    ids = [k.rsplit("/", 1)[-1] for k in author_keys]
+    results = await asyncio.gather(
+        *(bundle.openlibrary.get_author(aid) for aid in ids)
+    )
+    return [a["name"] for a in results if a and a.get("name")]
 
 
 def _extract_author_keys(work: dict[str, Any]) -> list[str]:
@@ -371,6 +371,7 @@ async def _resolve_edition(edition_id: str, bundle: ServiceBundle) -> str:
         return json.dumps({"error": "not_found", "identifier": edition_id})
 
     book: BookRecord = normalize_book(edition, source="edition")
+    await _enrich_authors_from_work(book, bundle)
     isbn_13 = book.get("isbn_13")
     if isbn_13:
         await bundle.cache.set_book_by_isbn(isbn_13, book)

--- a/src/scholar_mcp/_tools_books.py
+++ b/src/scholar_mcp/_tools_books.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import logging
 import re
+from typing import Any
 
 from fastmcp import FastMCP
 from fastmcp.dependencies import Depends
@@ -21,6 +22,75 @@ logger = logging.getLogger(__name__)
 # Patterns for detecting identifier types.
 _OL_WORK_RE = re.compile(r"^OL\d+W$")
 _OL_EDITION_RE = re.compile(r"^OL\d+M$")
+
+
+async def _resolve_author_keys(
+    author_keys: list[str], bundle: ServiceBundle
+) -> list[str]:
+    """Resolve Open Library author keys to author names.
+
+    Args:
+        author_keys: List of Open Library author keys (e.g. ``/authors/OL34184A``).
+        bundle: Service bundle with openlibrary client.
+
+    Returns:
+        List of resolved author name strings.
+    """
+    names: list[str] = []
+    for key in author_keys:
+        author_data = await bundle.openlibrary.get_author(key)
+        if author_data and author_data.get("name"):
+            names.append(author_data["name"])
+    return names
+
+
+def _extract_author_keys(work: dict[str, Any]) -> list[str]:
+    """Extract author keys from a work record.
+
+    Args:
+        work: Open Library work dict.
+
+    Returns:
+        List of author key strings.
+    """
+    keys: list[str] = []
+    for entry in work.get("authors") or []:
+        if isinstance(entry, dict):
+            author = entry.get("author")
+            if isinstance(author, dict) and author.get("key"):
+                keys.append(author["key"])
+    return keys
+
+
+async def _enrich_authors_from_work(
+    book: BookRecord, bundle: ServiceBundle
+) -> None:
+    """Enrich book in-place with authors from its work record.
+
+    Best-effort: failures are logged and silently skipped.
+
+    Args:
+        book: Book record to enrich in-place.
+        bundle: Service bundle with openlibrary client.
+    """
+    if book.get("authors"):
+        return
+    work_id = book.get("openlibrary_work_id")
+    if not work_id:
+        return
+    try:
+        work = await bundle.openlibrary.get_work(work_id)
+        if work is None:
+            return
+        author_keys = _extract_author_keys(work)
+        if author_keys:
+            names = await _resolve_author_keys(author_keys, bundle)
+            if names:
+                book["authors"] = names
+    except Exception:
+        logger.debug(
+            "author_enrichment_failed work_id=%s", work_id, exc_info=True
+        )
 
 
 def register_book_tools(mcp: FastMCP) -> None:
@@ -197,6 +267,7 @@ async def _resolve_isbn(isbn: str, bundle: ServiceBundle) -> str:
         return json.dumps({"error": "not_found", "identifier": isbn})
 
     book: BookRecord = normalize_book(edition, source="edition")
+    await _enrich_authors_from_work(book, bundle)
     await bundle.cache.set_book_by_isbn(isbn, book)
     work_id = book.get("openlibrary_work_id")
     if work_id:

--- a/src/scholar_mcp/_tools_books.py
+++ b/src/scholar_mcp/_tools_books.py
@@ -6,11 +6,11 @@ import asyncio
 import json
 import logging
 import re
-from typing import Any
 
 from fastmcp import FastMCP
 from fastmcp.dependencies import Depends
 
+from ._book_enrichment import enrich_authors_from_work
 from ._cache import normalize_isbn
 from ._openlibrary_client import normalize_book
 from ._rate_limiter import RateLimitedError
@@ -22,71 +22,6 @@ logger = logging.getLogger(__name__)
 # Patterns for detecting identifier types.
 _OL_WORK_RE = re.compile(r"^OL\d+W$")
 _OL_EDITION_RE = re.compile(r"^OL\d+M$")
-
-
-async def _resolve_author_keys(
-    author_keys: list[str], bundle: ServiceBundle
-) -> list[str]:
-    """Resolve Open Library author keys to author names.
-
-    Args:
-        author_keys: List of Open Library author keys (e.g. ``/authors/OL239963A``).
-        bundle: Service bundle with openlibrary client.
-
-    Returns:
-        List of resolved author name strings.
-    """
-    # Strip path prefix — get_author expects short IDs like "OL239963A"
-    ids = [k.rsplit("/", 1)[-1] for k in author_keys]
-    results = await asyncio.gather(
-        *(bundle.openlibrary.get_author(aid) for aid in ids)
-    )
-    return [a["name"] for a in results if a and a.get("name")]
-
-
-def _extract_author_keys(work: dict[str, Any]) -> list[str]:
-    """Extract author keys from a work record.
-
-    Args:
-        work: Open Library work dict.
-
-    Returns:
-        List of author key strings.
-    """
-    keys: list[str] = []
-    for entry in work.get("authors") or []:
-        if isinstance(entry, dict):
-            author = entry.get("author")
-            if isinstance(author, dict) and author.get("key"):
-                keys.append(author["key"])
-    return keys
-
-
-async def _enrich_authors_from_work(book: BookRecord, bundle: ServiceBundle) -> None:
-    """Enrich book in-place with authors from its work record.
-
-    Best-effort: failures are logged and silently skipped.
-
-    Args:
-        book: Book record to enrich in-place.
-        bundle: Service bundle with openlibrary client.
-    """
-    if book.get("authors"):
-        return
-    work_id = book.get("openlibrary_work_id")
-    if not work_id:
-        return
-    try:
-        work = await bundle.openlibrary.get_work(work_id)
-        if work is None:
-            return
-        author_keys = _extract_author_keys(work)
-        if author_keys:
-            names = await _resolve_author_keys(author_keys, bundle)
-            if names:
-                book["authors"] = names
-    except Exception:
-        logger.debug("author_enrichment_failed work_id=%s", work_id, exc_info=True)
 
 
 def register_book_tools(mcp: FastMCP) -> None:
@@ -263,7 +198,7 @@ async def _resolve_isbn(isbn: str, bundle: ServiceBundle) -> str:
         return json.dumps({"error": "not_found", "identifier": isbn})
 
     book: BookRecord = normalize_book(edition, source="edition")
-    await _enrich_authors_from_work(book, bundle)
+    await enrich_authors_from_work(book, bundle)
     await bundle.cache.set_book_by_isbn(isbn, book)
     work_id = book.get("openlibrary_work_id")
     if work_id:
@@ -367,7 +302,7 @@ async def _resolve_edition(edition_id: str, bundle: ServiceBundle) -> str:
         return json.dumps({"error": "not_found", "identifier": edition_id})
 
     book: BookRecord = normalize_book(edition, source="edition")
-    await _enrich_authors_from_work(book, bundle)
+    await enrich_authors_from_work(book, bundle)
     isbn_13 = book.get("isbn_13")
     if isbn_13:
         await bundle.cache.set_book_by_isbn(isbn_13, book)

--- a/tests/test_book_enrichment.py
+++ b/tests/test_book_enrichment.py
@@ -6,7 +6,12 @@ import httpx
 import pytest
 import respx
 
-from scholar_mcp._book_enrichment import enrich_books
+from scholar_mcp._book_enrichment import (
+    _extract_author_keys,
+    enrich_authors_from_work,
+    enrich_books,
+)
+from scholar_mcp._rate_limiter import RateLimitedError
 from scholar_mcp._server_deps import ServiceBundle
 
 OL_BASE = "https://openlibrary.org"
@@ -179,3 +184,101 @@ def test_to_enrichment_dict_empty_authors_defaults_to_list() -> None:
     book: dict = {"title": "Test"}
     result = _to_enrichment_dict(book)
     assert result["authors"] == []
+
+
+# --- _extract_author_keys branch coverage ---
+
+
+def test_extract_author_keys_skips_non_dict_entries() -> None:
+    """Non-dict entries in work['authors'] are ignored."""
+    work = {"authors": ["not-a-dict", None, 42]}
+    assert _extract_author_keys(work) == []
+
+
+def test_extract_author_keys_skips_non_dict_author_value() -> None:
+    """Entry dict where 'author' is not a dict is ignored."""
+    work = {"authors": [{"author": "/authors/OL123A"}]}
+    assert _extract_author_keys(work) == []
+
+
+def test_extract_author_keys_happy_path() -> None:
+    work = {
+        "authors": [
+            {"author": {"key": "/authors/OL239963A"}},
+            {"author": {"key": "/authors/OL239964A"}},
+        ]
+    }
+    assert _extract_author_keys(work) == ["/authors/OL239963A", "/authors/OL239964A"]
+
+
+# --- enrich_authors_from_work branch coverage ---
+
+
+@pytest.mark.respx(base_url=OL_BASE)
+async def test_enrich_authors_already_populated(
+    respx_mock: respx.MockRouter, bundle: ServiceBundle
+) -> None:
+    """Early-returns without fetching when authors already set."""
+    book: dict = {"authors": ["Already Here"], "openlibrary_work_id": "OL1W"}
+    await enrich_authors_from_work(book, bundle)
+    assert book["authors"] == ["Already Here"]
+    assert not respx_mock.calls
+
+
+@pytest.mark.respx(base_url=OL_BASE)
+async def test_enrich_authors_work_returns_none(
+    respx_mock: respx.MockRouter, bundle: ServiceBundle
+) -> None:
+    """No-ops when the work endpoint returns 404."""
+    respx_mock.get("/works/OL999W.json").mock(return_value=httpx.Response(404))
+    book: dict = {"authors": [], "openlibrary_work_id": "OL999W"}
+    await enrich_authors_from_work(book, bundle)
+    assert book["authors"] == []
+
+
+@pytest.mark.respx(base_url=OL_BASE)
+async def test_enrich_authors_work_has_no_author_keys(
+    respx_mock: respx.MockRouter, bundle: ServiceBundle
+) -> None:
+    """No-ops when the work has no recognisable author entries."""
+    respx_mock.get("/works/OL1W.json").mock(
+        return_value=httpx.Response(200, json={"title": "Anon", "authors": []})
+    )
+    book: dict = {"authors": [], "openlibrary_work_id": "OL1W"}
+    await enrich_authors_from_work(book, bundle)
+    assert book["authors"] == []
+
+
+@pytest.mark.respx(base_url=OL_BASE)
+async def test_enrich_authors_all_author_fetches_return_none(
+    respx_mock: respx.MockRouter, bundle: ServiceBundle
+) -> None:
+    """No-ops when every get_author call returns None (404)."""
+    respx_mock.get("/works/OL1W.json").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "authors": [{"author": {"key": "/authors/OL999A"}}],
+            },
+        )
+    )
+    respx_mock.get("/authors/OL999A.json").mock(return_value=httpx.Response(404))
+    book: dict = {"authors": [], "openlibrary_work_id": "OL1W"}
+    await enrich_authors_from_work(book, bundle)
+    assert book["authors"] == []
+
+
+# --- _enrich_one RateLimitedError propagation ---
+
+
+@pytest.mark.respx(base_url=OL_BASE)
+async def test_enrichment_rate_limited_error_propagates(
+    respx_mock: respx.MockRouter, bundle: ServiceBundle
+) -> None:
+    """RateLimitedError is re-raised, not swallowed."""
+    respx_mock.get("/isbn/9780201633610.json").mock(
+        side_effect=RateLimitedError("rate limited")
+    )
+    paper = _make_paper(isbn="9780201633610")
+    with pytest.raises(RateLimitedError):
+        await enrich_books([paper], bundle)

--- a/tests/test_book_enrichment.py
+++ b/tests/test_book_enrichment.py
@@ -152,3 +152,30 @@ async def test_enrichment_batch_multiple_papers(
     assert "book_metadata" in papers[0]
     assert "book_metadata" not in papers[1]
     assert "book_metadata" in papers[2]
+
+
+def test_to_enrichment_dict_includes_authors() -> None:
+    from scholar_mcp._book_enrichment import _to_enrichment_dict
+
+    book: dict = {
+        "title": "Test",
+        "authors": ["Alice", "Bob"],
+        "publisher": "Publisher",
+        "edition": None,
+        "isbn_13": "9781234567890",
+        "cover_url": None,
+        "openlibrary_work_id": "OL123W",
+        "description": None,
+        "subjects": [],
+        "page_count": None,
+    }
+    result = _to_enrichment_dict(book)
+    assert result["authors"] == ["Alice", "Bob"]
+
+
+def test_to_enrichment_dict_empty_authors_defaults_to_list() -> None:
+    from scholar_mcp._book_enrichment import _to_enrichment_dict
+
+    book: dict = {"title": "Test"}
+    result = _to_enrichment_dict(book)
+    assert result["authors"] == []

--- a/tests/test_tools_books.py
+++ b/tests/test_tools_books.py
@@ -153,6 +153,15 @@ async def test_get_book_by_edition_id(
     respx_mock.get("/books/OL1429049M.json").mock(
         return_value=httpx.Response(200, json=SAMPLE_EDITION_RESPONSE)
     )
+    respx_mock.get("/works/OL1168083W.json").mock(
+        return_value=httpx.Response(200, json=SAMPLE_WORK_RESPONSE)
+    )
+    respx_mock.get("/authors/OL239963A.json").mock(
+        return_value=httpx.Response(200, json=SAMPLE_AUTHOR_GAMMA)
+    )
+    respx_mock.get("/authors/OL239964A.json").mock(
+        return_value=httpx.Response(200, json=SAMPLE_AUTHOR_HELM)
+    )
     async with Client(mcp) as client:
         result = await client.call_tool("get_book", {"identifier": "OL1429049M"})
     data = json.loads(result.content[0].text)
@@ -331,6 +340,29 @@ async def test_get_book_isbn_enriches_authors(
     )
     async with Client(mcp) as client:
         result = await client.call_tool("get_book", {"identifier": "9780201633610"})
+    data = json.loads(result.content[0].text)
+    assert data["authors"] == ["Erich Gamma", "Richard Helm"]
+
+
+@pytest.mark.respx(base_url=OL_BASE)
+async def test_get_book_edition_enriches_authors(
+    respx_mock: respx.MockRouter, mcp: FastMCP
+) -> None:
+    """get_book by edition ID should resolve authors from the work record."""
+    respx_mock.get("/books/OL1429049M.json").mock(
+        return_value=httpx.Response(200, json=SAMPLE_EDITION_RESPONSE)
+    )
+    respx_mock.get("/works/OL1168083W.json").mock(
+        return_value=httpx.Response(200, json=SAMPLE_WORK_RESPONSE)
+    )
+    respx_mock.get("/authors/OL239963A.json").mock(
+        return_value=httpx.Response(200, json=SAMPLE_AUTHOR_GAMMA)
+    )
+    respx_mock.get("/authors/OL239964A.json").mock(
+        return_value=httpx.Response(200, json=SAMPLE_AUTHOR_HELM)
+    )
+    async with Client(mcp) as client:
+        result = await client.call_tool("get_book", {"identifier": "OL1429049M"})
     data = json.loads(result.content[0].text)
     assert data["authors"] == ["Erich Gamma", "Richard Helm"]
 

--- a/tests/test_tools_books.py
+++ b/tests/test_tools_books.py
@@ -129,6 +129,15 @@ async def test_get_book_isbn_cache_hit(
     respx_mock.get("/isbn/9780201633610.json").mock(
         return_value=httpx.Response(200, json=SAMPLE_EDITION_RESPONSE)
     )
+    respx_mock.get("/works/OL1168083W.json").mock(
+        return_value=httpx.Response(200, json=SAMPLE_WORK_RESPONSE)
+    )
+    respx_mock.get("/authors/OL239963A.json").mock(
+        return_value=httpx.Response(200, json=SAMPLE_AUTHOR_GAMMA)
+    )
+    respx_mock.get("/authors/OL239964A.json").mock(
+        return_value=httpx.Response(200, json=SAMPLE_AUTHOR_HELM)
+    )
     async with Client(mcp) as client:
         await client.call_tool("get_book", {"identifier": "9780201633610"})
         result = await client.call_tool("get_book", {"identifier": "9780201633610"})
@@ -199,6 +208,15 @@ async def test_get_book_by_work_id_not_found(
 async def test_get_book_by_isbn(respx_mock: respx.MockRouter, mcp: FastMCP) -> None:
     respx_mock.get("/isbn/9780201633610.json").mock(
         return_value=httpx.Response(200, json=SAMPLE_EDITION_RESPONSE)
+    )
+    respx_mock.get("/works/OL1168083W.json").mock(
+        return_value=httpx.Response(200, json=SAMPLE_WORK_RESPONSE)
+    )
+    respx_mock.get("/authors/OL239963A.json").mock(
+        return_value=httpx.Response(200, json=SAMPLE_AUTHOR_GAMMA)
+    )
+    respx_mock.get("/authors/OL239964A.json").mock(
+        return_value=httpx.Response(200, json=SAMPLE_AUTHOR_HELM)
     )
     async with Client(mcp) as client:
         result = await client.call_tool("get_book", {"identifier": "9780201633610"})
@@ -292,6 +310,29 @@ async def test_get_book_by_work_id_no_editions(
     assert data["authors"] == ["Erich Gamma", "Richard Helm"]
     assert data["isbn_13"] is None
     assert data["cover_url"] == "https://covers.openlibrary.org/b/id/12345-M.jpg"
+
+
+@pytest.mark.respx(base_url=OL_BASE)
+async def test_get_book_isbn_enriches_authors(
+    respx_mock: respx.MockRouter, mcp: FastMCP
+) -> None:
+    """get_book by ISBN should resolve authors from the work record."""
+    respx_mock.get("/isbn/9780201633610.json").mock(
+        return_value=httpx.Response(200, json=SAMPLE_EDITION_RESPONSE)
+    )
+    respx_mock.get("/works/OL1168083W.json").mock(
+        return_value=httpx.Response(200, json=SAMPLE_WORK_RESPONSE)
+    )
+    respx_mock.get("/authors/OL239963A.json").mock(
+        return_value=httpx.Response(200, json=SAMPLE_AUTHOR_GAMMA)
+    )
+    respx_mock.get("/authors/OL239964A.json").mock(
+        return_value=httpx.Response(200, json=SAMPLE_AUTHOR_HELM)
+    )
+    async with Client(mcp) as client:
+        result = await client.call_tool("get_book", {"identifier": "9780201633610"})
+    data = json.loads(result.content[0].text)
+    assert data["authors"] == ["Erich Gamma", "Richard Helm"]
 
 
 @pytest.mark.respx(base_url=OL_BASE)


### PR DESCRIPTION
## Summary

- Adds `OpenLibraryClient.get_author()` to resolve author keys to names
- Introduces `enrich_authors_from_work()` in `_book_enrichment.py` for best-effort author enrichment from Open Library work records
- Enriches `get_book` (ISBN, edition, work lookups) and `enrich_books` (paper pipeline) with resolved author names
- Authors are included in `book_metadata` enrichment output

Closes #74

## Stacked on
- #72 (feat/book-record-typeddict)

## Test plan
- [x] `test_get_author` / `test_get_author_not_found` — OL client author resolution
- [x] `test_get_book_isbn_enriches_authors` — ISBN lookup resolves authors
- [x] `test_get_book_edition_enriches_authors` — edition lookup resolves authors
- [x] `test_get_book_work_resolves_authors` — work lookup resolves authors directly
- [x] `test_to_enrichment_dict_includes_authors` — enrichment dict includes authors
- [x] `test_to_enrichment_dict_empty_authors_defaults_to_list` — empty authors defaults to `[]`
- [x] All 464 tests passing, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)