### PR TITLE
feat: BibLaTeX @book output in generate_citations (#65)

### DIFF
--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -366,11 +366,11 @@ Generate formatted citations for one or more papers. Resolves papers via Semanti
 | `citation_format` | string | `"bibtex"` | Output format: `bibtex`, `csl-json`, or `ris` |
 | `enrich` | boolean | `true` | Attempt OpenAlex enrichment for missing venue data |
 
-**BibTeX output** includes entry type inference (`@article`, `@inproceedings`, `@misc`), proper author formatting (`{Last}, First`), title casing preservation, DOI, arXiv eprint fields, and special character escaping.
+**BibTeX output** includes entry type inference (`@article`, `@inproceedings`, `@misc`, `@book`), proper author formatting (`{Last}, First`), title casing preservation, DOI, arXiv eprint fields, and special character escaping. Papers with `book_metadata` (ISBN or publisher) are emitted as `@book` entries with `publisher`, `edition`, and `isbn` fields.
 
-**CSL-JSON output** returns `{"citations": [...], "errors": [...]}` -- the citations array contains standard CSL-JSON objects compatible with Zotero, Mendeley, Pandoc, and other CSL processors.
+**CSL-JSON output** returns `{"citations": [...], "errors": [...]}` -- the citations array contains standard CSL-JSON objects compatible with Zotero, Mendeley, Pandoc, and other CSL processors. Book entries use `type: "book"` with `publisher` and `ISBN` fields.
 
-**RIS output** uses standard RIS tags (`TY`, `AU`, `TI`, `PY`, `JO`/`BT`, `DO`, `UR`, `AB`, `ER`).
+**RIS output** uses standard RIS tags (`TY`, `AU`, `TI`, `PY`, `JO`/`BT`, `DO`, `UR`, `AB`, `ER`). Book entries use `TY - BOOK` with `PB` (publisher) and `SN` (ISBN) tags.
 
 Papers that fail to resolve are reported inline (BibTeX/RIS: as comments, CSL-JSON: in the errors array) rather than failing the entire request. When all papers fail, a structured error is returned: `{"error": "no_papers_resolved", "failed": [...]}`.
 

--- a/src/scholar_mcp/_citation_formatter.py
+++ b/src/scholar_mcp/_citation_formatter.py
@@ -369,7 +369,7 @@ def format_csl_json(papers: list[dict[str, Any]], errors: list[dict[str, Any]]) 
             entry["issued"] = {"date-parts": [[year]]}
 
         venue = paper.get("venue")
-        if venue:
+        if venue and entry_type != "book":
             entry["container-title"] = venue
 
         external_ids = paper.get("externalIds") or {}
@@ -486,7 +486,7 @@ def format_ris(papers: list[dict[str, Any]], errors: list[dict[str, Any]]) -> st
         if venue:
             if entry_type == "inproceedings":
                 lines.append(f"BT  - {venue}")
-            else:
+            elif entry_type != "book":
                 lines.append(f"JO  - {venue}")
 
         external_ids = paper.get("externalIds") or {}

--- a/src/scholar_mcp/_citation_formatter.py
+++ b/src/scholar_mcp/_citation_formatter.py
@@ -289,6 +289,7 @@ _CSL_TYPE_MAP: dict[str, str] = {
     "article": "article-journal",
     "inproceedings": "paper-conference",
     "misc": "article",
+    "book": "book",
 }
 
 
@@ -347,6 +348,21 @@ def format_csl_json(papers: list[dict[str, Any]], errors: list[dict[str, Any]]) 
             entry["title"] = title
 
         csl_authors = _csl_author(paper)
+        if not csl_authors and entry_type == "book":
+            bm = paper.get("book_metadata") or {}
+            for author_name in bm.get("authors") or []:
+                parsed = parse_author_name(author_name)
+                ae: dict[str, str] = {}
+                if parsed.last:
+                    ae["family"] = parsed.last
+                if parsed.first:
+                    ae["given"] = parsed.first
+                if parsed.prefix:
+                    ae["non-dropping-particle"] = parsed.prefix
+                if parsed.suffix:
+                    ae["suffix"] = parsed.suffix
+                if ae:
+                    csl_authors.append(ae)
         if csl_authors:
             entry["author"] = csl_authors
 
@@ -370,6 +386,13 @@ def format_csl_json(papers: list[dict[str, Any]], errors: list[dict[str, Any]]) 
         abstract = paper.get("abstract")
         if abstract:
             entry["abstract"] = abstract
+
+        if entry_type == "book":
+            bm = paper.get("book_metadata") or {}
+            if bm.get("publisher"):
+                entry["publisher"] = bm["publisher"]
+            if bm.get("isbn_13"):
+                entry["ISBN"] = bm["isbn_13"]
 
         citations.append(entry)
 

--- a/src/scholar_mcp/_citation_formatter.py
+++ b/src/scholar_mcp/_citation_formatter.py
@@ -131,8 +131,11 @@ def infer_entry_type(paper: dict[str, Any]) -> str:
         paper: Paper metadata dict.
 
     Returns:
-        One of ``"article"``, ``"inproceedings"``, or ``"misc"``.
+        One of ``"book"``, ``"article"``, ``"inproceedings"``, or ``"misc"``.
     """
+    book_meta = paper.get("book_metadata")
+    if book_meta and (book_meta.get("isbn_13") or book_meta.get("publisher")):
+        return "book"
     venue = (paper.get("venue") or "").lower()
     if any(kw in venue for kw in _CONFERENCE_KEYWORDS):
         return "inproceedings"

--- a/src/scholar_mcp/_citation_formatter.py
+++ b/src/scholar_mcp/_citation_formatter.py
@@ -218,13 +218,17 @@ def format_bibtex(papers: list[dict[str, Any]], errors: list[dict[str, Any]]) ->
 
         fields: list[str] = []
 
-        # Author: prefer S2 authors, fall back to book_metadata authors
+        # Author: prefer S2 authors, fall back to book_metadata authors.
+        # Synthesise {"name": ...} entries so _format_bibtex_author applies
+        # parse_author_name and produces the {Last, First} BibTeX convention.
         author_str = _format_bibtex_author(paper)
         if not author_str and entry_type == "book":
             bm = paper.get("book_metadata") or {}
             bm_authors = bm.get("authors") or []
             if bm_authors:
-                author_str = " and ".join(escape_bibtex(a) for a in bm_authors)
+                author_str = _format_bibtex_author(
+                    {"authors": [{"name": a} for a in bm_authors]}
+                )
         if author_str:
             fields.append(f"  author = {{{author_str}}}")
 

--- a/src/scholar_mcp/_citation_formatter.py
+++ b/src/scholar_mcp/_citation_formatter.py
@@ -218,7 +218,15 @@ def format_bibtex(papers: list[dict[str, Any]], errors: list[dict[str, Any]]) ->
 
         fields: list[str] = []
 
+        # Author: prefer S2 authors, fall back to book_metadata authors
         author_str = _format_bibtex_author(paper)
+        if not author_str and entry_type == "book":
+            bm = paper.get("book_metadata") or {}
+            bm_authors = bm.get("authors") or []
+            if bm_authors:
+                author_str = " and ".join(
+                    escape_bibtex(a) for a in bm_authors
+                )
         if author_str:
             fields.append(f"  author = {{{author_str}}}")
 
@@ -234,8 +242,21 @@ def format_bibtex(papers: list[dict[str, Any]], errors: list[dict[str, Any]]) ->
         if venue:
             if entry_type == "inproceedings":
                 fields.append(f"  booktitle = {{{escape_bibtex(venue)}}}")
-            else:
+            elif entry_type != "book":
                 fields.append(f"  journal = {{{escape_bibtex(venue)}}}")
+
+        # Book-specific fields from book_metadata
+        if entry_type == "book":
+            bm = paper.get("book_metadata") or {}
+            publisher = bm.get("publisher")
+            if publisher:
+                fields.append(f"  publisher = {{{escape_bibtex(publisher)}}}")
+            edition = bm.get("edition")
+            if edition:
+                fields.append(f"  edition = {{{escape_bibtex(edition)}}}")
+            isbn = bm.get("isbn_13")
+            if isbn:
+                fields.append(f"  isbn = {{{isbn}}}")
 
         external_ids = paper.get("externalIds") or {}
         doi = external_ids.get("DOI")

--- a/src/scholar_mcp/_citation_formatter.py
+++ b/src/scholar_mcp/_citation_formatter.py
@@ -224,9 +224,7 @@ def format_bibtex(papers: list[dict[str, Any]], errors: list[dict[str, Any]]) ->
             bm = paper.get("book_metadata") or {}
             bm_authors = bm.get("authors") or []
             if bm_authors:
-                author_str = " and ".join(
-                    escape_bibtex(a) for a in bm_authors
-                )
+                author_str = " and ".join(escape_bibtex(a) for a in bm_authors)
         if author_str:
             fields.append(f"  author = {{{author_str}}}")
 
@@ -411,6 +409,7 @@ _RIS_TYPE_MAP: dict[str, str] = {
     "article": "JOUR",
     "inproceedings": "CONF",
     "misc": "GEN",
+    "book": "BOOK",
 }
 
 
@@ -459,7 +458,21 @@ def format_ris(papers: list[dict[str, Any]], errors: list[dict[str, Any]]) -> st
         ris_type = _RIS_TYPE_MAP.get(entry_type, "GEN")
         lines: list[str] = [f"TY  - {ris_type}"]
 
-        lines.extend(_ris_author_line(paper))
+        author_lines = _ris_author_line(paper)
+        if not author_lines and entry_type == "book":
+            bm = paper.get("book_metadata") or {}
+            for author_name in bm.get("authors") or []:
+                parsed = parse_author_name(author_name)
+                name = (
+                    f"{parsed.prefix} {parsed.last}" if parsed.prefix else parsed.last
+                )
+                if parsed.first:
+                    name = f"{name}, {parsed.first}"
+                if parsed.suffix:
+                    name = f"{name}, {parsed.suffix}"
+                if name:
+                    author_lines.append(f"AU  - {name}")
+        lines.extend(author_lines)
 
         title = paper.get("title")
         if title:
@@ -488,6 +501,13 @@ def format_ris(papers: list[dict[str, Any]], errors: list[dict[str, Any]]) -> st
         abstract = paper.get("abstract")
         if abstract:
             lines.append(f"AB  - {abstract}")
+
+        if entry_type == "book":
+            bm = paper.get("book_metadata") or {}
+            if bm.get("publisher"):
+                lines.append(f"PB  - {bm['publisher']}")
+            if bm.get("isbn_13"):
+                lines.append(f"SN  - {bm['isbn_13']}")
 
         lines.append("ER  -")
         blocks.append("\n".join(lines))

--- a/tests/test_citation_formatter.py
+++ b/tests/test_citation_formatter.py
@@ -219,6 +219,50 @@ class TestFormatBibtex:
         assert "url" not in field_names
 
 
+class TestFormatBibtexBook:
+    def test_book_entry_type_and_fields(self) -> None:
+        papers = [
+            {
+                "title": "Deep Learning",
+                "authors": [{"name": "Ian Goodfellow"}],
+                "year": 2016,
+                "venue": "",
+                "externalIds": {},
+                "book_metadata": {
+                    "isbn_13": "9780262035613",
+                    "publisher": "MIT Press",
+                    "edition": "1st",
+                    "authors": [],
+                },
+            }
+        ]
+        result = format_bibtex(papers, [])
+        assert "@book{goodfellow2016," in result
+        assert "publisher = {MIT Press}" in result
+        assert "edition = {1st}" in result
+        assert "isbn = {9780262035613}" in result
+        assert "journal" not in result
+
+    def test_book_author_fallback(self) -> None:
+        papers = [
+            {
+                "title": "Some Book",
+                "authors": [],
+                "year": 2020,
+                "venue": "",
+                "externalIds": {},
+                "book_metadata": {
+                    "isbn_13": "9781234567890",
+                    "publisher": "Publisher",
+                    "authors": ["Alice Smith", "Bob Jones"],
+                },
+            }
+        ]
+        result = format_bibtex(papers, [])
+        assert "@book{" in result
+        assert "author = {Alice Smith and Bob Jones}" in result
+
+
 class TestFormatCslJson:
     def test_single_paper(self) -> None:
         papers = [

--- a/tests/test_citation_formatter.py
+++ b/tests/test_citation_formatter.py
@@ -263,7 +263,7 @@ class TestFormatBibtexBook:
         ]
         result = format_bibtex(papers, [])
         assert "@book{" in result
-        assert "author = {Alice Smith and Bob Jones}" in result
+        assert "author = {Smith, Alice and Jones, Bob}" in result
 
 
 class TestFormatCslJson:

--- a/tests/test_citation_formatter.py
+++ b/tests/test_citation_formatter.py
@@ -83,7 +83,10 @@ class TestInferEntryType:
 
     def test_book_with_isbn(self) -> None:
         paper = {
-            "book_metadata": {"isbn_13": "9780201633610", "publisher": "Addison-Wesley"},
+            "book_metadata": {
+                "isbn_13": "9780201633610",
+                "publisher": "Addison-Wesley",
+            },
         }
         assert infer_entry_type(paper) == "book"
 

--- a/tests/test_citation_formatter.py
+++ b/tests/test_citation_formatter.py
@@ -431,3 +431,44 @@ class TestFormatRis:
         ]
         result = format_ris(papers, [])
         assert result.count("ER  -") == 2
+
+
+class TestFormatRisBook:
+    def test_book_type_and_fields(self) -> None:
+        papers = [
+            {
+                "title": "Deep Learning",
+                "authors": [{"name": "Ian Goodfellow"}],
+                "year": 2016,
+                "venue": "",
+                "externalIds": {},
+                "book_metadata": {
+                    "isbn_13": "9780262035613",
+                    "publisher": "MIT Press",
+                    "authors": [],
+                },
+            }
+        ]
+        result = format_ris(papers, [])
+        assert "TY  - BOOK" in result
+        assert "PB  - MIT Press" in result
+        assert "SN  - 9780262035613" in result
+
+    def test_book_author_fallback_ris(self) -> None:
+        papers = [
+            {
+                "title": "Some Book",
+                "authors": [],
+                "year": 2020,
+                "venue": "",
+                "externalIds": {},
+                "book_metadata": {
+                    "isbn_13": "9781234567890",
+                    "publisher": "Publisher",
+                    "authors": ["Alice Smith"],
+                },
+            }
+        ]
+        result = format_ris(papers, [])
+        assert "TY  - BOOK" in result
+        assert "AU  - Smith, Alice" in result

--- a/tests/test_citation_formatter.py
+++ b/tests/test_citation_formatter.py
@@ -81,6 +81,25 @@ class TestInferEntryType:
     def test_none_venue(self) -> None:
         assert infer_entry_type({"venue": None}) == "article"
 
+    def test_book_with_isbn(self) -> None:
+        paper = {
+            "book_metadata": {"isbn_13": "9780201633610", "publisher": "Addison-Wesley"},
+        }
+        assert infer_entry_type(paper) == "book"
+
+    def test_book_with_publisher_only(self) -> None:
+        paper = {
+            "book_metadata": {"publisher": "MIT Press"},
+        }
+        assert infer_entry_type(paper) == "book"
+
+    def test_book_metadata_without_isbn_or_publisher_falls_through(self) -> None:
+        paper = {
+            "book_metadata": {"description": "A book"},
+            "venue": "Nature",
+        }
+        assert infer_entry_type(paper) == "article"
+
 
 class TestEscapeBibtex:
     def test_special_chars(self) -> None:

--- a/tests/test_citation_formatter.py
+++ b/tests/test_citation_formatter.py
@@ -316,6 +316,51 @@ class TestFormatCslJson:
         assert "issued" not in result["citations"][0]
 
 
+class TestFormatCslJsonBook:
+    def test_book_type_and_fields(self) -> None:
+        papers = [
+            {
+                "title": "Deep Learning",
+                "authors": [{"name": "Ian Goodfellow"}],
+                "year": 2016,
+                "venue": "",
+                "externalIds": {},
+                "book_metadata": {
+                    "isbn_13": "9780262035613",
+                    "publisher": "MIT Press",
+                    "authors": [],
+                },
+            }
+        ]
+        result_str = format_csl_json(papers, [])
+        result = json.loads(result_str)
+        entry = result["citations"][0]
+        assert entry["type"] == "book"
+        assert entry["publisher"] == "MIT Press"
+        assert entry["ISBN"] == "9780262035613"
+
+    def test_book_author_fallback_csl(self) -> None:
+        papers = [
+            {
+                "title": "Some Book",
+                "authors": [],
+                "year": 2020,
+                "venue": "",
+                "externalIds": {},
+                "book_metadata": {
+                    "isbn_13": "9781234567890",
+                    "publisher": "Publisher",
+                    "authors": ["Alice Smith"],
+                },
+            }
+        ]
+        result_str = format_csl_json(papers, [])
+        result = json.loads(result_str)
+        entry = result["citations"][0]
+        assert entry["author"][0]["family"] == "Smith"
+        assert entry["author"][0]["given"] == "Alice"
+
+
 class TestFormatRis:
     def test_single_journal_article(self) -> None:
         papers = [

--- a/tests/test_citation_formatter.py
+++ b/tests/test_citation_formatter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from typing import Any
 
 from scholar_mcp._citation_formatter import (
     escape_bibtex,
@@ -43,7 +44,7 @@ class TestGenerateBibtexKey:
         assert generate_bibtex_key(paper, set()) == "houten2020"
 
     def test_no_authors(self) -> None:
-        paper: dict = {"authors": [], "year": 2024}
+        paper: dict[str, Any] = {"authors": [], "year": 2024}
         assert generate_bibtex_key(paper, set()) == "anon2024"
 
     def test_no_year(self) -> None:
@@ -304,7 +305,7 @@ class TestFormatCslJson:
         assert result["errors"][0]["identifier"] == "bad_id"
 
     def test_missing_year(self) -> None:
-        papers = [
+        papers: list[dict[str, Any]] = [
             {
                 "title": "No Year",
                 "year": None,
@@ -362,6 +363,30 @@ class TestFormatCslJsonBook:
         entry = result["citations"][0]
         assert entry["author"][0]["family"] == "Smith"
         assert entry["author"][0]["given"] == "Alice"
+
+    def test_book_author_prefix_and_suffix_csl(self) -> None:
+        """Authors with von-prefix and suffix map to CSL non-dropping-particle and suffix."""
+        papers = [
+            {
+                "title": "Some Book",
+                "authors": [],
+                "year": 2020,
+                "venue": "",
+                "externalIds": {},
+                "book_metadata": {
+                    "isbn_13": "9781234567890",
+                    "publisher": "Publisher",
+                    "authors": ["Jan van Houten Jr."],
+                },
+            }
+        ]
+        result_str = format_csl_json(papers, [])
+        result = json.loads(result_str)
+        author = result["citations"][0]["author"][0]
+        assert author["family"] == "Houten"
+        assert author["given"] == "Jan"
+        assert author["non-dropping-particle"] == "van"
+        assert author["suffix"] == "Jr."
 
 
 class TestFormatRis:
@@ -475,3 +500,22 @@ class TestFormatRisBook:
         result = format_ris(papers, [])
         assert "TY  - BOOK" in result
         assert "AU  - Smith, Alice" in result
+
+    def test_book_author_suffix_ris(self) -> None:
+        """Authors with a suffix emit Last, First, Suffix in RIS AU field."""
+        papers = [
+            {
+                "title": "Some Book",
+                "authors": [],
+                "year": 2020,
+                "venue": "",
+                "externalIds": {},
+                "book_metadata": {
+                    "isbn_13": "9781234567890",
+                    "publisher": "Publisher",
+                    "authors": ["Martin Luther King Jr."],
+                },
+            }
+        ]
+        result = format_ris(papers, [])
+        assert "AU  - King, Martin Luther, Jr." in result


### PR DESCRIPTION
## Summary

- `infer_entry_type()` detects books via `book_metadata` (ISBN or publisher)
- BibTeX: emits `@book` with `publisher`, `edition`, `isbn` fields
- CSL-JSON: emits `type: "book"` with `publisher` and `ISBN`
- RIS: emits `TY - BOOK` with `PB` and `SN` tags
- Author fallback: uses `book_metadata.authors` when S2 authors list is empty
- Venue tags suppressed for book entries across all three formats
- `@incollection` deferred to v0.6.0 milestone containing #64

Stacked on: #78 (recommend_books)
Closes #65

## Test plan
- [x] `TestInferEntryType` — book detection with ISBN, publisher, fallback
- [x] `TestFormatBibtexBook` — @book entry, fields, author fallback
- [x] `TestFormatCslJsonBook` — book type, publisher, ISBN, author fallback
- [x] `TestFormatRisBook` — BOOK type, PB/SN tags, author fallback
- [x] All 482 tests passing, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)