### PR TITLE
feat: EPO per-service throttle checking and LLM retry guidance

### DIFF
--- a/docs/superpowers/plans/2026-04-08-epo-throttle.md
+++ b/docs/superpowers/plans/2026-04-08-epo-throttle.md
@@ -1,0 +1,1028 @@
+# EPO Per-Service Throttle & LLM Retry Guidance — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix EPO OPS throttle checking to use per-service quota colors, add a pre-flight cache to prevent wasted API calls, and replace raw exception strings in task results with clear, actionable messages for LLM clients.
+
+**Architecture:** Three coordinated changes: (1) `_epo_client.py` gains a header parser, per-service throttle check, and a 60-second instance-level cache that short-circuits pre-throttled calls; (2) `_tools_tasks.py` sanitises rate-limit errors and adds patent tool duration hints; (3) patent tool docstrings gain a standard note explaining transparent queueing. No new tools; no changes to task queue retry logic.
+
+**Tech Stack:** Python 3.12, `asyncio`, `epo_ops` (sync library wrapped in `asyncio.to_thread`), `fastmcp`, `pytest-asyncio`
+
+**Spec:** `docs/superpowers/specs/2026-04-08-epo-throttle-design.md`
+
+---
+
+## File Map
+
+| File | Role |
+|---|---|
+| `src/scholar_mcp/_epo_client.py` | `_parse_throttle_header`, cache attrs, `_is_service_throttled`, updated `_check_throttle(service)`, updated `EpoRateLimitedError`, pre-flight in every public method |
+| `src/scholar_mcp/_tools_tasks.py` | Sanitised error in `get_task_result`, patent entries in `_DURATION_HINTS` |
+| `src/scholar_mcp/_tools_patent.py` | Docstring note on three tools |
+| `tests/test_epo_client.py` | All new throttle tests |
+| `tests/test_tools_tasks.py` | Rate-limit error sanitisation tests, patent hint tests |
+
+---
+
+## Task 1: `_parse_throttle_header` — module-level header parser
+
+**Files:**
+- Modify: `src/scholar_mcp/_epo_client.py` (add function before `EpoRateLimitedError`)
+- Test: `tests/test_epo_client.py`
+
+- [ ] **Write failing tests**
+
+Add to `tests/test_epo_client.py` after the existing imports — import the new function alongside `EpoClient`:
+
+```python
+from scholar_mcp._epo_client import EpoClient, EpoRateLimitedError, _parse_throttle_header
+```
+
+Add these test functions after the existing `_mock_response` helper:
+
+```python
+# ---------------------------------------------------------------------------
+# _parse_throttle_header unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_parse_throttle_header_full() -> None:
+    """Full header extracts overall color and all per-service colors."""
+    result = _parse_throttle_header(
+        "busy (images=green:100, search=yellow:2, retrieval=green:50, inpadoc=green:45, other=green:1000)"
+    )
+    assert result["_overall"] == "busy"
+    assert result["search"] == "yellow"
+    assert result["retrieval"] == "green"
+    assert result["images"] == "green"
+    assert result["inpadoc"] == "green"
+
+
+def test_parse_throttle_header_simple_color_only() -> None:
+    """Header with no sub-services returns only _overall."""
+    result = _parse_throttle_header("green")
+    assert result["_overall"] == "green"
+    assert "search" not in result
+
+
+def test_parse_throttle_header_idle() -> None:
+    """idle color is parsed correctly for overall and sub-services."""
+    result = _parse_throttle_header("idle (search=idle:30, retrieval=idle:200)")
+    assert result["_overall"] == "idle"
+    assert result["search"] == "idle"
+
+
+def test_parse_throttle_header_normalises_to_lowercase() -> None:
+    """Colors are always returned as lowercase."""
+    result = _parse_throttle_header("Green (Search=Yellow:2)")
+    assert result["_overall"] == "green"
+    assert result["search"] == "yellow"
+```
+
+- [ ] **Run tests to verify they fail**
+
+```
+uv run pytest tests/test_epo_client.py::test_parse_throttle_header_full -v
+```
+
+Expected: `ImportError: cannot import name '_parse_throttle_header'`
+
+- [ ] **Implement `_parse_throttle_header`**
+
+Add `import re` and `import time` to the existing imports in `_epo_client.py`, then insert this function immediately before the `EpoRateLimitedError` class:
+
+```python
+def _parse_throttle_header(header: str) -> dict[str, str]:
+    """Parse an EPO ``X-Throttling-Control`` header into a service→color mapping.
+
+    Args:
+        header: Raw header value, e.g.
+            ``"busy (images=green:100, search=yellow:2, retrieval=green:50)"``.
+
+    Returns:
+        Dict with ``"_overall"`` holding the top-level color, plus one entry
+        per named service.  All values are lowercase.  Missing header should
+        be represented by calling this with ``"green"``.
+    """
+    parts = header.strip().split(None, 1)
+    result: dict[str, str] = {"_overall": parts[0].lower() if parts else "green"}
+    if len(parts) > 1:
+        for match in re.finditer(r"(\w+)=(\w+):\d+", parts[1]):
+            result[match.group(1).lower()] = match.group(2).lower()
+    return result
+```
+
+- [ ] **Run tests to verify they pass**
+
+```
+uv run pytest tests/test_epo_client.py::test_parse_throttle_header_full tests/test_epo_client.py::test_parse_throttle_header_simple_color_only tests/test_epo_client.py::test_parse_throttle_header_idle tests/test_epo_client.py::test_parse_throttle_header_normalises_to_lowercase -v
+```
+
+Expected: 4 passed
+
+- [ ] **Commit**
+
+```bash
+git add src/scholar_mcp/_epo_client.py tests/test_epo_client.py
+git commit -m "feat: add _parse_throttle_header for EPO per-service throttle parsing"
+```
+
+---
+
+## Task 2: Update `_mock_response` + `_check_throttle` to use per-service color
+
+The `_mock_response` test helper currently builds a header with only the `search` sub-service. Expand it to include all four services so that per-service checks work correctly in all existing and new tests. Then update `_check_throttle` to use the parsed per-service color.
+
+**Files:**
+- Modify: `tests/test_epo_client.py` (`_mock_response` helper + two new tests)
+- Modify: `src/scholar_mcp/_epo_client.py` (`_check_throttle` signature and body)
+
+- [ ] **Write failing tests**
+
+Add these two tests to `tests/test_epo_client.py` in the throttle section (after `test_green_throttle_does_not_raise`):
+
+```python
+async def test_search_checks_search_service_not_overall(
+    epo_client: EpoClient,
+    mock_ops_client: MagicMock,
+) -> None:
+    """overall=busy but search=green must NOT raise — per-service check."""
+    mock_ops_client.published_data_search.return_value = _mock_response(
+        _SEARCH_XML,
+        throttle="busy (images=green:100, retrieval=green:200, search=green:15, inpadoc=green:45, other=green:1000)",
+    )
+    result = await epo_client.search("ti=Test")
+    assert result["total_count"] == 1
+
+
+async def test_search_raises_on_search_service_yellow_despite_overall_green(
+    epo_client: EpoClient,
+    mock_ops_client: MagicMock,
+) -> None:
+    """search=yellow must raise EpoRateLimitedError even when overall=green."""
+    mock_ops_client.published_data_search.return_value = _mock_response(
+        _SEARCH_XML,
+        throttle="green (images=green:100, retrieval=green:200, search=yellow:2, inpadoc=green:45, other=green:1000)",
+    )
+    with pytest.raises(EpoRateLimitedError):
+        await epo_client.search("ti=Test")
+```
+
+- [ ] **Run tests to verify they fail**
+
+```
+uv run pytest tests/test_epo_client.py::test_search_checks_search_service_not_overall tests/test_epo_client.py::test_search_raises_on_search_service_yellow_despite_overall_green -v
+```
+
+Expected: both FAIL (first one raises unexpectedly, second one does not raise)
+
+- [ ] **Update `_mock_response` helper**
+
+Replace the existing `_mock_response` function in `tests/test_epo_client.py`:
+
+```python
+def _mock_response(
+    content: bytes,
+    status_code: int = 200,
+    throttle: str = "green",
+) -> MagicMock:
+    """Create a fake requests.Response for use with mocked epo_ops methods.
+
+    Args:
+        content: Raw response body bytes.
+        status_code: HTTP status code.
+        throttle: Either a simple color word (``"green"``, ``"yellow"``, etc.)
+            which is expanded into a full header with all four services set to
+            that color, or a complete ``X-Throttling-Control`` header string
+            (detected by the presence of ``"("``).
+
+    Returns:
+        MagicMock configured to behave like a requests.Response.
+    """
+    resp = MagicMock(spec=requests.Response)
+    resp.content = content
+    resp.status_code = status_code
+    if "(" in throttle:
+        header = throttle
+    else:
+        header = (
+            f"{throttle} ("
+            f"search={throttle}:30, "
+            f"retrieval={throttle}:200, "
+            f"inpadoc={throttle}:45, "
+            f"other={throttle}:1000)"
+        )
+    resp.headers = {"X-Throttling-Control": header}
+    resp.raise_for_status = MagicMock()
+    return resp
+```
+
+- [ ] **Update `_check_throttle` in `_epo_client.py`**
+
+Replace the existing `_check_throttle` method body:
+
+```python
+def _check_throttle(self, response: Any, service: str = "_overall") -> None:
+    """Inspect the throttle header and raise if the relevant service is not green.
+
+    Parses the full ``X-Throttling-Control`` header and checks the color for
+    *service* specifically, falling back to the overall color when the service
+    is not listed.  Updates the instance throttle cache on every call.
+
+    Args:
+        response: A ``requests.Response``-like object with a ``headers`` dict.
+        service: EPO service name to check — ``"search"``, ``"retrieval"``,
+            ``"inpadoc"``, or ``"_overall"`` (default).
+
+    Raises:
+        RuntimeError: When color is ``"black"`` (daily quota exhausted).
+        EpoRateLimitedError: When color is not green or idle.
+    """
+    header = response.headers.get("X-Throttling-Control", "green")
+    throttle = _parse_throttle_header(header)
+    self._throttle_cache = throttle
+    self._throttle_cache_ts = time.monotonic()
+
+    color = throttle.get(service, throttle.get("_overall", "green"))
+    if color == "black":
+        raise RuntimeError("EPO daily quota exhausted. Please try again tomorrow.")
+    if color not in ("green", "idle"):
+        logger.warning("epo_throttle service=%s color=%s", service, color)
+        raise EpoRateLimitedError(color, service=service)
+```
+
+Also add `import time` and `import re` at the top of `_epo_client.py` (alongside the existing imports).
+
+- [ ] **Run all throttle tests**
+
+```
+uv run pytest tests/test_epo_client.py -k "throttle" -v
+```
+
+Expected: all pass (existing tests still pass because the expanded `_mock_response` sets all services to the same color, so per-service == overall)
+
+- [ ] **Commit**
+
+```bash
+git add src/scholar_mcp/_epo_client.py tests/test_epo_client.py
+git commit -m "feat: check per-service EPO throttle color instead of overall"
+```
+
+---
+
+## Task 3: `EpoRateLimitedError.service` + throttle cache + pre-flight on `search()`
+
+**Files:**
+- Modify: `src/scholar_mcp/_epo_client.py`
+- Test: `tests/test_epo_client.py`
+
+- [ ] **Write failing tests**
+
+Add to `tests/test_epo_client.py`:
+
+```python
+def test_epo_rate_limited_error_stores_service() -> None:
+    """EpoRateLimitedError stores the service name."""
+    exc = EpoRateLimitedError("yellow", service="search")
+    assert exc.service == "search"
+    assert exc.color == "yellow"
+
+
+def test_epo_rate_limited_error_default_service() -> None:
+    """EpoRateLimitedError defaults service to '_overall'."""
+    exc = EpoRateLimitedError("red")
+    assert exc.service == "_overall"
+
+
+async def test_search_preflight_uses_cache_to_skip_api(
+    epo_client: EpoClient,
+    mock_ops_client: MagicMock,
+) -> None:
+    """After a throttled response, subsequent search() calls raise without hitting the API."""
+    mock_ops_client.published_data_search.return_value = _mock_response(
+        _SEARCH_XML, throttle="yellow"
+    )
+    with pytest.raises(EpoRateLimitedError):
+        await epo_client.search("ti=First")
+
+    mock_ops_client.published_data_search.reset_mock()
+
+    with pytest.raises(EpoRateLimitedError):
+        await epo_client.search("ti=Second")
+
+    mock_ops_client.published_data_search.assert_not_called()
+
+
+async def test_search_preflight_bypasses_expired_cache(
+    epo_client: EpoClient,
+    mock_ops_client: MagicMock,
+) -> None:
+    """After the 60-second TTL, the next call goes through to the API."""
+    mock_ops_client.published_data_search.return_value = _mock_response(
+        _SEARCH_XML, throttle="yellow"
+    )
+    with pytest.raises(EpoRateLimitedError):
+        await epo_client.search("ti=Test")
+
+    # Manually expire the cache
+    epo_client._throttle_cache_ts = 0.0
+
+    mock_ops_client.published_data_search.return_value = _mock_response(
+        _SEARCH_XML, throttle="green"
+    )
+    result = await epo_client.search("ti=Test")
+    assert result["total_count"] == 1
+    mock_ops_client.published_data_search.assert_called()
+```
+
+- [ ] **Run tests to verify they fail**
+
+```
+uv run pytest tests/test_epo_client.py::test_epo_rate_limited_error_stores_service tests/test_epo_client.py::test_search_preflight_uses_cache_to_skip_api -v
+```
+
+Expected: FAIL — `EpoRateLimitedError` has no `service` param, `_throttle_cache` does not exist
+
+- [ ] **Update `EpoRateLimitedError`**
+
+Replace the existing class definition:
+
+```python
+class EpoRateLimitedError(RateLimitedError):
+    """Raised when the EPO traffic light is yellow, red, or black for a service."""
+
+    def __init__(self, color: str, *, service: str = "_overall") -> None:
+        self.color = color
+        self.service = service
+        super().__init__(f"EPO rate limited: {service}={color}")
+```
+
+- [ ] **Add throttle cache attrs to `EpoClient.__init__`**
+
+In `EpoClient.__init__`, after `self._lock = asyncio.Lock()`:
+
+```python
+self._throttle_cache: dict[str, str] = {}
+self._throttle_cache_ts: float = 0.0
+```
+
+- [ ] **Add `_is_service_throttled` helper**
+
+Add this method to `EpoClient` immediately after `_check_throttle`:
+
+```python
+def _is_service_throttled(self, service: str) -> bool:
+    """Return True if a recent throttled response indicates *service* is not green.
+
+    The cache expires after 60 seconds to allow automatic recovery.
+
+    Args:
+        service: EPO service name — ``"search"``, ``"retrieval"``, or
+            ``"inpadoc"``.
+
+    Returns:
+        ``True`` when the cached color for *service* is non-green and the
+        cache is less than 60 seconds old.  ``False`` when the cache is stale
+        or the service is green/idle.
+    """
+    if time.monotonic() - self._throttle_cache_ts > 60:
+        return False
+    color = self._throttle_cache.get(
+        service, self._throttle_cache.get("_overall", "green")
+    )
+    return color not in ("green", "idle")
+```
+
+- [ ] **Add pre-flight to `search()` and pass `service="search"` to `_check_throttle`**
+
+Replace the `search()` method body:
+
+```python
+async def search(
+    self,
+    cql_query: str,
+    range_begin: int = 1,
+    range_end: int = 25,
+) -> dict[str, Any]:
+    """Search EPO published data using a CQL query.
+
+    Args:
+        cql_query: CQL (Contextual Query Language) search expression.
+        range_begin: First result number in the requested range (1-based).
+        range_end: Last result number in the requested range (inclusive).
+
+    Returns:
+        Parsed search results dict with keys ``total_count`` and
+        ``references`` (see :func:`parse_search_xml`).
+
+    Raises:
+        EpoRateLimitedError: When the EPO search quota is not green.
+    """
+    if self._is_service_throttled("search"):
+        raise EpoRateLimitedError(
+            self._throttle_cache.get(
+                "search", self._throttle_cache.get("_overall", "unknown")
+            ),
+            service="search",
+        )
+    try:
+        async with self._lock:
+            response = await asyncio.to_thread(
+                self._client.published_data_search,
+                cql_query,
+                range_begin=range_begin,
+                range_end=range_end,
+            )
+    except HTTPError as exc:
+        if exc.response is not None and exc.response.status_code == 404:
+            logger.debug("epo_search_no_results cql=%s", cql_query)
+            return {"total_count": 0, "references": []}
+        raise
+    self._check_throttle(response, service="search")
+    return parse_search_xml(response.content)
+```
+
+- [ ] **Run tests**
+
+```
+uv run pytest tests/test_epo_client.py -v
+```
+
+Expected: all pass
+
+- [ ] **Commit**
+
+```bash
+git add src/scholar_mcp/_epo_client.py tests/test_epo_client.py
+git commit -m "feat: add throttle cache and pre-flight check to EpoClient.search()"
+```
+
+---
+
+## Task 4: Pre-flight + per-service check for all remaining EpoClient methods
+
+Wire `_is_service_throttled` and the correct `service` arg into `get_biblio`, `get_claims`, `get_description`, `get_citations` (all `"retrieval"`) and `get_family`, `get_legal` (both `"inpadoc"`).
+
+**Files:**
+- Modify: `src/scholar_mcp/_epo_client.py`
+- Test: `tests/test_epo_client.py`
+
+- [ ] **Write failing tests**
+
+```python
+async def test_get_biblio_preflight_uses_cache(
+    epo_client: EpoClient,
+    mock_ops_client: MagicMock,
+) -> None:
+    """After retrieval=yellow response, get_biblio raises without hitting the API."""
+    mock_ops_client.published_data.return_value = _mock_response(
+        _BIBLIO_XML, throttle="yellow"
+    )
+    doc = DocdbNumber(country="EP", number="1234567", kind="A1")
+    with pytest.raises(EpoRateLimitedError):
+        await epo_client.get_biblio(doc)
+
+    mock_ops_client.published_data.reset_mock()
+
+    with pytest.raises(EpoRateLimitedError):
+        await epo_client.get_biblio(doc)
+
+    mock_ops_client.published_data.assert_not_called()
+
+
+async def test_get_family_preflight_uses_cache(
+    epo_client: EpoClient,
+    mock_ops_client: MagicMock,
+) -> None:
+    """After inpadoc=yellow response, get_family raises without hitting the API."""
+    mock_ops_client.family.return_value = _mock_response(
+        _FAMILY_RESPONSE_XML, throttle="yellow"
+    )
+    doc = DocdbNumber(country="EP", number="1234567", kind="A1")
+    with pytest.raises(EpoRateLimitedError):
+        await epo_client.get_family(doc)
+
+    mock_ops_client.family.reset_mock()
+
+    with pytest.raises(EpoRateLimitedError):
+        await epo_client.get_family(doc)
+
+    mock_ops_client.family.assert_not_called()
+```
+
+- [ ] **Run tests to verify they fail**
+
+```
+uv run pytest tests/test_epo_client.py::test_get_biblio_preflight_uses_cache tests/test_epo_client.py::test_get_family_preflight_uses_cache -v
+```
+
+Expected: FAIL — no pre-flight yet in those methods
+
+- [ ] **Add pre-flight + per-service to retrieval methods**
+
+Replace each method body. Pattern for `"retrieval"` methods (`get_biblio`, `get_claims`, `get_description`, `get_citations`):
+
+```python
+async def get_biblio(self, doc: DocdbNumber) -> dict[str, Any]:
+    """Fetch bibliographic data for a single patent.
+
+    Args:
+        doc: Patent number in DOCDB format.
+
+    Returns:
+        Parsed bibliographic metadata dict (see :func:`parse_biblio_xml`).
+
+    Raises:
+        EpoRateLimitedError: When the EPO retrieval quota is not green.
+    """
+    if self._is_service_throttled("retrieval"):
+        raise EpoRateLimitedError(
+            self._throttle_cache.get(
+                "retrieval", self._throttle_cache.get("_overall", "unknown")
+            ),
+            service="retrieval",
+        )
+    inp = self._to_docdb_input(doc)
+    async with self._lock:
+        response = await asyncio.to_thread(
+            self._client.published_data,
+            "publication",
+            inp,
+            endpoint="biblio",
+        )
+    self._check_throttle(response, service="retrieval")
+    return parse_biblio_xml(response.content)
+
+
+async def get_claims(self, doc: DocdbNumber) -> str:
+    """Fetch claims text for a patent.
+
+    Args:
+        doc: Patent number in DOCDB format.
+
+    Returns:
+        Claims text as a single string (see :func:`parse_claims_xml`).
+
+    Raises:
+        EpoRateLimitedError: When the EPO retrieval quota is not green.
+    """
+    if self._is_service_throttled("retrieval"):
+        raise EpoRateLimitedError(
+            self._throttle_cache.get(
+                "retrieval", self._throttle_cache.get("_overall", "unknown")
+            ),
+            service="retrieval",
+        )
+    inp = self._to_docdb_input(doc)
+    async with self._lock:
+        response = await asyncio.to_thread(
+            self._client.published_data,
+            "publication",
+            inp,
+            endpoint="claims",
+        )
+    self._check_throttle(response, service="retrieval")
+    return parse_claims_xml(response.content)
+
+
+async def get_description(self, doc: DocdbNumber) -> str:
+    """Fetch description text for a patent.
+
+    Args:
+        doc: Patent number in DOCDB format.
+
+    Returns:
+        Description text as a single string (see :func:`parse_description_xml`).
+
+    Raises:
+        EpoRateLimitedError: When the EPO retrieval quota is not green.
+    """
+    if self._is_service_throttled("retrieval"):
+        raise EpoRateLimitedError(
+            self._throttle_cache.get(
+                "retrieval", self._throttle_cache.get("_overall", "unknown")
+            ),
+            service="retrieval",
+        )
+    inp = self._to_docdb_input(doc)
+    async with self._lock:
+        response = await asyncio.to_thread(
+            self._client.published_data,
+            "publication",
+            inp,
+            endpoint="description",
+        )
+    self._check_throttle(response, service="retrieval")
+    return parse_description_xml(response.content)
+
+
+async def get_citations(self, doc: DocdbNumber) -> dict[str, list[dict[str, Any]]]:
+    """Fetch cited references (patent and NPL) for a patent.
+
+    Args:
+        doc: Patent number in DOCDB format.
+
+    Returns:
+        Dict with ``patent_refs`` and ``npl_refs`` lists
+        (see :func:`parse_citations_from_biblio`).
+
+    Raises:
+        EpoRateLimitedError: When the EPO retrieval quota is not green.
+    """
+    if self._is_service_throttled("retrieval"):
+        raise EpoRateLimitedError(
+            self._throttle_cache.get(
+                "retrieval", self._throttle_cache.get("_overall", "unknown")
+            ),
+            service="retrieval",
+        )
+    inp = self._to_docdb_input(doc)
+    async with self._lock:
+        response = await asyncio.to_thread(
+            self._client.published_data,
+            "publication",
+            inp,
+            endpoint="biblio",
+        )
+    self._check_throttle(response, service="retrieval")
+    return parse_citations_from_biblio(response.content)
+```
+
+- [ ] **Add pre-flight + per-service to inpadoc methods**
+
+```python
+async def get_family(self, doc: DocdbNumber) -> list[dict[str, str]]:
+    """Fetch patent family members.
+
+    Args:
+        doc: Patent number in DOCDB format.
+
+    Returns:
+        List of family member dicts (see :func:`parse_family_xml`).
+
+    Raises:
+        EpoRateLimitedError: When the EPO inpadoc quota is not green.
+    """
+    if self._is_service_throttled("inpadoc"):
+        raise EpoRateLimitedError(
+            self._throttle_cache.get(
+                "inpadoc", self._throttle_cache.get("_overall", "unknown")
+            ),
+            service="inpadoc",
+        )
+    inp = self._to_docdb_input(doc)
+    async with self._lock:
+        response = await asyncio.to_thread(
+            self._client.family,
+            "publication",
+            inp,
+        )
+    self._check_throttle(response, service="inpadoc")
+    return parse_family_xml(response.content)
+
+
+async def get_legal(self, doc: DocdbNumber) -> list[dict[str, str]]:
+    """Fetch legal status events for a patent.
+
+    Args:
+        doc: Patent number in DOCDB format.
+
+    Returns:
+        List of legal event dicts (see :func:`parse_legal_xml`).
+
+    Raises:
+        EpoRateLimitedError: When the EPO inpadoc quota is not green.
+    """
+    if self._is_service_throttled("inpadoc"):
+        raise EpoRateLimitedError(
+            self._throttle_cache.get(
+                "inpadoc", self._throttle_cache.get("_overall", "unknown")
+            ),
+            service="inpadoc",
+        )
+    inp = self._to_docdb_input(doc)
+    async with self._lock:
+        response = await asyncio.to_thread(
+            self._client.legal,
+            "publication",
+            inp,
+        )
+    self._check_throttle(response, service="inpadoc")
+    return parse_legal_xml(response.content)
+```
+
+- [ ] **Run all epo client tests**
+
+```
+uv run pytest tests/test_epo_client.py -v
+```
+
+Expected: all pass
+
+- [ ] **Commit**
+
+```bash
+git add src/scholar_mcp/_epo_client.py tests/test_epo_client.py
+git commit -m "feat: add per-service throttle check and pre-flight cache to all EpoClient methods"
+```
+
+---
+
+## Task 5: Sanitise rate-limit errors + patent duration hints in `get_task_result`
+
+**Files:**
+- Modify: `src/scholar_mcp/_tools_tasks.py`
+- Test: `tests/test_tools_tasks.py`
+
+- [ ] **Write failing tests**
+
+Add to `tests/test_tools_tasks.py`:
+
+```python
+async def test_get_task_result_rate_limit_error_is_sanitised(
+    mcp: FastMCP, bundle: ServiceBundle
+) -> None:
+    """Rate-limit errors are replaced with a generic 60-second retry message."""
+
+    async def _rate_limited_coro() -> str:
+        raise Exception("EpoRateLimitedError: EPO rate limited: search=yellow")
+
+    task_id = bundle.tasks.submit(_rate_limited_coro())
+    for _ in range(40):
+        task = bundle.tasks.get(task_id)
+        if task and task.status in ("completed", "failed"):
+            break
+        await asyncio.sleep(0.05)
+
+    async with Client(mcp) as client:
+        result = await client.call_tool("get_task_result", {"task_id": task_id})
+    data = json.loads(result.content[0].text)
+    assert data["status"] == "failed"
+    assert data["retryable"] is True
+    assert "60 seconds" in data["error"]
+    assert "RateLimitedError" not in data["error"]
+    assert "yellow" not in data["error"]
+
+
+async def test_get_task_result_daily_quota_error_is_sanitised(
+    mcp: FastMCP, bundle: ServiceBundle
+) -> None:
+    """Daily quota errors are replaced with a 'try tomorrow' message."""
+
+    async def _quota_coro() -> str:
+        raise Exception("RuntimeError: EPO daily quota exhausted. Please try again tomorrow.")
+
+    task_id = bundle.tasks.submit(_quota_coro())
+    for _ in range(40):
+        task = bundle.tasks.get(task_id)
+        if task and task.status in ("completed", "failed"):
+            break
+        await asyncio.sleep(0.05)
+
+    async with Client(mcp) as client:
+        result = await client.call_tool("get_task_result", {"task_id": task_id})
+    data = json.loads(result.content[0].text)
+    assert data["status"] == "failed"
+    assert data["retryable"] is False
+    assert "tomorrow" in data["error"]
+    assert "daily quota" not in data["error"].lower()
+
+
+async def test_get_task_result_other_errors_pass_through(
+    mcp: FastMCP, bundle: ServiceBundle
+) -> None:
+    """Non-rate-limit errors are returned unchanged (regression guard)."""
+
+    async def _failing_coro() -> str:
+        raise ValueError("unexpected database error")
+
+    task_id = bundle.tasks.submit(_failing_coro())
+    for _ in range(40):
+        task = bundle.tasks.get(task_id)
+        if task and task.status in ("completed", "failed"):
+            break
+        await asyncio.sleep(0.05)
+
+    async with Client(mcp) as client:
+        result = await client.call_tool("get_task_result", {"task_id": task_id})
+    data = json.loads(result.content[0].text)
+    assert data["status"] == "failed"
+    assert "unexpected database error" in data["error"]
+    assert "retryable" not in data
+
+
+async def test_get_task_result_patent_search_hint(
+    mcp: FastMCP, bundle: ServiceBundle
+) -> None:
+    """get_task_result includes a hint for queued search_patents tasks."""
+
+    async def _slow_coro() -> str:
+        await asyncio.sleep(10)
+        return "{}"
+
+    task_id = bundle.tasks.submit(_slow_coro(), tool="search_patents")
+
+    async with Client(mcp) as client:
+        result = await client.call_tool("get_task_result", {"task_id": task_id})
+    data = json.loads(result.content[0].text)
+    assert data["status"] in ("pending", "running")
+    assert "hint" in data
+    assert "5-15 seconds" in data["hint"]
+
+
+async def test_get_task_result_get_patent_hint(
+    mcp: FastMCP, bundle: ServiceBundle
+) -> None:
+    """get_task_result includes a hint for queued get_patent tasks."""
+
+    async def _slow_coro() -> str:
+        await asyncio.sleep(10)
+        return "{}"
+
+    task_id = bundle.tasks.submit(_slow_coro(), tool="get_patent")
+
+    async with Client(mcp) as client:
+        result = await client.call_tool("get_task_result", {"task_id": task_id})
+    data = json.loads(result.content[0].text)
+    assert "hint" in data
+    assert "5-20 seconds" in data["hint"]
+```
+
+- [ ] **Run tests to verify they fail**
+
+```
+uv run pytest tests/test_tools_tasks.py::test_get_task_result_rate_limit_error_is_sanitised tests/test_tools_tasks.py::test_get_task_result_patent_search_hint -v
+```
+
+Expected: FAIL
+
+- [ ] **Update `_DURATION_HINTS` in `_tools_tasks.py`**
+
+Replace the existing `_DURATION_HINTS` dict:
+
+```python
+_DURATION_HINTS: dict[str, str] = {
+    "fetch_paper_pdf": "PDF download usually completes in 10-30 seconds.",
+    "convert_pdf_to_markdown": (
+        "PDF conversion typically takes 1-5 minutes depending on page count."
+    ),
+    "fetch_and_convert": (
+        "Full pipeline (download + conversion) typically takes 1-5 minutes."
+    ),
+    "search_patents": "Patent searches usually complete in 5-15 seconds.",
+    "get_patent": "Patent data retrieval usually completes in 5-20 seconds.",
+    "get_citing_patents": "Citing patent lookup usually completes in 10-30 seconds.",
+}
+```
+
+- [ ] **Update the `failed` branch in `get_task_result`**
+
+Replace this section in `get_task_result`:
+
+```python
+        if task.status == "completed":
+            response["result"] = task.result
+        elif task.status == "failed":
+            response["error"] = task.error
+```
+
+With:
+
+```python
+        if task.status == "completed":
+            response["result"] = task.result
+        elif task.status == "failed":
+            error = task.error or ""
+            if "daily quota" in error:
+                response["error"] = (
+                    "The service has reached its daily quota. Try again tomorrow."
+                )
+                response["retryable"] = False
+            elif "RateLimitedError" in error:
+                response["error"] = (
+                    "The service was busy and could not complete the request. "
+                    "Try calling the tool again in about 60 seconds."
+                )
+                response["retryable"] = True
+            else:
+                response["error"] = error
+```
+
+- [ ] **Run all task tool tests**
+
+```
+uv run pytest tests/test_tools_tasks.py -v
+```
+
+Expected: all pass
+
+- [ ] **Commit**
+
+```bash
+git add src/scholar_mcp/_tools_tasks.py tests/test_tools_tasks.py
+git commit -m "feat: sanitise rate-limit errors in get_task_result and add patent duration hints"
+```
+
+---
+
+## Task 6: Update patent tool docstrings
+
+No tests needed — docstring-only change.
+
+**Files:**
+- Modify: `src/scholar_mcp/_tools_patent.py`
+
+- [ ] **Add standard note to `search_patents` Returns: section**
+
+Find the `Returns:` block in `search_patents` and replace it:
+
+```python
+        Returns:
+            JSON string with ``total_count`` and ``references`` list, or an
+            error dict if the EPO client is not configured or the API fails.
+            If the EPO service is busy, the request is automatically retried
+            once and ``{"queued": true, "task_id": "..."}`` is returned. Use
+            ``get_task_result`` to retrieve the result. If the retry also
+            fails, ``get_task_result`` returns ``status: failed`` — call this
+            tool again after about 60 seconds. Do not attempt to manage or
+            reason about EPO throttle states directly.
+```
+
+- [ ] **Add same note to `get_patent` Returns: section**
+
+```python
+        Returns:
+            JSON string with ``patent_number`` (normalised DOCDB format) and
+            the requested section data, or an error dict on failure.
+            If the EPO service is busy, the request is automatically retried
+            once and ``{"queued": true, "task_id": "..."}`` is returned. Use
+            ``get_task_result`` to retrieve the result. If the retry also
+            fails, ``get_task_result`` returns ``status: failed`` — call this
+            tool again after about 60 seconds. Do not attempt to manage or
+            reason about EPO throttle states directly.
+```
+
+- [ ] **Add same note to `get_citing_patents` Returns: section**
+
+```python
+        Returns:
+            JSON string with ``paper_id``, ``patents`` list (each with
+            biblio data and ``match_source``), ``total_count``, and a
+            ``note`` about coverage limitations.
+            If the EPO service is busy, the request is automatically retried
+            once and ``{"queued": true, "task_id": "..."}`` is returned. Use
+            ``get_task_result`` to retrieve the result. If the retry also
+            fails, ``get_task_result`` returns ``status: failed`` — call this
+            tool again after about 60 seconds. Do not attempt to manage or
+            reason about EPO throttle states directly.
+```
+
+- [ ] **Run full test suite to confirm nothing broken**
+
+```
+uv run pytest tests/ -q --tb=short
+```
+
+Expected: all pass
+
+- [ ] **Commit**
+
+```bash
+git add src/scholar_mcp/_tools_patent.py
+git commit -m "docs: add transparent rate-limiting note to patent tool descriptions"
+```
+
+---
+
+## Task 7: Rebuild Docker image
+
+- [ ] **Rebuild and restart**
+
+```bash
+cd /mnt/docker-volumes/compose.git/70-ai
+docker compose up -d --build scholar-mcp
+```
+
+Expected: `Container ai-scholar-mcp Started`
+
+- [ ] **Verify new code is live**
+
+```bash
+docker exec ai-scholar-mcp python -c "
+from scholar_mcp._epo_client import _parse_throttle_header, EpoRateLimitedError
+r = _parse_throttle_header('busy (search=green:15, retrieval=green:100)')
+print(r)
+e = EpoRateLimitedError('yellow', service='search')
+print(e.service, e.color)
+"
+```
+
+Expected:
+```
+{'_overall': 'busy', 'search': 'green', 'retrieval': 'green'}
+search yellow
+```
+
+- [ ] **Commit** *(no code changes — this step just rebuilds)*
+
+No commit needed. The image is built from already-committed source.

--- a/docs/superpowers/specs/2026-04-08-epo-throttle-design.md
+++ b/docs/superpowers/specs/2026-04-08-epo-throttle-design.md
@@ -11,20 +11,27 @@ The EPO OPS API returns an `X-Throttling-Control` header with both an overall co
 busy (images=green:100, inpadoc=green:45, other=green:1000, retrieval=green:100, search=green:15)
 ```
 
-Currently `_check_throttle` reads only the overall color. A response with `overall=busy` but `search=green` causes all searches to be queued unnecessarily. Additionally, when a tool does queue due to rate limiting, the LLM client receives only `{"queued": true, "task_id": "..."}` with no guidance on when to retry — leading to immediate re-attempts that burn further quota.
+Currently `_check_throttle` reads only the overall color. A response with `overall=busy` but `search=green` causes all searches to be queued unnecessarily.
+
+When a patent tool does queue due to rate limiting, two further problems arise:
+
+1. The task result on failure contains the raw exception string `EpoRateLimitedError: EPO rate limited: search=yellow`. LLMs trained on EPO OPS documentation recognise this and may start reasoning about the traffic light system themselves — retrying too aggressively, alarming the user, or otherwise behaving in ways the server already handles correctly.
+2. Patent tools have no entry in `_DURATION_HINTS`, so `get_task_result` gives no hint about expected wait time — just a bare `elapsed_seconds` with no context.
 
 ## Goals
 
 1. Check the relevant **per-service color** instead of the overall color.
-2. Prevent wasted API calls when a service is known to be throttled (pre-flight cache check).
-3. Tell LLM clients **when to retry** in the queued response.
-4. Update tool **descriptions** so LLMs know to just attempt calls — throttling is handled server-side.
+2. Prevent wasted API calls via a **pre-flight cache check** when a service is known to be throttled.
+3. **Sanitise rate-limit error strings** surfaced through `get_task_result` so LLMs see a generic, actionable message rather than EPO-specific terminology.
+4. Add **patent tool duration hints** to `get_task_result` so LLMs understand progress is happening.
+5. Update **tool descriptions** so LLMs know to just attempt calls — throttling is fully server-side.
 
 ## Non-Goals
 
-- No new `check_epo_quota` tool (not needed given transparent queueing).
+- No new `check_epo_quota` tool.
 - No change to the task queue retry logic.
 - No change to S2 or other non-EPO rate limiting.
+- No EPO-specific retry timing exposed to LLMs (color, `retry_after_seconds`, etc.).
 
 ---
 
@@ -43,18 +50,18 @@ def _parse_throttle_header(header: str) -> dict[str, str]:
     """
 ```
 
-Uses a regex to extract `name=color:count` pairs from the parenthesised section. The `_overall` key always holds the first token.
+Uses a regex to extract `name=color:count` pairs from the parenthesised section. The `_overall` key always holds the first token. Missing header defaults to `{"_overall": "green"}`.
 
 ### 2. Per-Service Throttle Check — `_check_throttle(response, service)`
 
-`_check_throttle` gains a `service: str` parameter (default `"_overall"`). After parsing the header, it looks up `throttle.get(service, throttle["_overall"])` for the effective color. Behavior is otherwise unchanged:
+`_check_throttle` gains a `service: str` parameter (default `"_overall"`). After parsing the header it looks up `throttle.get(service, throttle["_overall"])` for the effective color. Behaviour is otherwise unchanged:
 
-- `black` → `RuntimeError` (daily quota exhausted, not retryable)
+- `black` → `RuntimeError("EPO daily quota exhausted. Please try again tomorrow.")`
 - not in `{"green", "idle"}` → `EpoRateLimitedError`
 
-Every call to `_check_throttle` also updates the instance-level throttle cache (see §3).
+Every call to `_check_throttle` also writes the freshly-parsed throttle dict to the instance-level cache (see §3).
 
-Service mappings across `EpoClient` methods:
+Service mappings:
 
 | Method(s) | EPO service |
 |---|---|
@@ -71,16 +78,14 @@ self._throttle_cache: dict[str, str] = {}   # service → color
 self._throttle_cache_ts: float = 0.0         # time.monotonic() of last update
 ```
 
-Every `_check_throttle` call writes the freshly-parsed throttle dict to `_throttle_cache` and updates `_throttle_cache_ts`.
-
 New helper `_is_service_throttled(service: str) -> bool`:
 
-- Returns `False` if `time.monotonic() - _throttle_cache_ts > 60` (cache stale — let the call through)
+- Returns `False` if `time.monotonic() - _throttle_cache_ts > 60` (stale — let the call through)
 - Returns `True` if `_throttle_cache.get(service, "green") not in {"green", "idle"}`
 
-Each public `EpoClient` method checks `_is_service_throttled` before acquiring the lock or making any network call. If throttled, it raises `EpoRateLimitedError` immediately with the cached color.
+Each public `EpoClient` method calls `_is_service_throttled` **before** acquiring the lock or making any network call. If throttled, raises `EpoRateLimitedError` immediately using the cached color.
 
-This means: after the first throttled response, subsequent calls (including concurrent ones serialised behind the `asyncio.Lock`) short-circuit without touching EPO, until the 60-second TTL expires.
+Effect: after the first throttled response, subsequent concurrent calls (serialised behind the `asyncio.Lock`) short-circuit without touching EPO for up to 60 seconds.
 
 ### 4. `EpoRateLimitedError` — `service` Attribute
 
@@ -92,43 +97,39 @@ class EpoRateLimitedError(RateLimitedError):
         super().__init__(f"EPO rate limited: {service}={color}")
 ```
 
-The `service` attribute is keyword-only to preserve the existing positional `color` signature used in tests.
+`service` is keyword-only to preserve the existing positional `color` signature used in tests.
 
-### 5. Queued Response — Retry Guidance
+### 5. Sanitised Error Strings in `get_task_result`
 
-Color → `retry_after_seconds` mapping (module-level constant in `_tools_patent.py`):
+`get_task_result` in `_tools_tasks.py` currently returns `task.error` verbatim. Two substring checks (no import needed) replace EPO-specific strings with concrete, actionable messages:
+
+| Condition | `error` returned | `retryable` |
+|---|---|---|
+| `"daily quota"` in `task.error` | `"The service has reached its daily quota. Try again tomorrow."` | `false` |
+| `"RateLimitedError"` in `task.error` | `"The service was busy and could not complete the request. Try calling the tool again in about 60 seconds."` | `true` |
+| anything else | `task.error` unchanged | *(omitted)* |
+
+Checks run in that order so the daily-quota case is caught before the generic rate-limit case.
+
+This keeps EPO-specific terminology out of LLM responses entirely. The `retryable` flag gives the LLM a clear, implementation-agnostic signal without requiring it to interpret error strings.
+
+### 6. Patent Tool Duration Hints
+
+Add entries to `_DURATION_HINTS` in `_tools_tasks.py`:
 
 ```python
-_RETRY_AFTER: dict[str, int | None] = {
-    "yellow": 30,
-    "red": 120,
-    "black": None,   # daily quota; message explains
-}
+"search_patents": "Patent searches usually complete in 5-15 seconds.",
+"get_patent": "Patent data retrieval usually completes in 5-20 seconds.",
+"get_citing_patents": "Citing patent lookup usually completes in 10-30 seconds.",
 ```
 
-When a tool catches `EpoRateLimitedError` and queues the task, the response becomes:
+These appear in `get_task_result` responses while a patent task is `pending` or `running`, alongside `elapsed_seconds`.
 
-```json
-{
-  "queued": true,
-  "task_id": "<id>",
-  "tool": "search_patents",
-  "rate_limited": {
-    "service": "search",
-    "color": "yellow",
-    "retry_after_seconds": 30,
-    "message": "EPO search quota is limited. Request queued for retry. Check task status or retry the search in ~30 s."
-  }
-}
-```
+### 7. Tool Description Updates
 
-For `black` (daily quota exhausted), `retry_after_seconds` is `null` and the message says "EPO daily quota exhausted. Try again tomorrow."
+The `search_patents`, `get_patent`, and `get_citing_patents` docstrings gain a note in their `Returns:` section:
 
-### 6. Tool Description Updates
-
-The `search_patents`, `get_patent`, and `get_citing_patents` docstrings gain a standard note in their `Returns:` section:
-
-> Rate limiting is handled automatically. If the EPO quota is limited, the request is queued and `{"queued": true, "task_id": "..."}` is returned along with retry guidance. There is no need to pre-check quota — just attempt the call.
+> If the EPO service is busy, the request is automatically retried once and a `{"queued": true, "task_id": "..."}` response is returned. Use `get_task_result` to retrieve the result. If the retry also fails, `get_task_result` returns `status: failed` — call the tool again after about 60 seconds. Do not attempt to manage or reason about EPO throttle states directly.
 
 ---
 
@@ -137,17 +138,20 @@ The `search_patents`, `get_patent`, and `get_citing_patents` docstrings gain a s
 | File | Changes |
 |---|---|
 | `src/scholar_mcp/_epo_client.py` | `_parse_throttle_header`, `_check_throttle(service)`, throttle cache, pre-flight check, `EpoRateLimitedError.service` |
-| `src/scholar_mcp/_tools_patent.py` | `_RETRY_AFTER` constant, richer queued response, updated docstrings |
-| `tests/test_epo_client.py` | Tests for header parsing, per-service check, cache pre-flight, idle color |
-| `tests/test_tools_patent.py` | Tests for `_RETRY_AFTER` mapping, queued response shape |
+| `src/scholar_mcp/_tools_patent.py` | Updated docstrings on three tools |
+| `src/scholar_mcp/_tools_tasks.py` | Patent entries in `_DURATION_HINTS`; sanitise rate-limit errors in `get_task_result` |
+| `tests/test_epo_client.py` | Header parsing, per-service check, cache pre-flight, cache TTL |
+| `tests/test_tools_patent.py` | Queued response shape (no `rate_limited` block) |
+| `tests/test_tools_tasks.py` | Sanitised error string, `retryable` flag, patent hints |
 
 ---
 
 ## Testing
 
-- `_parse_throttle_header`: unit tests covering full header, header with no sub-services, missing header (defaults to green), each known color.
-- Per-service check: `overall=busy, search=green` does not raise; `overall=green, search=yellow` raises `EpoRateLimitedError` with `service="search"`.
-- Pre-flight cache: after a throttled response, a second call raises without hitting the mock client.
-- Cache TTL: after > 60 s (mocked), the call goes through normally.
-- Queued response shape: `rate_limited` block present and correct for `yellow`, `red`, `black`.
+- `_parse_throttle_header`: full header, no sub-services, missing header (defaults green), all known colors.
+- Per-service check: `overall=busy, search=green` does not raise; `overall=green, search=yellow` raises `EpoRateLimitedError(service="search")`.
+- Pre-flight cache: after a throttled response, second call raises without touching the mock EPO client.
+- Cache TTL: after > 60 s (mocked `time.monotonic`), call goes through normally.
+- Sanitised error: `task.error` containing `"daily quota"` → daily quota message + `retryable: false`; containing `"RateLimitedError"` → 60-second retry message + `retryable: true`; other errors unchanged.
+- Patent hints: `get_task_result` for a pending `search_patents` task includes `hint` and `elapsed_seconds`.
 - Existing throttle tests (`green`, `yellow`, `red`, `black`, `idle`) continue to pass.

--- a/docs/superpowers/specs/2026-04-08-epo-throttle-design.md
+++ b/docs/superpowers/specs/2026-04-08-epo-throttle-design.md
@@ -1,0 +1,153 @@
+# EPO OPS Per-Service Throttle & LLM Retry Guidance
+
+**Date:** 2026-04-08
+**Status:** Approved
+
+## Problem
+
+The EPO OPS API returns an `X-Throttling-Control` header with both an overall color and a per-service breakdown:
+
+```
+busy (images=green:100, inpadoc=green:45, other=green:1000, retrieval=green:100, search=green:15)
+```
+
+Currently `_check_throttle` reads only the overall color. A response with `overall=busy` but `search=green` causes all searches to be queued unnecessarily. Additionally, when a tool does queue due to rate limiting, the LLM client receives only `{"queued": true, "task_id": "..."}` with no guidance on when to retry — leading to immediate re-attempts that burn further quota.
+
+## Goals
+
+1. Check the relevant **per-service color** instead of the overall color.
+2. Prevent wasted API calls when a service is known to be throttled (pre-flight cache check).
+3. Tell LLM clients **when to retry** in the queued response.
+4. Update tool **descriptions** so LLMs know to just attempt calls — throttling is handled server-side.
+
+## Non-Goals
+
+- No new `check_epo_quota` tool (not needed given transparent queueing).
+- No change to the task queue retry logic.
+- No change to S2 or other non-EPO rate limiting.
+
+---
+
+## Design
+
+### 1. Throttle Header Parsing — `_parse_throttle_header`
+
+New module-level function in `_epo_client.py`:
+
+```python
+def _parse_throttle_header(header: str) -> dict[str, str]:
+    """Parse X-Throttling-Control into {service: color, '_overall': color}.
+
+    Example input: "busy (images=green:100, search=yellow:2, retrieval=green:50)"
+    Example output: {"_overall": "busy", "images": "green", "search": "yellow", "retrieval": "green"}
+    """
+```
+
+Uses a regex to extract `name=color:count` pairs from the parenthesised section. The `_overall` key always holds the first token.
+
+### 2. Per-Service Throttle Check — `_check_throttle(response, service)`
+
+`_check_throttle` gains a `service: str` parameter (default `"_overall"`). After parsing the header, it looks up `throttle.get(service, throttle["_overall"])` for the effective color. Behavior is otherwise unchanged:
+
+- `black` → `RuntimeError` (daily quota exhausted, not retryable)
+- not in `{"green", "idle"}` → `EpoRateLimitedError`
+
+Every call to `_check_throttle` also updates the instance-level throttle cache (see §3).
+
+Service mappings across `EpoClient` methods:
+
+| Method(s) | EPO service |
+|---|---|
+| `search()` | `"search"` |
+| `get_biblio()`, `get_claims()`, `get_description()`, `get_citations()` | `"retrieval"` |
+| `get_family()`, `get_legal()` | `"inpadoc"` |
+
+### 3. Pre-Flight Cache Check
+
+`EpoClient` gains two instance attributes initialised in `__init__`:
+
+```python
+self._throttle_cache: dict[str, str] = {}   # service → color
+self._throttle_cache_ts: float = 0.0         # time.monotonic() of last update
+```
+
+Every `_check_throttle` call writes the freshly-parsed throttle dict to `_throttle_cache` and updates `_throttle_cache_ts`.
+
+New helper `_is_service_throttled(service: str) -> bool`:
+
+- Returns `False` if `time.monotonic() - _throttle_cache_ts > 60` (cache stale — let the call through)
+- Returns `True` if `_throttle_cache.get(service, "green") not in {"green", "idle"}`
+
+Each public `EpoClient` method checks `_is_service_throttled` before acquiring the lock or making any network call. If throttled, it raises `EpoRateLimitedError` immediately with the cached color.
+
+This means: after the first throttled response, subsequent calls (including concurrent ones serialised behind the `asyncio.Lock`) short-circuit without touching EPO, until the 60-second TTL expires.
+
+### 4. `EpoRateLimitedError` — `service` Attribute
+
+```python
+class EpoRateLimitedError(RateLimitedError):
+    def __init__(self, color: str, *, service: str = "_overall") -> None:
+        self.color = color
+        self.service = service
+        super().__init__(f"EPO rate limited: {service}={color}")
+```
+
+The `service` attribute is keyword-only to preserve the existing positional `color` signature used in tests.
+
+### 5. Queued Response — Retry Guidance
+
+Color → `retry_after_seconds` mapping (module-level constant in `_tools_patent.py`):
+
+```python
+_RETRY_AFTER: dict[str, int | None] = {
+    "yellow": 30,
+    "red": 120,
+    "black": None,   # daily quota; message explains
+}
+```
+
+When a tool catches `EpoRateLimitedError` and queues the task, the response becomes:
+
+```json
+{
+  "queued": true,
+  "task_id": "<id>",
+  "tool": "search_patents",
+  "rate_limited": {
+    "service": "search",
+    "color": "yellow",
+    "retry_after_seconds": 30,
+    "message": "EPO search quota is limited. Request queued for retry. Check task status or retry the search in ~30 s."
+  }
+}
+```
+
+For `black` (daily quota exhausted), `retry_after_seconds` is `null` and the message says "EPO daily quota exhausted. Try again tomorrow."
+
+### 6. Tool Description Updates
+
+The `search_patents`, `get_patent`, and `get_citing_patents` docstrings gain a standard note in their `Returns:` section:
+
+> Rate limiting is handled automatically. If the EPO quota is limited, the request is queued and `{"queued": true, "task_id": "..."}` is returned along with retry guidance. There is no need to pre-check quota — just attempt the call.
+
+---
+
+## Files Changed
+
+| File | Changes |
+|---|---|
+| `src/scholar_mcp/_epo_client.py` | `_parse_throttle_header`, `_check_throttle(service)`, throttle cache, pre-flight check, `EpoRateLimitedError.service` |
+| `src/scholar_mcp/_tools_patent.py` | `_RETRY_AFTER` constant, richer queued response, updated docstrings |
+| `tests/test_epo_client.py` | Tests for header parsing, per-service check, cache pre-flight, idle color |
+| `tests/test_tools_patent.py` | Tests for `_RETRY_AFTER` mapping, queued response shape |
+
+---
+
+## Testing
+
+- `_parse_throttle_header`: unit tests covering full header, header with no sub-services, missing header (defaults to green), each known color.
+- Per-service check: `overall=busy, search=green` does not raise; `overall=green, search=yellow` raises `EpoRateLimitedError` with `service="search"`.
+- Pre-flight cache: after a throttled response, a second call raises without hitting the mock client.
+- Cache TTL: after > 60 s (mocked), the call goes through normally.
+- Queued response shape: `rate_limited` block present and correct for `yellow`, `red`, `black`.
+- Existing throttle tests (`green`, `yellow`, `red`, `black`, `idle`) continue to pass.

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -390,7 +390,7 @@ Search for patents across 100+ patent offices via the EPO Open Patent Services (
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `query` | string | *(required)* | Natural language or keyword search query |
+| `query` | string | -- | Keyword search — searches patent titles and abstracts. Optional when using structured filters. |
 | `cpc_classification` | string | -- | CPC classification code filter (e.g. `"H01M10/00"`) |
 | `applicant` | string | -- | Applicant (assignee) name filter |
 | `inventor` | string | -- | Inventor name filter |
@@ -401,10 +401,12 @@ Search for patents across 100+ patent offices via the EPO Open Patent Services (
 | `limit` | int | `10` | Results per page (max 100) |
 | `offset` | int | `0` | Pagination offset |
 
+At least one parameter must be provided.
+
 **Returns:** `{"total_count": N, "references": [...]}` where each reference has `country`, `number`, and `kind` fields.
 
 !!! tip "Query syntax"
-    The tool translates parameters into EPO CQL internally. The `query` parameter maps to title+abstract search. Use the filter parameters for structured queries — they are properly escaped and quoted.
+    The tool translates parameters into EPO CQL internally. `query` searches titles and abstracts only — it will not find patents where the keyword appears only in inventor/applicant names. To find all patents by an inventor or from an applicant, omit `query` and use only the structured filters (e.g. `inventor="Smith"`). Combining `query` with filters applies both constraints.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,10 @@ ignore_missing_imports = true
 module = ["lxml", "lxml.*"]
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = ["requests", "requests.*"]
+ignore_missing_imports = true
+
 [tool.semantic_release]
 version_toml = ["pyproject.toml:project.version"]
 commit_parser = "angular"

--- a/src/scholar_mcp/_epo_client.py
+++ b/src/scholar_mcp/_epo_client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+import time
 from typing import TYPE_CHECKING, Any
 
 import epo_ops
@@ -51,11 +52,12 @@ def _parse_throttle_header(header: str) -> dict[str, str]:
 
 
 class EpoRateLimitedError(RateLimitedError):
-    """Raised when EPO traffic light is yellow, red, or black."""
+    """Raised when the EPO OPS API throttles a request."""
 
-    def __init__(self, color: str) -> None:
+    def __init__(self, color: str, *, service: str = "_overall") -> None:
         self.color = color
-        super().__init__(f"EPO rate limited: traffic light is {color}")
+        self.service = service
+        super().__init__(f"EPO rate limited: {service}={color}")
 
 
 class EpoClient:
@@ -89,6 +91,8 @@ class EpoClient:
                 middlewares=[],
             )
         self._lock = asyncio.Lock()
+        self._throttle_cache: dict[str, str] = {}
+        self._throttle_cache_ts: float = 0.0
 
     # ------------------------------------------------------------------
     # Private helpers
@@ -110,6 +114,22 @@ class EpoClient:
             kind_code=doc.kind or "A",
         )
 
+    def _is_service_throttled(self, service: str) -> bool:
+        """Check if a service is known to be throttled from the cache.
+
+        Args:
+            service: The EPO service name, e.g. ``"search"``.
+
+        Returns:
+            ``True`` if the cache is fresh (< 60 s old) and the service color
+            is not green or idle. ``False`` if the cache is stale or the service
+            is not throttled.
+        """
+        if time.monotonic() - self._throttle_cache_ts > 60:
+            return False
+        color = self._throttle_cache.get(service, "green")
+        return color not in ("green", "idle")
+
     def _check_throttle(self, response: Any, service: str = "_overall") -> None:
         """Check the throttle header and raise if the relevant service is throttled.
 
@@ -124,12 +144,15 @@ class EpoClient:
         """
         header = response.headers.get("X-Throttling-Control", "green")
         throttle = _parse_throttle_header(header)
+        # Update cache
+        self._throttle_cache = throttle
+        self._throttle_cache_ts = time.monotonic()
         color = throttle.get(service, throttle["_overall"])
         if color == "black":
             raise RuntimeError("EPO daily quota exhausted. Please try again tomorrow.")
         if color not in ("green", "idle"):
             logger.warning("epo_throttle service=%s color=%s", service, color)
-            raise EpoRateLimitedError(color)
+            raise EpoRateLimitedError(color, service=service)
 
     # ------------------------------------------------------------------
     # Public API
@@ -155,6 +178,15 @@ class EpoClient:
         Raises:
             EpoRateLimitedError: When the EPO traffic light is not green.
         """
+        if self._is_service_throttled("search"):
+            cached_color = self._throttle_cache.get(
+                "search", self._throttle_cache.get("_overall", "red")
+            )
+            if cached_color == "black":
+                raise RuntimeError(
+                    "EPO daily quota exhausted. Please try again tomorrow."
+                )
+            raise EpoRateLimitedError(cached_color, service="search")
         try:
             async with self._lock:
                 response = await asyncio.to_thread(
@@ -169,7 +201,7 @@ class EpoClient:
                 logger.debug("epo_search_no_results cql=%s", cql_query)
                 return {"total_count": 0, "references": []}
             raise
-        self._check_throttle(response)
+        self._check_throttle(response, service="search")
         return parse_search_xml(response.content)
 
     async def get_biblio(self, doc: DocdbNumber) -> dict[str, Any]:

--- a/src/scholar_mcp/_epo_client.py
+++ b/src/scholar_mcp/_epo_client.py
@@ -216,6 +216,11 @@ class EpoClient:
         Raises:
             EpoRateLimitedError: When the EPO traffic light is not green.
         """
+        if self._is_service_throttled("retrieval"):
+            raise EpoRateLimitedError(
+                self._throttle_cache.get("retrieval", self._throttle_cache.get("_overall", "red")),
+                service="retrieval",
+            )
         inp = self._to_docdb_input(doc)
         async with self._lock:
             response = await asyncio.to_thread(
@@ -224,7 +229,7 @@ class EpoClient:
                 inp,
                 endpoint="biblio",
             )
-        self._check_throttle(response)
+        self._check_throttle(response, service="retrieval")
         return parse_biblio_xml(response.content)
 
     async def get_claims(self, doc: DocdbNumber) -> str:
@@ -239,6 +244,11 @@ class EpoClient:
         Raises:
             EpoRateLimitedError: When the EPO traffic light is not green.
         """
+        if self._is_service_throttled("retrieval"):
+            raise EpoRateLimitedError(
+                self._throttle_cache.get("retrieval", self._throttle_cache.get("_overall", "red")),
+                service="retrieval",
+            )
         inp = self._to_docdb_input(doc)
         async with self._lock:
             response = await asyncio.to_thread(
@@ -247,7 +257,7 @@ class EpoClient:
                 inp,
                 endpoint="claims",
             )
-        self._check_throttle(response)
+        self._check_throttle(response, service="retrieval")
         return parse_claims_xml(response.content)
 
     async def get_description(self, doc: DocdbNumber) -> str:
@@ -262,6 +272,11 @@ class EpoClient:
         Raises:
             EpoRateLimitedError: When the EPO traffic light is not green.
         """
+        if self._is_service_throttled("retrieval"):
+            raise EpoRateLimitedError(
+                self._throttle_cache.get("retrieval", self._throttle_cache.get("_overall", "red")),
+                service="retrieval",
+            )
         inp = self._to_docdb_input(doc)
         async with self._lock:
             response = await asyncio.to_thread(
@@ -270,7 +285,7 @@ class EpoClient:
                 inp,
                 endpoint="description",
             )
-        self._check_throttle(response)
+        self._check_throttle(response, service="retrieval")
         return parse_description_xml(response.content)
 
     async def get_family(self, doc: DocdbNumber) -> list[dict[str, str]]:
@@ -285,6 +300,11 @@ class EpoClient:
         Raises:
             EpoRateLimitedError: When the EPO traffic light is not green.
         """
+        if self._is_service_throttled("inpadoc"):
+            raise EpoRateLimitedError(
+                self._throttle_cache.get("inpadoc", self._throttle_cache.get("_overall", "red")),
+                service="inpadoc",
+            )
         inp = self._to_docdb_input(doc)
         async with self._lock:
             response = await asyncio.to_thread(
@@ -292,7 +312,7 @@ class EpoClient:
                 "publication",
                 inp,
             )
-        self._check_throttle(response)
+        self._check_throttle(response, service="inpadoc")
         return parse_family_xml(response.content)
 
     async def get_legal(self, doc: DocdbNumber) -> list[dict[str, str]]:
@@ -307,6 +327,11 @@ class EpoClient:
         Raises:
             EpoRateLimitedError: When the EPO traffic light is not green.
         """
+        if self._is_service_throttled("inpadoc"):
+            raise EpoRateLimitedError(
+                self._throttle_cache.get("inpadoc", self._throttle_cache.get("_overall", "red")),
+                service="inpadoc",
+            )
         inp = self._to_docdb_input(doc)
         async with self._lock:
             response = await asyncio.to_thread(
@@ -314,7 +339,7 @@ class EpoClient:
                 "publication",
                 inp,
             )
-        self._check_throttle(response)
+        self._check_throttle(response, service="inpadoc")
         return parse_legal_xml(response.content)
 
     async def get_citations(self, doc: DocdbNumber) -> dict[str, list[dict[str, Any]]]:
@@ -330,6 +355,11 @@ class EpoClient:
         Raises:
             EpoRateLimitedError: When the EPO traffic light is not green.
         """
+        if self._is_service_throttled("retrieval"):
+            raise EpoRateLimitedError(
+                self._throttle_cache.get("retrieval", self._throttle_cache.get("_overall", "red")),
+                service="retrieval",
+            )
         inp = self._to_docdb_input(doc)
         async with self._lock:
             response = await asyncio.to_thread(
@@ -338,7 +368,7 @@ class EpoClient:
                 inp,
                 endpoint="biblio",
             )
-        self._check_throttle(response)
+        self._check_throttle(response, service="retrieval")
         return parse_citations_from_biblio(response.content)
 
     async def aclose(self) -> None:

--- a/src/scholar_mcp/_epo_client.py
+++ b/src/scholar_mcp/_epo_client.py
@@ -110,31 +110,25 @@ class EpoClient:
             kind_code=doc.kind or "A",
         )
 
-    def _check_throttle(self, response: Any) -> None:
-        """Inspect the X-Throttling-Control header and raise if not green.
-
-        The header format is:
-        ``green (search=green:30, retrieval=green:200, ...)``.
-        The first word is the overall traffic-light colour.
+    def _check_throttle(self, response: Any, service: str = "_overall") -> None:
+        """Check the throttle header and raise if the relevant service is throttled.
 
         Args:
-            response: A ``requests.Response``-like object with a ``headers``
-                dict attribute.
+            response: The HTTP response object with a ``headers`` dict-like attribute.
+            service: The EPO service to check (e.g. ``"search"``, ``"retrieval"``,
+                ``"inpadoc"``). Defaults to ``"_overall"``.
 
         Raises:
-            RuntimeError: When the traffic-light colour is ``"black"``
-                (daily quota exhausted — not retryable).
-            EpoRateLimitedError: When the traffic-light colour is yellow or
-                red (retryable rate limit).
+            RuntimeError: If the daily quota is exhausted.
+            EpoRateLimitedError: If the service color is not green or idle.
         """
         header = response.headers.get("X-Throttling-Control", "green")
-        parts = header.split()
-        color = parts[0].lower() if parts else "green"
+        throttle = _parse_throttle_header(header)
+        color = throttle.get(service, throttle["_overall"])
         if color == "black":
             raise RuntimeError("EPO daily quota exhausted. Please try again tomorrow.")
-        # "idle" and "green" are both non-throttled states; only warn on yellow/red.
         if color not in ("green", "idle"):
-            logger.warning("epo_throttle color=%s", color)
+            logger.warning("epo_throttle service=%s color=%s", service, color)
             raise EpoRateLimitedError(color)
 
     # ------------------------------------------------------------------

--- a/src/scholar_mcp/_epo_client.py
+++ b/src/scholar_mcp/_epo_client.py
@@ -127,7 +127,8 @@ class EpoClient:
         """
         if time.monotonic() - self._throttle_cache_ts > 60:
             return False
-        color = self._throttle_cache.get(service, "green")
+        cached = self._throttle_cache
+        color = cached.get(service, cached.get("_overall", "green"))
         return color not in ("green", "idle")
 
     def _check_throttle(self, response: Any, service: str = "_overall") -> None:
@@ -217,10 +218,13 @@ class EpoClient:
             EpoRateLimitedError: When the EPO traffic light is not green.
         """
         if self._is_service_throttled("retrieval"):
-            raise EpoRateLimitedError(
-                self._throttle_cache.get("retrieval", self._throttle_cache.get("_overall", "red")),
-                service="retrieval",
-            )
+            cached = self._throttle_cache
+            color = cached.get("retrieval", cached.get("_overall", "red"))
+            if color == "black":
+                raise RuntimeError(
+                    "EPO daily quota exhausted. Please try again tomorrow."
+                )
+            raise EpoRateLimitedError(color, service="retrieval")
         inp = self._to_docdb_input(doc)
         async with self._lock:
             response = await asyncio.to_thread(
@@ -245,10 +249,13 @@ class EpoClient:
             EpoRateLimitedError: When the EPO traffic light is not green.
         """
         if self._is_service_throttled("retrieval"):
-            raise EpoRateLimitedError(
-                self._throttle_cache.get("retrieval", self._throttle_cache.get("_overall", "red")),
-                service="retrieval",
-            )
+            cached = self._throttle_cache
+            color = cached.get("retrieval", cached.get("_overall", "red"))
+            if color == "black":
+                raise RuntimeError(
+                    "EPO daily quota exhausted. Please try again tomorrow."
+                )
+            raise EpoRateLimitedError(color, service="retrieval")
         inp = self._to_docdb_input(doc)
         async with self._lock:
             response = await asyncio.to_thread(
@@ -273,10 +280,13 @@ class EpoClient:
             EpoRateLimitedError: When the EPO traffic light is not green.
         """
         if self._is_service_throttled("retrieval"):
-            raise EpoRateLimitedError(
-                self._throttle_cache.get("retrieval", self._throttle_cache.get("_overall", "red")),
-                service="retrieval",
-            )
+            cached = self._throttle_cache
+            color = cached.get("retrieval", cached.get("_overall", "red"))
+            if color == "black":
+                raise RuntimeError(
+                    "EPO daily quota exhausted. Please try again tomorrow."
+                )
+            raise EpoRateLimitedError(color, service="retrieval")
         inp = self._to_docdb_input(doc)
         async with self._lock:
             response = await asyncio.to_thread(
@@ -301,10 +311,13 @@ class EpoClient:
             EpoRateLimitedError: When the EPO traffic light is not green.
         """
         if self._is_service_throttled("inpadoc"):
-            raise EpoRateLimitedError(
-                self._throttle_cache.get("inpadoc", self._throttle_cache.get("_overall", "red")),
-                service="inpadoc",
-            )
+            cached = self._throttle_cache
+            color = cached.get("inpadoc", cached.get("_overall", "red"))
+            if color == "black":
+                raise RuntimeError(
+                    "EPO daily quota exhausted. Please try again tomorrow."
+                )
+            raise EpoRateLimitedError(color, service="inpadoc")
         inp = self._to_docdb_input(doc)
         async with self._lock:
             response = await asyncio.to_thread(
@@ -328,10 +341,13 @@ class EpoClient:
             EpoRateLimitedError: When the EPO traffic light is not green.
         """
         if self._is_service_throttled("inpadoc"):
-            raise EpoRateLimitedError(
-                self._throttle_cache.get("inpadoc", self._throttle_cache.get("_overall", "red")),
-                service="inpadoc",
-            )
+            cached = self._throttle_cache
+            color = cached.get("inpadoc", cached.get("_overall", "red"))
+            if color == "black":
+                raise RuntimeError(
+                    "EPO daily quota exhausted. Please try again tomorrow."
+                )
+            raise EpoRateLimitedError(color, service="inpadoc")
         inp = self._to_docdb_input(doc)
         async with self._lock:
             response = await asyncio.to_thread(
@@ -356,10 +372,13 @@ class EpoClient:
             EpoRateLimitedError: When the EPO traffic light is not green.
         """
         if self._is_service_throttled("retrieval"):
-            raise EpoRateLimitedError(
-                self._throttle_cache.get("retrieval", self._throttle_cache.get("_overall", "red")),
-                service="retrieval",
-            )
+            cached = self._throttle_cache
+            color = cached.get("retrieval", cached.get("_overall", "red"))
+            if color == "black":
+                raise RuntimeError(
+                    "EPO daily quota exhausted. Please try again tomorrow."
+                )
+            raise EpoRateLimitedError(color, service="retrieval")
         inp = self._to_docdb_input(doc)
         async with self._lock:
             response = await asyncio.to_thread(

--- a/src/scholar_mcp/_epo_client.py
+++ b/src/scholar_mcp/_epo_client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 from typing import TYPE_CHECKING, Any
 
 import epo_ops
@@ -25,6 +26,28 @@ if TYPE_CHECKING:
     from scholar_mcp._patent_numbers import DocdbNumber
 
 logger = logging.getLogger(__name__)
+
+
+def _parse_throttle_header(header: str) -> dict[str, str]:
+    """Parse X-Throttling-Control into {service: color, '_overall': color}.
+
+    Args:
+        header: The X-Throttling-Control header value, e.g.
+            ``"busy (images=green:100, search=yellow:2, retrieval=green:50)"``.
+            Pass an empty string to get the green default.
+
+    Returns:
+        Dict with ``"_overall"`` key holding the first token, plus one entry
+        per ``name=color:count`` pair found in the parenthesised section.
+        Colors are lowercased. Missing header defaults to
+        ``{"_overall": "green"}``.
+    """
+    parts = header.strip().split(None, 1)
+    result: dict[str, str] = {"_overall": parts[0].lower() if parts else "green"}
+    if len(parts) > 1:
+        for match in re.finditer(r"(\w+)=(\w+):\d+", parts[1]):
+            result[match.group(1).lower()] = match.group(2).lower()
+    return result
 
 
 class EpoRateLimitedError(RateLimitedError):

--- a/src/scholar_mcp/_epo_client.py
+++ b/src/scholar_mcp/_epo_client.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 import epo_ops
 import epo_ops.models
+from requests.exceptions import HTTPError
 
 from scholar_mcp._epo_xml import (
     parse_biblio_xml,
@@ -108,7 +109,8 @@ class EpoClient:
         color = parts[0].lower() if parts else "green"
         if color == "black":
             raise RuntimeError("EPO daily quota exhausted. Please try again tomorrow.")
-        if color != "green":
+        # "idle" and "green" are both non-throttled states; only warn on yellow/red.
+        if color not in ("green", "idle"):
             logger.warning("epo_throttle color=%s", color)
             raise EpoRateLimitedError(color)
 
@@ -136,13 +138,20 @@ class EpoClient:
         Raises:
             EpoRateLimitedError: When the EPO traffic light is not green.
         """
-        async with self._lock:
-            response = await asyncio.to_thread(
-                self._client.published_data_search,
-                cql_query,
-                range_begin=range_begin,
-                range_end=range_end,
-            )
+        try:
+            async with self._lock:
+                response = await asyncio.to_thread(
+                    self._client.published_data_search,
+                    cql_query,
+                    range_begin=range_begin,
+                    range_end=range_end,
+                )
+        except HTTPError as exc:
+            if exc.response is not None and exc.response.status_code == 404:
+                # EPO returns 404 with SERVER.EntityNotFound when no results match.
+                logger.debug("epo_search_no_results cql=%s", cql_query)
+                return {"total_count": 0, "references": []}
+            raise
         self._check_throttle(response)
         return parse_search_xml(response.content)
 

--- a/src/scholar_mcp/_tools_patent.py
+++ b/src/scholar_mcp/_tools_patent.py
@@ -75,7 +75,7 @@ def _build_cql(
         ValueError: When no search criteria are provided at all.
     """
     parts: list[str] = []
-    if query:
+    if query is not None:
         parts.append(f'ta="{_cql_escape(query)}"')
 
     if cpc_classification is not None:

--- a/src/scholar_mcp/_tools_patent.py
+++ b/src/scholar_mcp/_tools_patent.py
@@ -172,6 +172,12 @@ def register_patent_tools(mcp: FastMCP) -> None:
         Returns:
             JSON string with ``total_count`` and ``references`` list, or an
             error dict if the EPO client is not configured or the API fails.
+            If the EPO service is busy, the request is automatically retried
+            once and ``{"queued": true, "task_id": "..."}`` is returned. Use
+            ``get_task_result`` to retrieve the result. If the retry also
+            fails, ``get_task_result`` returns ``status: failed`` — call this
+            tool again after about 60 seconds. Do not attempt to manage or
+            reason about EPO throttle states directly.
         """
         if bundle.epo is None:
             return json.dumps(
@@ -271,6 +277,12 @@ def register_patent_tools(mcp: FastMCP) -> None:
         Returns:
             JSON string with ``patent_number`` (normalised DOCDB format) and
             the requested section data, or an error dict on failure.
+            If the EPO service is busy, the request is automatically retried
+            once and ``{"queued": true, "task_id": "..."}`` is returned. Use
+            ``get_task_result`` to retrieve the result. If the retry also
+            fails, ``get_task_result`` returns ``status: failed`` — call this
+            tool again after about 60 seconds. Do not attempt to manage or
+            reason about EPO throttle states directly.
         """
         if bundle.epo is None:
             return json.dumps(
@@ -348,6 +360,12 @@ def register_patent_tools(mcp: FastMCP) -> None:
             JSON string with ``paper_id``, ``patents`` list (each with
             biblio data and ``match_source``), ``total_count``, and a
             ``note`` about coverage limitations.
+            If the EPO service is busy, the request is automatically retried
+            once and ``{"queued": true, "task_id": "..."}`` is returned. Use
+            ``get_task_result`` to retrieve the result. If the retry also
+            fails, ``get_task_result`` returns ``status: failed`` — call this
+            tool again after about 60 seconds. Do not attempt to manage or
+            reason about EPO throttle states directly.
         """
         if bundle.epo is None:
             return json.dumps(

--- a/src/scholar_mcp/_tools_patent.py
+++ b/src/scholar_mcp/_tools_patent.py
@@ -36,7 +36,7 @@ def _cql_escape(s: str) -> str:
 
 
 def _build_cql(
-    query: str,
+    query: str | None = None,
     *,
     cpc_classification: str | None = None,
     applicant: str | None = None,
@@ -49,11 +49,13 @@ def _build_cql(
     """Build an EPO CQL query string from individual filter parameters.
 
     Translates tool parameters into Contextual Query Language (CQL) clauses
-    joined with ``AND``.  The *query* text is always mapped to a title+abstract
-    search (``ta=`` field).
+    joined with ``AND``.  When *query* is provided it is mapped to a
+    title+abstract search (``ta=`` field); omitting it allows searching purely
+    by structured filters (inventor, applicant, CPC, date, jurisdiction).
 
     Args:
-        query: Free-text search string — mapped to ``ta="query"``.
+        query: Free-text search string — mapped to ``ta="query"``.  Optional;
+            when omitted the search relies entirely on the filter parameters.
         cpc_classification: CPC classification code, e.g. ``"H01M10/00"``.
         applicant: Applicant name, mapped to ``pa=``.
         inventor: Inventor name, mapped to ``in=``.
@@ -68,8 +70,13 @@ def _build_cql(
 
     Returns:
         A CQL expression string ready for the EPO OPS search endpoint.
+
+    Raises:
+        ValueError: When no search criteria are provided at all.
     """
-    parts: list[str] = [f'ta="{_cql_escape(query)}"']
+    parts: list[str] = []
+    if query:
+        parts.append(f'ta="{_cql_escape(query)}"')
 
     if cpc_classification is not None:
         parts.append(f'cpc="{_cql_escape(cpc_classification)}"')
@@ -90,7 +97,7 @@ def _build_cql(
         if d_to and not d_to.isdigit():
             raise ValueError(f"Invalid date_to: {date_to!r}")
         if d_from is not None and d_to is not None:
-            parts.append(f"{field} within {d_from},{d_to}")
+            parts.append(f'{field} within "{d_from},{d_to}"')
         elif d_from is not None:
             parts.append(f"{field} >= {d_from}")
         else:
@@ -98,6 +105,12 @@ def _build_cql(
 
     if jurisdiction is not None:
         parts.append(f'pn="{_cql_escape(jurisdiction)}"')
+
+    if not parts:
+        raise ValueError(
+            "At least one search criterion is required: query, inventor, applicant, "
+            "cpc_classification, jurisdiction, or a date range."
+        )
 
     return " AND ".join(parts)
 
@@ -118,7 +131,7 @@ def register_patent_tools(mcp: FastMCP) -> None:
         },
     )
     async def search_patents(
-        query: str,
+        query: str | None = None,
         cpc_classification: str | None = None,
         applicant: str | None = None,
         inventor: str | None = None,
@@ -133,12 +146,15 @@ def register_patent_tools(mcp: FastMCP) -> None:
         """Search for patents in the European Patent Office database.
 
         Covers European patents and global patents via INPADOC (100+ patent
-        offices). Accepts natural language queries. Use CPC classification
-        codes, applicant names, or date ranges to narrow results. For
-        academic paper search, use search_papers instead.
+        offices). At least one parameter must be provided. For keyword search,
+        ``query`` searches titles and abstracts. To find all patents by an
+        inventor or applicant, omit ``query`` and use only the structured
+        filters. For academic paper search, use search_papers instead.
 
         Args:
-            query: Natural language or keyword search query.
+            query: Keyword search — searches patent titles and abstracts.
+                Optional; omit when searching purely by inventor, applicant,
+                CPC code, or date.
             cpc_classification: CPC classification code to filter by,
                 e.g. ``"H01M10/00"`` for lithium-ion batteries.
             applicant: Applicant (assignee) name to filter by.
@@ -169,16 +185,19 @@ def register_patent_tools(mcp: FastMCP) -> None:
                 }
             )
 
-        cql = _build_cql(
-            query,
-            cpc_classification=cpc_classification,
-            applicant=applicant,
-            inventor=inventor,
-            date_from=date_from,
-            date_to=date_to,
-            date_type=date_type,
-            jurisdiction=jurisdiction,
-        )
+        try:
+            cql = _build_cql(
+                query,
+                cpc_classification=cpc_classification,
+                applicant=applicant,
+                inventor=inventor,
+                date_from=date_from,
+                date_to=date_to,
+                date_type=date_type,
+                jurisdiction=jurisdiction,
+            )
+        except ValueError as exc:
+            return json.dumps({"error": "invalid_query", "detail": str(exc)})
         range_begin = offset + 1  # EPO OPS uses 1-based ranges
         range_end = offset + limit
         cache_key = f"{cql}|{range_begin}-{range_end}"

--- a/src/scholar_mcp/_tools_tasks.py
+++ b/src/scholar_mcp/_tools_tasks.py
@@ -21,6 +21,9 @@ _DURATION_HINTS: dict[str, str] = {
     "fetch_and_convert": (
         "Full pipeline (download + conversion) typically takes 1-5 minutes."
     ),
+    "search_patents": "Patent searches usually complete in 5-15 seconds.",
+    "get_patent": "Patent data retrieval usually completes in 5-20 seconds.",
+    "get_citing_patents": "Citing patent lookup usually completes in 10-30 seconds.",
 }
 
 
@@ -72,7 +75,20 @@ def register_task_tools(mcp: FastMCP) -> None:
         if task.status == "completed":
             response["result"] = task.result
         elif task.status == "failed":
-            response["error"] = task.error
+            error = task.error or ""
+            if "daily quota" in error:
+                response["error"] = (
+                    "The service has reached its daily quota. Try again tomorrow."
+                )
+                response["retryable"] = False
+            elif "RateLimitedError" in error:
+                response["error"] = (
+                    "The service was busy and could not complete the request. "
+                    "Try calling the tool again in about 60 seconds."
+                )
+                response["retryable"] = True
+            else:
+                response["error"] = error
         else:
             # Task still in progress — give the client context
             response["elapsed_seconds"] = task.elapsed_seconds

--- a/src/scholar_mcp/_tools_tasks.py
+++ b/src/scholar_mcp/_tools_tasks.py
@@ -81,7 +81,7 @@ def register_task_tools(mcp: FastMCP) -> None:
                     "The service has reached its daily quota. Try again tomorrow."
                 )
                 response["retryable"] = False
-            elif "RateLimitedError" in error:
+            elif "EPO rate limited" in error:
                 response["error"] = (
                     "The service was busy and could not complete the request. "
                     "Try calling the tool again in about 60 seconds."

--- a/tests/test_epo_client.py
+++ b/tests/test_epo_client.py
@@ -9,7 +9,11 @@ import pytest
 import requests
 from requests.exceptions import HTTPError
 
-from scholar_mcp._epo_client import EpoClient, EpoRateLimitedError, _parse_throttle_header
+from scholar_mcp._epo_client import (
+    EpoClient,
+    EpoRateLimitedError,
+    _parse_throttle_header,
+)
 from scholar_mcp._patent_numbers import DocdbNumber
 from scholar_mcp._rate_limiter import RateLimitedError
 
@@ -247,7 +251,7 @@ async def test_search_returns_empty_on_404(
         response=fake_response
     )
 
-    result = await epo_client.search("ct=\"doi:nonexistent\"")
+    result = await epo_client.search('ct="doi:nonexistent"')
 
     assert result == {"total_count": 0, "references": []}
 

--- a/tests/test_epo_client.py
+++ b/tests/test_epo_client.py
@@ -136,6 +136,30 @@ def _mock_response(
     return resp
 
 
+def _mock_throttle_response(
+    color: str, *, service_colors: dict[str, str] | None = None
+) -> MagicMock:
+    """Create a fake response with a configurable X-Throttling-Control header.
+
+    Args:
+        color: The overall traffic-light colour (e.g. ``"green"``, ``"busy"``).
+        service_colors: Optional mapping of service name to colour, used to
+            build the per-service section of the header (e.g.
+            ``{"search": "green", "retrieval": "green"}``).
+
+    Returns:
+        MagicMock with ``headers`` dict containing the constructed header.
+    """
+    response = MagicMock()
+    if service_colors:
+        parts = ", ".join(f"{svc}={c}:100" for svc, c in service_colors.items())
+        header_value = f"{color} ({parts})"
+    else:
+        header_value = color
+    response.headers = {"X-Throttling-Control": header_value}
+    return response
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -392,6 +416,23 @@ async def test_throttle_on_get_biblio(
     doc = DocdbNumber(country="EP", number="1234567", kind="A1")
     with pytest.raises(EpoRateLimitedError):
         await epo_client.get_biblio(doc)
+
+
+def test_check_throttle_overall_busy_search_green_does_not_raise() -> None:
+    """overall=busy but search=green: search calls should NOT raise."""
+    response = _mock_throttle_response(
+        "busy", service_colors={"search": "green", "retrieval": "green"}
+    )
+    epo = EpoClient(consumer_key="key", consumer_secret="secret", _client=MagicMock())
+    epo._check_throttle(response, service="search")  # must not raise
+
+
+def test_check_throttle_overall_green_search_yellow_raises() -> None:
+    """overall=green but search=yellow: search calls SHOULD raise."""
+    response = _mock_throttle_response("green", service_colors={"search": "yellow"})
+    epo = EpoClient(consumer_key="key", consumer_secret="secret", _client=MagicMock())
+    with pytest.raises(EpoRateLimitedError):
+        epo._check_throttle(response, service="search")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_epo_client.py
+++ b/tests/test_epo_client.py
@@ -702,6 +702,55 @@ async def test_preflight_inpadoc_blocks_get_family(
     mock_epo_client._client.family.assert_not_called()
 
 
+async def test_preflight_retrieval_black_raises_runtime_error(
+    mock_epo_client: EpoClient,
+) -> None:
+    """Pre-flight raises RuntimeError (not EpoRateLimitedError) for retrieval=black."""
+    mock_epo_client._throttle_cache = {"_overall": "green", "retrieval": "black"}
+    mock_epo_client._throttle_cache_ts = time.monotonic()
+
+    doc = DocdbNumber(country="EP", number="1000000", kind="A1")
+    with pytest.raises(RuntimeError, match="daily quota"):
+        await mock_epo_client.get_biblio(doc)
+
+    mock_epo_client._client.published_data.assert_not_called()
+
+
+async def test_preflight_inpadoc_black_raises_runtime_error(
+    mock_epo_client: EpoClient,
+) -> None:
+    """Pre-flight raises RuntimeError (not EpoRateLimitedError) for inpadoc=black."""
+    mock_epo_client._throttle_cache = {"_overall": "green", "inpadoc": "black"}
+    mock_epo_client._throttle_cache_ts = time.monotonic()
+
+    doc = DocdbNumber(country="EP", number="1000000", kind="A1")
+    with pytest.raises(RuntimeError, match="daily quota"):
+        await mock_epo_client.get_family(doc)
+
+    mock_epo_client._client.family.assert_not_called()
+
+
+def test_is_service_throttled_falls_back_to_overall(
+    mock_epo_client: EpoClient,
+) -> None:
+    """_is_service_throttled returns True when service absent but _overall is throttled."""
+    # Cache has only _overall=red, no service-specific key
+    mock_epo_client._throttle_cache = {"_overall": "red"}
+    mock_epo_client._throttle_cache_ts = time.monotonic()
+
+    assert mock_epo_client._is_service_throttled("search") is True
+
+
+def test_is_service_throttled_overall_green_no_service_key(
+    mock_epo_client: EpoClient,
+) -> None:
+    """_is_service_throttled returns False when _overall=green and service key absent."""
+    mock_epo_client._throttle_cache = {"_overall": "green"}
+    mock_epo_client._throttle_cache_ts = time.monotonic()
+
+    assert mock_epo_client._is_service_throttled("search") is False
+
+
 async def test_preflight_cache_expires_after_60s(
     mock_epo_client: EpoClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_epo_client.py
+++ b/tests/test_epo_client.py
@@ -688,6 +688,62 @@ async def test_preflight_retrieval_blocks_get_biblio(
     mock_epo_client._client.published_data.assert_not_called()
 
 
+async def test_preflight_retrieval_blocks_get_claims(
+    mock_epo_client: EpoClient,
+) -> None:
+    """Pre-flight blocks get_claims when retrieval service is throttled."""
+    mock_epo_client._throttle_cache = {"_overall": "green", "retrieval": "yellow"}
+    mock_epo_client._throttle_cache_ts = time.monotonic()
+
+    doc = DocdbNumber(country="EP", number="1000000", kind="A1")
+    with pytest.raises(EpoRateLimitedError) as exc_info:
+        await mock_epo_client.get_claims(doc)
+    assert exc_info.value.service == "retrieval"
+    mock_epo_client._client.published_data.assert_not_called()
+
+
+async def test_preflight_retrieval_blocks_get_description(
+    mock_epo_client: EpoClient,
+) -> None:
+    """Pre-flight blocks get_description when retrieval service is throttled."""
+    mock_epo_client._throttle_cache = {"_overall": "green", "retrieval": "yellow"}
+    mock_epo_client._throttle_cache_ts = time.monotonic()
+
+    doc = DocdbNumber(country="EP", number="1000000", kind="A1")
+    with pytest.raises(EpoRateLimitedError) as exc_info:
+        await mock_epo_client.get_description(doc)
+    assert exc_info.value.service == "retrieval"
+    mock_epo_client._client.published_data.assert_not_called()
+
+
+async def test_preflight_retrieval_blocks_get_citations(
+    mock_epo_client: EpoClient,
+) -> None:
+    """Pre-flight blocks get_citations when retrieval service is throttled."""
+    mock_epo_client._throttle_cache = {"_overall": "green", "retrieval": "yellow"}
+    mock_epo_client._throttle_cache_ts = time.monotonic()
+
+    doc = DocdbNumber(country="EP", number="1000000", kind="A1")
+    with pytest.raises(EpoRateLimitedError) as exc_info:
+        await mock_epo_client.get_citations(doc)
+    assert exc_info.value.service == "retrieval"
+    mock_epo_client._client.published_data.assert_not_called()
+
+
+async def test_preflight_inpadoc_blocks_get_legal(
+    mock_epo_client: EpoClient,
+) -> None:
+    """Pre-flight blocks get_legal when inpadoc service is throttled."""
+    mock_epo_client._throttle_cache = {"_overall": "green", "inpadoc": "yellow"}
+    mock_epo_client._throttle_cache_ts = time.monotonic()
+
+    doc = DocdbNumber(country="EP", number="1000000", kind="A1")
+    with pytest.raises(EpoRateLimitedError) as exc_info:
+        await mock_epo_client.get_legal(doc)
+    assert exc_info.value.service == "inpadoc"
+    mock_epo_client._client.legal.assert_not_called()
+
+
 async def test_preflight_inpadoc_blocks_get_family(
     mock_epo_client: EpoClient,
 ) -> None:
@@ -716,6 +772,48 @@ async def test_preflight_retrieval_black_raises_runtime_error(
     mock_epo_client._client.published_data.assert_not_called()
 
 
+async def test_preflight_retrieval_black_raises_runtime_error_claims(
+    mock_epo_client: EpoClient,
+) -> None:
+    """Pre-flight raises RuntimeError for retrieval=black on get_claims."""
+    mock_epo_client._throttle_cache = {"_overall": "green", "retrieval": "black"}
+    mock_epo_client._throttle_cache_ts = time.monotonic()
+
+    doc = DocdbNumber(country="EP", number="1000000", kind="A1")
+    with pytest.raises(RuntimeError, match="daily quota"):
+        await mock_epo_client.get_claims(doc)
+
+    mock_epo_client._client.published_data.assert_not_called()
+
+
+async def test_preflight_retrieval_black_raises_runtime_error_description(
+    mock_epo_client: EpoClient,
+) -> None:
+    """Pre-flight raises RuntimeError for retrieval=black on get_description."""
+    mock_epo_client._throttle_cache = {"_overall": "green", "retrieval": "black"}
+    mock_epo_client._throttle_cache_ts = time.monotonic()
+
+    doc = DocdbNumber(country="EP", number="1000000", kind="A1")
+    with pytest.raises(RuntimeError, match="daily quota"):
+        await mock_epo_client.get_description(doc)
+
+    mock_epo_client._client.published_data.assert_not_called()
+
+
+async def test_preflight_retrieval_black_raises_runtime_error_citations(
+    mock_epo_client: EpoClient,
+) -> None:
+    """Pre-flight raises RuntimeError for retrieval=black on get_citations."""
+    mock_epo_client._throttle_cache = {"_overall": "green", "retrieval": "black"}
+    mock_epo_client._throttle_cache_ts = time.monotonic()
+
+    doc = DocdbNumber(country="EP", number="1000000", kind="A1")
+    with pytest.raises(RuntimeError, match="daily quota"):
+        await mock_epo_client.get_citations(doc)
+
+    mock_epo_client._client.published_data.assert_not_called()
+
+
 async def test_preflight_inpadoc_black_raises_runtime_error(
     mock_epo_client: EpoClient,
 ) -> None:
@@ -728,6 +826,20 @@ async def test_preflight_inpadoc_black_raises_runtime_error(
         await mock_epo_client.get_family(doc)
 
     mock_epo_client._client.family.assert_not_called()
+
+
+async def test_preflight_inpadoc_black_raises_runtime_error_legal(
+    mock_epo_client: EpoClient,
+) -> None:
+    """Pre-flight raises RuntimeError for inpadoc=black on get_legal."""
+    mock_epo_client._throttle_cache = {"_overall": "green", "inpadoc": "black"}
+    mock_epo_client._throttle_cache_ts = time.monotonic()
+
+    doc = DocdbNumber(country="EP", number="1000000", kind="A1")
+    with pytest.raises(RuntimeError, match="daily quota"):
+        await mock_epo_client.get_legal(doc)
+
+    mock_epo_client._client.legal.assert_not_called()
 
 
 def test_is_service_throttled_falls_back_to_overall(

--- a/tests/test_epo_client.py
+++ b/tests/test_epo_client.py
@@ -8,7 +8,7 @@ import pytest
 import requests
 from requests.exceptions import HTTPError
 
-from scholar_mcp._epo_client import EpoClient, EpoRateLimitedError
+from scholar_mcp._epo_client import EpoClient, EpoRateLimitedError, _parse_throttle_header
 from scholar_mcp._patent_numbers import DocdbNumber
 from scholar_mcp._rate_limiter import RateLimitedError
 
@@ -539,3 +539,37 @@ async def test_get_legal_calls_legal_method(
 async def test_aclose_is_noop(epo_client: EpoClient) -> None:
     """aclose() completes without error (no-op cleanup)."""
     await epo_client.aclose()  # Must not raise
+
+
+# ---------------------------------------------------------------------------
+# _parse_throttle_header tests
+# ---------------------------------------------------------------------------
+
+
+def test_parse_throttle_header_full() -> None:
+    """Full header with overall and per-service breakdown is parsed correctly."""
+    header = "busy (images=green:100, search=yellow:2, retrieval=green:50)"
+    result = _parse_throttle_header(header)
+    assert result["_overall"] == "busy"
+    assert result["search"] == "yellow"
+    assert result["retrieval"] == "green"
+    assert result["images"] == "green"
+
+
+def test_parse_throttle_header_no_subservices() -> None:
+    """Header with only an overall color (no parenthesised section) is handled."""
+    result = _parse_throttle_header("green")
+    assert result == {"_overall": "green"}
+
+
+def test_parse_throttle_header_missing_header() -> None:
+    """Empty string defaults to _overall=green."""
+    result = _parse_throttle_header("")
+    assert result == {"_overall": "green"}
+
+
+def test_parse_throttle_header_all_colors() -> None:
+    """All known EPO throttle colors are preserved verbatim."""
+    for color in ("green", "yellow", "red", "black", "idle"):
+        result = _parse_throttle_header(color)
+        assert result["_overall"] == color

--- a/tests/test_epo_client.py
+++ b/tests/test_epo_client.py
@@ -669,6 +669,35 @@ async def test_preflight_cache_prevents_second_search_call(
     mock_epo_client._client.published_data_search.assert_not_called()
 
 
+async def test_preflight_retrieval_blocks_get_biblio(
+    mock_epo_client: EpoClient,
+) -> None:
+    """Pre-flight blocks get_biblio when retrieval service is throttled."""
+    # Seed the cache with a throttled retrieval color
+    mock_epo_client._throttle_cache = {"_overall": "green", "retrieval": "yellow"}
+    mock_epo_client._throttle_cache_ts = time.monotonic()
+
+    doc = DocdbNumber(country="EP", number="1000000", kind="A1")
+    with pytest.raises(EpoRateLimitedError) as exc_info:
+        await mock_epo_client.get_biblio(doc)
+    assert exc_info.value.service == "retrieval"
+    mock_epo_client._client.published_data.assert_not_called()
+
+
+async def test_preflight_inpadoc_blocks_get_family(
+    mock_epo_client: EpoClient,
+) -> None:
+    """Pre-flight blocks get_family when inpadoc service is throttled."""
+    mock_epo_client._throttle_cache = {"_overall": "green", "inpadoc": "yellow"}
+    mock_epo_client._throttle_cache_ts = time.monotonic()
+
+    doc = DocdbNumber(country="EP", number="1000000", kind="A1")
+    with pytest.raises(EpoRateLimitedError) as exc_info:
+        await mock_epo_client.get_family(doc)
+    assert exc_info.value.service == "inpadoc"
+    mock_epo_client._client.family.assert_not_called()
+
+
 async def test_preflight_cache_expires_after_60s(
     mock_epo_client: EpoClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_epo_client.py
+++ b/tests/test_epo_client.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 import requests
+from requests.exceptions import HTTPError
 
 from scholar_mcp._epo_client import EpoClient, EpoRateLimitedError
 from scholar_mcp._patent_numbers import DocdbNumber
@@ -203,6 +204,37 @@ async def test_search_default_range(
     )
 
 
+async def test_search_returns_empty_on_404(
+    epo_client: EpoClient,
+    mock_ops_client: MagicMock,
+) -> None:
+    """search() returns empty results when EPO returns 404 (no results found)."""
+    fake_response = MagicMock(spec=requests.Response)
+    fake_response.status_code = 404
+    mock_ops_client.published_data_search.side_effect = HTTPError(
+        response=fake_response
+    )
+
+    result = await epo_client.search("ct=\"doi:nonexistent\"")
+
+    assert result == {"total_count": 0, "references": []}
+
+
+async def test_search_re_raises_non_404_http_errors(
+    epo_client: EpoClient,
+    mock_ops_client: MagicMock,
+) -> None:
+    """search() re-raises HTTPError for non-404 status codes."""
+    fake_response = MagicMock(spec=requests.Response)
+    fake_response.status_code = 500
+    mock_ops_client.published_data_search.side_effect = HTTPError(
+        response=fake_response
+    )
+
+    with pytest.raises(HTTPError):
+        await epo_client.search("ti=Test")
+
+
 # ---------------------------------------------------------------------------
 # get_biblio() tests
 # ---------------------------------------------------------------------------
@@ -275,6 +307,18 @@ async def test_green_throttle_does_not_raise(
     """Green traffic light does not raise any error."""
     mock_ops_client.published_data_search.return_value = _mock_response(
         _SEARCH_XML, throttle="green"
+    )
+    # Should not raise
+    await epo_client.search("ti=Test")
+
+
+async def test_idle_throttle_does_not_raise(
+    epo_client: EpoClient,
+    mock_ops_client: MagicMock,
+) -> None:
+    """Idle traffic light (API at rest) does not raise any error."""
+    mock_ops_client.published_data_search.return_value = _mock_response(
+        _SEARCH_XML, throttle="idle"
     )
     # Should not raise
     await epo_client.search("ti=Test")

--- a/tests/test_epo_client.py
+++ b/tests/test_epo_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from unittest.mock import MagicMock
 
 import pytest
@@ -179,6 +180,13 @@ def epo_client(mock_ops_client: MagicMock) -> EpoClient:
         consumer_secret="secret",
         _client=mock_ops_client,
     )
+
+
+@pytest.fixture
+def mock_epo_client() -> EpoClient:
+    """EpoClient with a mocked underlying ops client."""
+    epo = EpoClient(consumer_key="key", consumer_secret="secret", _client=MagicMock())
+    return epo
 
 
 # ---------------------------------------------------------------------------
@@ -614,3 +622,72 @@ def test_parse_throttle_header_all_colors() -> None:
     for color in ("green", "yellow", "red", "black", "idle"):
         result = _parse_throttle_header(color)
         assert result["_overall"] == color
+
+
+# ---------------------------------------------------------------------------
+# EpoRateLimitedError.service tests
+# ---------------------------------------------------------------------------
+
+
+def test_rate_limited_error_has_service_attribute() -> None:
+    """EpoRateLimitedError stores service as a keyword-only attribute."""
+    err = EpoRateLimitedError("yellow", service="search")
+    assert err.service == "search"
+    assert err.color == "yellow"
+    assert "search=yellow" in str(err)
+
+
+def test_rate_limited_error_default_service() -> None:
+    """EpoRateLimitedError defaults to _overall when service not specified."""
+    err = EpoRateLimitedError("red")
+    assert err.service == "_overall"
+
+
+# ---------------------------------------------------------------------------
+# Pre-flight throttle cache tests
+# ---------------------------------------------------------------------------
+
+
+async def test_preflight_cache_prevents_second_search_call(
+    mock_epo_client: EpoClient,
+) -> None:
+    """After a throttled search response, the next call raises from cache without network."""
+    # Simulate a throttled search response being returned by the EPO search endpoint
+    throttled_response = _mock_throttle_response(
+        "green", service_colors={"search": "yellow"}
+    )
+    mock_epo_client._client.published_data_search.return_value = throttled_response
+
+    with pytest.raises(EpoRateLimitedError):
+        await mock_epo_client.search("ti=test")
+
+    # Second call should raise from cache, not touch the network again
+    mock_epo_client._client.published_data_search.reset_mock()
+    with pytest.raises(EpoRateLimitedError):
+        await mock_epo_client.search("ti=test")
+
+    mock_epo_client._client.published_data_search.assert_not_called()
+
+
+async def test_preflight_cache_expires_after_60s(
+    mock_epo_client: EpoClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pre-flight cache expires after 60 seconds and lets the next call through."""
+    throttled_response = _mock_throttle_response(
+        "green", service_colors={"search": "yellow"}
+    )
+    mock_epo_client._client.published_data_search.return_value = throttled_response
+
+    with pytest.raises(EpoRateLimitedError):
+        await mock_epo_client.search("ti=test")
+
+    # Advance monotonic time by 61 seconds
+    original_monotonic = time.monotonic
+    monkeypatch.setattr(time, "monotonic", lambda: original_monotonic() + 61)
+
+    # The cache is now stale — call goes through (hits network again)
+    mock_epo_client._client.published_data_search.reset_mock()
+    with pytest.raises(EpoRateLimitedError):  # still fails but from network, not cache
+        await mock_epo_client.search("ti=test")
+
+    mock_epo_client._client.published_data_search.assert_called_once()

--- a/tests/test_tools_patent.py
+++ b/tests/test_tools_patent.py
@@ -266,6 +266,16 @@ async def test_search_patents_returns_results(
     assert data["references"][0]["country"] == "EP"
 
 
+async def test_search_patents_no_criteria_returns_error(
+    mcp_with_epo: FastMCP,
+) -> None:
+    """search_patents with no criteria returns an invalid_query error."""
+    async with Client(mcp_with_epo) as client:
+        result = await client.call_tool("search_patents", {})
+    data = json.loads(result.content[0].text)
+    assert data["error"] == "invalid_query"
+
+
 async def test_search_patents_uses_cache(
     bundle: ServiceBundle, epo_client: EpoClient
 ) -> None:

--- a/tests/test_tools_patent.py
+++ b/tests/test_tools_patent.py
@@ -85,7 +85,7 @@ def test_build_cql_with_jurisdiction() -> None:
 def test_build_cql_date_range_both() -> None:
     """Both date_from and date_to produce 'within' expression."""
     cql = _build_cql("solar panel", date_from="2020-01-01", date_to="2023-12-31")
-    assert "pd within 20200101,20231231" in cql
+    assert 'pd within "20200101,20231231"' in cql
 
 
 def test_build_cql_date_range_from_only() -> None:
@@ -164,6 +164,26 @@ def test_build_cql_date_to_rejects_non_numeric() -> None:
     """date_to with non-numeric content raises ValueError."""
     with pytest.raises(ValueError, match="Invalid date_to"):
         _build_cql("test", date_to="not-a-date")
+
+
+def test_build_cql_inventor_only_omits_ta() -> None:
+    """Inventor-only search produces just in= without a ta= clause."""
+    cql = _build_cql(inventor="Smith")
+    assert cql == 'in="Smith"'
+    assert "ta=" not in cql
+
+
+def test_build_cql_applicant_only_omits_ta() -> None:
+    """Applicant-only search produces just pa= without a ta= clause."""
+    cql = _build_cql(applicant="ACME Corp")
+    assert cql == 'pa="ACME Corp"'
+    assert "ta=" not in cql
+
+
+def test_build_cql_no_criteria_raises() -> None:
+    """Calling _build_cql with no criteria raises ValueError."""
+    with pytest.raises(ValueError, match="At least one search criterion"):
+        _build_cql()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tools_tasks.py
+++ b/tests/test_tools_tasks.py
@@ -116,3 +116,91 @@ async def test_list_tasks(mcp: FastMCP, bundle: ServiceBundle) -> None:
     task_entry = next(t for t in data if t["task_id"] == task_id)
     assert task_entry["tool"] == "fetch_paper_pdf"
     assert "elapsed_seconds" in task_entry
+
+
+async def _instant_fail(msg: str) -> str:
+    raise RuntimeError(msg)
+
+
+async def test_get_task_result_daily_quota_error_is_sanitised(
+    mcp: FastMCP, bundle: ServiceBundle
+) -> None:
+    """daily quota error string is replaced with a user-friendly message."""
+    task_id = bundle.tasks.submit(_instant_fail("EPO daily quota exhausted."), tool="search_patents")
+
+    async with Client(mcp) as client:
+        result = await client.call_tool("get_task_result", {"task_id": task_id})
+    data = json.loads(result.content[0].text)
+    assert data["status"] == "failed"
+    assert "daily quota" in data["error"].lower()
+    assert data["retryable"] is False
+    assert "EpoRateLimitedError" not in data["error"]
+
+
+async def test_get_task_result_rate_limit_error_is_sanitised(
+    mcp: FastMCP, bundle: ServiceBundle
+) -> None:
+    """RateLimitedError string is replaced with a generic retry message."""
+    task_id = bundle.tasks.submit(
+        _instant_fail("EpoRateLimitedError: EPO rate limited: search=yellow"),
+        tool="search_patents",
+    )
+
+    async with Client(mcp) as client:
+        result = await client.call_tool("get_task_result", {"task_id": task_id})
+    data = json.loads(result.content[0].text)
+    assert data["status"] == "failed"
+    assert "60 seconds" in data["error"]
+    assert data["retryable"] is True
+    assert "EpoRateLimitedError" not in data["error"]
+
+
+async def test_get_task_result_other_error_unchanged(
+    mcp: FastMCP, bundle: ServiceBundle
+) -> None:
+    """Non-rate-limit errors are returned verbatim."""
+    task_id = bundle.tasks.submit(_instant_fail("Some other error"), tool="search_patents")
+
+    async with Client(mcp) as client:
+        result = await client.call_tool("get_task_result", {"task_id": task_id})
+    data = json.loads(result.content[0].text)
+    assert data["status"] == "failed"
+    assert "Some other error" in data["error"]
+    assert "retryable" not in data
+
+
+async def test_get_task_result_search_patents_hint(
+    mcp: FastMCP, bundle: ServiceBundle
+) -> None:
+    """get_task_result includes a hint for queued search_patents tasks."""
+
+    async def _slow_coro() -> str:
+        await asyncio.sleep(10)
+        return "{}"
+
+    task_id = bundle.tasks.submit(_slow_coro(), tool="search_patents")
+
+    async with Client(mcp) as client:
+        result = await client.call_tool("get_task_result", {"task_id": task_id})
+    data = json.loads(result.content[0].text)
+    assert data["status"] in ("pending", "running")
+    assert "hint" in data
+    assert "5-15 seconds" in data["hint"]
+
+
+async def test_get_task_result_get_patent_hint(
+    mcp: FastMCP, bundle: ServiceBundle
+) -> None:
+    """get_task_result includes a hint for queued get_patent tasks."""
+
+    async def _slow_coro() -> str:
+        await asyncio.sleep(10)
+        return "{}"
+
+    task_id = bundle.tasks.submit(_slow_coro(), tool="get_patent")
+
+    async with Client(mcp) as client:
+        result = await client.call_tool("get_task_result", {"task_id": task_id})
+    data = json.loads(result.content[0].text)
+    assert "hint" in data
+    assert "5-20 seconds" in data["hint"]

--- a/tests/test_tools_tasks.py
+++ b/tests/test_tools_tasks.py
@@ -126,7 +126,9 @@ async def test_get_task_result_daily_quota_error_is_sanitised(
     mcp: FastMCP, bundle: ServiceBundle
 ) -> None:
     """daily quota error string is replaced with a user-friendly message."""
-    task_id = bundle.tasks.submit(_instant_fail("EPO daily quota exhausted."), tool="search_patents")
+    task_id = bundle.tasks.submit(
+        _instant_fail("EPO daily quota exhausted."), tool="search_patents"
+    )
 
     async with Client(mcp) as client:
         result = await client.call_tool("get_task_result", {"task_id": task_id})
@@ -159,7 +161,9 @@ async def test_get_task_result_other_error_unchanged(
     mcp: FastMCP, bundle: ServiceBundle
 ) -> None:
     """Non-rate-limit errors are returned verbatim."""
-    task_id = bundle.tasks.submit(_instant_fail("Some other error"), tool="search_patents")
+    task_id = bundle.tasks.submit(
+        _instant_fail("Some other error"), tool="search_patents"
+    )
 
     async with Client(mcp) as client:
         result = await client.call_tool("get_task_result", {"task_id": task_id})


### PR DESCRIPTION
## Summary

- **Per-service throttle parsing**: New `_parse_throttle_header` function extracts per-service colors from `X-Throttling-Control` (e.g. `overall=busy` + `search=green` no longer blocks search calls)
- **Throttle cache + pre-flight checks**: 60-second cache prevents wasted EPO calls; all six `EpoClient` methods short-circuit without touching the API when their service is known throttled
- **LLM-safe error messages**: `get_task_result` sanitises `EpoRateLimitedError` strings into generic, actionable messages ("try again in 60 seconds") so LLMs don't reason about EPO traffic-light states
- **Patent duration hints**: `search_patents`, `get_patent`, `get_citing_patents` now appear in `get_task_result` pending responses with expected wait times
- **Tool description updates**: All three patent tools explain transparent queueing and instruct LLMs not to manage throttle states directly
- **EPO search bug fixes**: 404 → empty results, `idle` throttle treated as green, `within` date syntax quoted correctly, `query` parameter made optional (fixes inventor/applicant-only searches)

## Test plan

- [ ] `uv run pytest tests/test_epo_client.py -v` — header parsing, per-service throttle, cache pre-flight, TTL expiry
- [ ] `uv run pytest tests/test_tools_tasks.py -v` — error sanitisation, patent duration hints
- [ ] `uv run pytest tests/test_tools_patent.py -v` — CQL builder fixes (inventor-only, date range)
- [ ] `uv run pytest tests/ -q` — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)