### PR TITLE
feat: logging standard with FastMCP middleware

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ src/scholar_mcp/
 - `hatchling` build backend
 - Conventional commits: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`
 - Google-style docstrings on all public functions
-- `logging.getLogger(__name__)` throughout, no `print()`
+- `logging.getLogger(__name__)` throughout, no `print()` — see **Logging Standard** below
 - Type hints everywhere
 
 ## Documentation
@@ -60,3 +60,30 @@ Always fetch both before declaring a review round complete.
 - `_ENV_PREFIX` in `config.py` controls all env var names — change once, affects everything
 - **Async task queue**: S2 tools try once (`retry=False`); on 429 `RateLimitedError`, queue with retries for background execution. PDF tools always queue (unless cache hit). `TaskQueue` lives in `ServiceBundle.tasks`.
 - **Tool queueing pattern**: extract tool logic into `async def _execute(*, retry=True) -> str`, try with `retry=False`, catch `RateLimitedError` and `bundle.tasks.submit(_execute(retry=True))`
+
+## Logging Standard
+
+### Framework
+- Standard library `logging` throughout. Every module: `logger = logging.getLogger(__name__)`.
+- No `print()` for operational output. No third-party logging libraries.
+- FastMCP middleware handles tool invocation, timing, and error logging automatically.
+
+### Log Levels
+| Level | Use for |
+|-------|---------|
+| `DEBUG` | Detailed internals: cache hits, parameter values, enrichment attempts, rate-limit queueing |
+| `INFO` | Significant operations: service startup, configuration decisions (tool calls logged by middleware) |
+| `WARNING` | Degraded but continuing: API errors with fallback, missing optional config, unexpected data |
+| `ERROR` | Failures affecting the primary result. Use `logger.error(..., exc_info=True)` when traceback is needed |
+
+### Exception Handling
+- All exceptions must be caught and handled. No bare `except:`. Always specify the exception type.
+- Expected errors (HTTP 4xx, rate limits, missing data): catch, log, return user-facing error string.
+- Optional enrichment failures (OpenAlex, Unpaywall): catch, log at `DEBUG` with `exc_info=True`, continue.
+- Primary result errors: catch, log at `WARNING` or `ERROR`, return error string.
+- `ErrorHandlingMiddleware` is a safety net. If it catches something, that's a bug to fix.
+
+### Message Format
+- Pseudo-structured: `logger.info("event_name key=%s", value)`
+- Event name as first token (snake_case), then key=value pairs via `%s` formatting.
+- Never use f-strings in log calls (defeats lazy evaluation).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ Always fetch both before declaring a review round complete.
 - Standard library `logging` throughout. Every module: `logger = logging.getLogger(__name__)`.
 - No `print()` for operational output. No third-party logging libraries.
 - FastMCP middleware handles tool invocation, timing, and error logging automatically.
-- `SCHOLAR_MCP_LOG_LEVEL` (or `-v`) is the single log level control — `cli.py` syncs it to `FASTMCP_LOG_LEVEL` via `os.environ.setdefault` so FastMCP middleware respects the same level.
+- All logging goes through FastMCP's `configure_logging()` + RichHandler for uniform output. `cli.py` syncs `SCHOLAR_MCP_LOG_LEVEL` to `FASTMCP_LOG_LEVEL` so there is a single log level control.
 
 ### Log Levels
 | Level | Use for |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ Always fetch both before declaring a review round complete.
 - Standard library `logging` throughout. Every module: `logger = logging.getLogger(__name__)`.
 - No `print()` for operational output. No third-party logging libraries.
 - FastMCP middleware handles tool invocation, timing, and error logging automatically.
+- `SCHOLAR_MCP_LOG_LEVEL` (or `-v`) is the single log level control — `cli.py` syncs it to `FASTMCP_LOG_LEVEL` via `os.environ.setdefault` so FastMCP middleware respects the same level.
 
 ### Log Levels
 | Level | Use for |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ Always fetch both before declaring a review round complete.
 - Standard library `logging` throughout. Every module: `logger = logging.getLogger(__name__)`.
 - No `print()` for operational output. No third-party logging libraries.
 - FastMCP middleware handles tool invocation, timing, and error logging automatically.
-- All logging goes through FastMCP's `configure_logging()` + RichHandler for uniform output. `cli.py` syncs `SCHOLAR_MCP_LOG_LEVEL` to `FASTMCP_LOG_LEVEL` so there is a single log level control.
+- All logging goes through FastMCP's `configure_logging()` for uniform output. `FASTMCP_LOG_LEVEL` is the single log level control; the `-v` CLI flag sets it to `DEBUG`. `FASTMCP_ENABLE_RICH_LOGGING=false` switches to plain/JSON output.
 
 ### Log Levels
 | Level | Use for |

--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ All settings are controlled via environment variables with the `SCHOLAR_MCP_` pr
 | `SCHOLAR_MCP_READ_ONLY` | `true` | If `true`, write-tagged tools (`fetch_paper_pdf`, `convert_pdf_to_markdown`, `fetch_and_convert`, `fetch_pdf_by_url`) are hidden |
 | `SCHOLAR_MCP_CACHE_DIR` | `/data/scholar-mcp` | Directory for the SQLite cache database and downloaded PDFs |
 | `SCHOLAR_MCP_CONTACT_EMAIL` | -- | Included in the OpenAlex User-Agent for [polite pool](https://docs.openalex.org/how-to-use-the-api/rate-limits-and-authentication#the-polite-pool) access (faster rate limits); also enables Unpaywall PDF lookups |
-| `SCHOLAR_MCP_LOG_LEVEL` | `INFO` | Logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
-| `SCHOLAR_MCP_LOG_FORMAT` | `console` | Log output format: `console` (human-readable) or `json` (structured, for log aggregators) |
+| `FASTMCP_LOG_LEVEL` | `INFO` | Logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`). Controls all output (app + middleware). The `-v` CLI flag sets this to `DEBUG`. |
+| `FASTMCP_ENABLE_RICH_LOGGING` | `true` | Set `false` for plain/JSON-structured log output (e.g. for log aggregators) |
 
 ### PDF Conversion (optional)
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ All settings are controlled via environment variables with the `SCHOLAR_MCP_` pr
 | `SCHOLAR_MCP_CACHE_DIR` | `/data/scholar-mcp` | Directory for the SQLite cache database and downloaded PDFs |
 | `SCHOLAR_MCP_CONTACT_EMAIL` | -- | Included in the OpenAlex User-Agent for [polite pool](https://docs.openalex.org/how-to-use-the-api/rate-limits-and-authentication#the-polite-pool) access (faster rate limits); also enables Unpaywall PDF lookups |
 | `SCHOLAR_MCP_LOG_LEVEL` | `INFO` | Logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
+| `SCHOLAR_MCP_LOG_FORMAT` | `console` | Log output format: `console` (human-readable) or `json` (structured, for log aggregators) |
 
 ### PDF Conversion (optional)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,6 +11,7 @@ All settings are controlled via environment variables with the `SCHOLAR_MCP_` pr
 | `SCHOLAR_MCP_CACHE_DIR` | `/data/scholar-mcp` | Directory for the SQLite cache database (`cache.db`) and downloaded PDFs (`pdfs/`, `md/`). |
 | `SCHOLAR_MCP_CONTACT_EMAIL` | -- | Included in the OpenAlex `User-Agent` header for [polite pool](https://docs.openalex.org/how-to-use-the-api/rate-limits-and-authentication#the-polite-pool) access. Also enables [Unpaywall](https://unpaywall.org/products/api) lookups as a PDF fallback source when a paper has no open-access URL in Semantic Scholar. |
 | `SCHOLAR_MCP_LOG_LEVEL` | `INFO` | Python logging level: `DEBUG`, `INFO`, `WARNING`, or `ERROR`. |
+| `SCHOLAR_MCP_LOG_FORMAT` | `console` | Log output format. `console` produces human-readable output; `json` produces structured JSON lines for log aggregation tools (Loki, Datadog, Splunk). |
 
 ## PDF Conversion
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,8 +10,8 @@ All settings are controlled via environment variables with the `SCHOLAR_MCP_` pr
 | `SCHOLAR_MCP_READ_ONLY` | `true` | When `true`, all write-tagged tools are hidden. Set to `false` to enable PDF download and conversion. |
 | `SCHOLAR_MCP_CACHE_DIR` | `/data/scholar-mcp` | Directory for the SQLite cache database (`cache.db`) and downloaded PDFs (`pdfs/`, `md/`). |
 | `SCHOLAR_MCP_CONTACT_EMAIL` | -- | Included in the OpenAlex `User-Agent` header for [polite pool](https://docs.openalex.org/how-to-use-the-api/rate-limits-and-authentication#the-polite-pool) access. Also enables [Unpaywall](https://unpaywall.org/products/api) lookups as a PDF fallback source when a paper has no open-access URL in Semantic Scholar. |
-| `SCHOLAR_MCP_LOG_LEVEL` | `INFO` | Python logging level: `DEBUG`, `INFO`, `WARNING`, or `ERROR`. |
-| `SCHOLAR_MCP_LOG_FORMAT` | `console` | Log output format. `console` produces human-readable output; `json` produces structured JSON lines for log aggregation tools (Loki, Datadog, Splunk). |
+| `FASTMCP_LOG_LEVEL` | `INFO` | Logging level: `DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL`. Controls all output (application and middleware). The `-v` CLI flag sets this to `DEBUG`. |
+| `FASTMCP_ENABLE_RICH_LOGGING` | `true` | Set to `false` for plain/JSON-structured output suitable for log aggregation tools (Loki, Datadog, Splunk). When `true`, output uses Rich formatting (colors, timestamps). |
 
 ## PDF Conversion
 

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -95,8 +95,8 @@ See [Configuration](../configuration.md) for the full reference. Key variables f
 | `SCHOLAR_MCP_READ_ONLY` | `true` | Set `false` to enable PDF tools |
 | `SCHOLAR_MCP_DOCLING_URL` | -- | docling-serve URL (e.g. `http://docling-serve:5001`) |
 | `SCHOLAR_MCP_BEARER_TOKEN` | -- | Bearer token for HTTP auth |
-| `SCHOLAR_MCP_LOG_LEVEL` | `INFO` | Logging level |
-| `SCHOLAR_MCP_LOG_FORMAT` | `console` | `json` for structured logging with aggregators |
+| `FASTMCP_LOG_LEVEL` | `INFO` | Logging level (use `-v` or set to `DEBUG` for verbose output) |
+| `FASTMCP_ENABLE_RICH_LOGGING` | `true` | Set `false` for structured JSON logging with aggregators |
 
 For OIDC authentication, see [OIDC deployment](oidc.md).
 

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -96,6 +96,7 @@ See [Configuration](../configuration.md) for the full reference. Key variables f
 | `SCHOLAR_MCP_DOCLING_URL` | -- | docling-serve URL (e.g. `http://docling-serve:5001`) |
 | `SCHOLAR_MCP_BEARER_TOKEN` | -- | Bearer token for HTTP auth |
 | `SCHOLAR_MCP_LOG_LEVEL` | `INFO` | Logging level |
+| `SCHOLAR_MCP_LOG_FORMAT` | `console` | `json` for structured logging with aggregators |
 
 For OIDC authentication, see [OIDC deployment](oidc.md).
 

--- a/src/scholar_mcp/_tools_books.py
+++ b/src/scholar_mcp/_tools_books.py
@@ -137,6 +137,7 @@ def register_book_tools(mcp: FastMCP) -> None:
         try:
             return await _execute(retry=False)
         except RateLimitedError:
+            logger.debug("rate_limited_queued tool=%s", "search_books")
             task_id = bundle.tasks.submit(_execute(retry=True), tool="search_books")
             return json.dumps(
                 {"queued": True, "task_id": task_id, "tool": "search_books"}
@@ -179,6 +180,7 @@ def register_book_tools(mcp: FastMCP) -> None:
         try:
             return await _execute(retry=False)
         except RateLimitedError:
+            logger.debug("rate_limited_queued tool=%s", "get_book")
             task_id = bundle.tasks.submit(_execute(retry=True), tool="get_book")
             return json.dumps({"queued": True, "task_id": task_id, "tool": "get_book"})
 

--- a/src/scholar_mcp/_tools_citation.py
+++ b/src/scholar_mcp/_tools_citation.py
@@ -147,6 +147,7 @@ def register_citation_tools(mcp: FastMCP) -> None:
         try:
             return await _execute(retry=False)
         except RateLimitedError:
+            logger.debug("rate_limited_queued tool=%s", "generate_citations")
             task_id = bundle.tasks.submit(
                 _execute(retry=True), tool="generate_citations"
             )

--- a/src/scholar_mcp/_tools_graph.py
+++ b/src/scholar_mcp/_tools_graph.py
@@ -192,6 +192,7 @@ def register_graph_tools(mcp: FastMCP) -> None:
         try:
             return await _execute(retry=False)
         except RateLimitedError:
+            logger.debug("rate_limited_queued tool=%s", "get_citations")
             task_id = bundle.tasks.submit(_execute(retry=True), tool="get_citations")
             return json.dumps(
                 {"queued": True, "task_id": task_id, "tool": "get_citations"}
@@ -249,6 +250,7 @@ def register_graph_tools(mcp: FastMCP) -> None:
         try:
             return await _execute(retry=False)
         except RateLimitedError:
+            logger.debug("rate_limited_queued tool=%s", "get_references")
             task_id = bundle.tasks.submit(_execute(retry=True), tool="get_references")
             return json.dumps(
                 {"queued": True, "task_id": task_id, "tool": "get_references"}
@@ -502,6 +504,7 @@ def register_graph_tools(mcp: FastMCP) -> None:
         try:
             return await _execute(retry=False)
         except RateLimitedError:
+            logger.debug("rate_limited_queued tool=%s", "get_citation_graph")
             task_id = bundle.tasks.submit(
                 _execute(retry=True), tool="get_citation_graph"
             )
@@ -616,6 +619,7 @@ def register_graph_tools(mcp: FastMCP) -> None:
         try:
             return await _execute(retry=False)
         except RateLimitedError:
+            logger.debug("rate_limited_queued tool=%s", "find_bridge_papers")
             task_id = bundle.tasks.submit(
                 _execute(retry=True), tool="find_bridge_papers"
             )

--- a/src/scholar_mcp/_tools_patent.py
+++ b/src/scholar_mcp/_tools_patent.py
@@ -229,6 +229,7 @@ def register_patent_tools(mcp: FastMCP) -> None:
         try:
             return await _execute(retry=False)
         except (RateLimitedError, EpoRateLimitedError):
+            logger.debug("rate_limited_queued tool=%s", "search_patents")
             task_id = bundle.tasks.submit(_execute(retry=True), tool="search_patents")
             return json.dumps(
                 {"queued": True, "task_id": task_id, "tool": "search_patents"}
@@ -324,6 +325,7 @@ def register_patent_tools(mcp: FastMCP) -> None:
         try:
             return await _execute(retry=False)
         except (RateLimitedError, EpoRateLimitedError):
+            logger.debug("rate_limited_queued tool=%s", "get_patent")
             task_id = bundle.tasks.submit(_execute(retry=True), tool="get_patent")
             return json.dumps(
                 {"queued": True, "task_id": task_id, "tool": "get_patent"}
@@ -392,6 +394,7 @@ def register_patent_tools(mcp: FastMCP) -> None:
         try:
             return await _execute(retry=False)
         except (RateLimitedError, EpoRateLimitedError):
+            logger.debug("rate_limited_queued tool=%s", "get_citing_patents")
             task_id = bundle.tasks.submit(
                 _execute(retry=True), tool="get_citing_patents"
             )

--- a/src/scholar_mcp/_tools_pdf.py
+++ b/src/scholar_mcp/_tools_pdf.py
@@ -117,6 +117,8 @@ def register_pdf_tools(mcp: FastMCP) -> None:
             )
         except RateLimitedError:
             # S2 rate-limited; queue entire operation for background
+            logger.debug("rate_limited_queued tool=%s", "fetch_paper_pdf")
+
             async def _execute_full() -> str:
                 try:
                     p = await bundle.s2.get_paper(

--- a/src/scholar_mcp/_tools_recommendations.py
+++ b/src/scholar_mcp/_tools_recommendations.py
@@ -79,6 +79,7 @@ def register_recommendation_tools(mcp: FastMCP) -> None:
         try:
             return await _execute(retry=False)
         except RateLimitedError:
+            logger.debug("rate_limited_queued tool=%s", "recommend_papers")
             task_id = bundle.tasks.submit(_execute(retry=True), tool="recommend_papers")
             return json.dumps(
                 {

--- a/src/scholar_mcp/_tools_search.py
+++ b/src/scholar_mcp/_tools_search.py
@@ -106,6 +106,7 @@ def register_search_tools(mcp: FastMCP) -> None:
         try:
             return await _execute(retry=False)
         except RateLimitedError:
+            logger.debug("rate_limited_queued tool=%s", "search_papers")
             task_id = bundle.tasks.submit(_execute(retry=True), tool="search_papers")
             return json.dumps(
                 {"queued": True, "task_id": task_id, "tool": "search_papers"}
@@ -166,6 +167,7 @@ def register_search_tools(mcp: FastMCP) -> None:
         try:
             return await _execute(retry=False)
         except RateLimitedError:
+            logger.debug("rate_limited_queued tool=%s", "get_paper")
             task_id = bundle.tasks.submit(_execute(retry=True), tool="get_paper")
             return json.dumps({"queued": True, "task_id": task_id, "tool": "get_paper"})
 
@@ -225,6 +227,7 @@ def register_search_tools(mcp: FastMCP) -> None:
             try:
                 return await _execute_author(retry=False)
             except RateLimitedError:
+                logger.debug("rate_limited_queued tool=%s", "get_author")
                 task_id = bundle.tasks.submit(
                     _execute_author(retry=True), tool="get_author"
                 )
@@ -247,6 +250,7 @@ def register_search_tools(mcp: FastMCP) -> None:
         try:
             return await _execute_search(retry=False)
         except RateLimitedError:
+            logger.debug("rate_limited_queued tool=%s", "get_author")
             task_id = bundle.tasks.submit(
                 _execute_search(retry=True), tool="get_author"
             )

--- a/src/scholar_mcp/_tools_standards.py
+++ b/src/scholar_mcp/_tools_standards.py
@@ -252,6 +252,7 @@ async def _handle_full_text(
     try:
         return await _convert()
     except RateLimitedError:
+        logger.debug("rate_limited_queued tool=%s", "get_standard")
         task_id = bundle.tasks.submit(_convert(), tool="get_standard")
         return json.dumps({"queued": True, "task_id": task_id, "tool": "get_standard"})
     except Exception as exc:

--- a/src/scholar_mcp/_tools_utility.py
+++ b/src/scholar_mcp/_tools_utility.py
@@ -202,6 +202,7 @@ def register_utility_tools(mcp: FastMCP) -> None:
         try:
             return await _execute(retry=False)
         except (RateLimitedError, EpoRateLimitedError):
+            logger.debug("rate_limited_queued tool=%s", "batch_resolve")
             task_id = bundle.tasks.submit(_execute(retry=True), tool="batch_resolve")
             return json.dumps(
                 {"queued": True, "task_id": task_id, "tool": "batch_resolve"}
@@ -286,6 +287,7 @@ def register_utility_tools(mcp: FastMCP) -> None:
         try:
             return await _execute(retry=False)
         except RateLimitedError:
+            logger.debug("rate_limited_queued tool=%s", "enrich_paper")
             task_id = bundle.tasks.submit(_execute(retry=True), tool="enrich_paper")
             return json.dumps(
                 {"queued": True, "task_id": task_id, "tool": "enrich_paper"}

--- a/src/scholar_mcp/cli.py
+++ b/src/scholar_mcp/cli.py
@@ -60,11 +60,15 @@ def cli(ctx: click.Context, verbose: bool) -> None:
     configure_logging(level=level)
     # Attach FastMCP's handler to the root logger so application
     # loggers (scholar_mcp.*) share the same output format.
+    # configure_logging() sets propagate=False on the fastmcp logger,
+    # so fastmcp.* records won't double-fire through root.
     fastmcp_logger = logging.getLogger("fastmcp")
     root = logging.getLogger()
     root.setLevel(level)
-    if fastmcp_logger.handlers:
-        root.addHandler(fastmcp_logger.handlers[0])
+    if fastmcp_logger.handlers and not fastmcp_logger.propagate:
+        handler = fastmcp_logger.handlers[0]
+        if handler not in root.handlers:
+            root.addHandler(handler)
     if level == logging.DEBUG:
         logging.getLogger("httpx").setLevel(logging.WARNING)
         logging.getLogger("httpcore").setLevel(logging.WARNING)

--- a/src/scholar_mcp/cli.py
+++ b/src/scholar_mcp/cli.py
@@ -51,13 +51,20 @@ def _normalise_http_path(path: str | None) -> str:
 def cli(ctx: click.Context, verbose: bool) -> None:
     """Scholar MCP — academic literature server."""
     level = logging.DEBUG if verbose else get_log_level()
-    logging.basicConfig(
-        level=level,
-        format="%(levelname)s %(name)s: %(message)s",
-    )
-    # Sync FastMCP's logger to the same level so SCHOLAR_MCP_LOG_LEVEL
-    # (or -v) is the single knob controlling all logging output.
-    os.environ.setdefault("FASTMCP_LOG_LEVEL", logging.getLevelName(level))
+    level_name = logging.getLevelName(level)
+    # Set FASTMCP_LOG_LEVEL *before* FastMCP is imported so its
+    # internal configure_logging() picks up the same level.
+    os.environ.setdefault("FASTMCP_LOG_LEVEL", level_name)
+    from fastmcp.utilities.logging import configure_logging
+
+    configure_logging(level=level)
+    # Attach FastMCP's RichHandler to the root logger so all
+    # application loggers (scholar_mcp.*) share the same format.
+    fastmcp_logger = logging.getLogger("fastmcp")
+    root = logging.getLogger()
+    root.setLevel(level)
+    if fastmcp_logger.handlers:
+        root.addHandler(fastmcp_logger.handlers[0])
     if level == logging.DEBUG:
         logging.getLogger("httpx").setLevel(logging.WARNING)
         logging.getLogger("httpcore").setLevel(logging.WARNING)

--- a/src/scholar_mcp/cli.py
+++ b/src/scholar_mcp/cli.py
@@ -55,6 +55,9 @@ def cli(ctx: click.Context, verbose: bool) -> None:
         level=level,
         format="%(levelname)s %(name)s: %(message)s",
     )
+    # Sync FastMCP's logger to the same level so SCHOLAR_MCP_LOG_LEVEL
+    # (or -v) is the single knob controlling all logging output.
+    os.environ.setdefault("FASTMCP_LOG_LEVEL", logging.getLevelName(level))
     if level == logging.DEBUG:
         logging.getLogger("httpx").setLevel(logging.WARNING)
         logging.getLogger("httpcore").setLevel(logging.WARNING)

--- a/src/scholar_mcp/cli.py
+++ b/src/scholar_mcp/cli.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 import click
 
-from scholar_mcp.config import _ENV_PREFIX, get_log_level
+from scholar_mcp.config import _ENV_PREFIX
 
 logger = logging.getLogger(__name__)
 
@@ -50,16 +50,16 @@ def _normalise_http_path(path: str | None) -> str:
 @click.pass_context
 def cli(ctx: click.Context, verbose: bool) -> None:
     """Scholar MCP — academic literature server."""
-    level = logging.DEBUG if verbose else get_log_level()
-    level_name = logging.getLevelName(level)
-    # Set FASTMCP_LOG_LEVEL *before* FastMCP is imported so its
-    # internal configure_logging() picks up the same level.
-    os.environ.setdefault("FASTMCP_LOG_LEVEL", level_name)
+    # The -v flag overrides FASTMCP_LOG_LEVEL for convenience.
+    if verbose:
+        os.environ["FASTMCP_LOG_LEVEL"] = "DEBUG"
     from fastmcp.utilities.logging import configure_logging
 
+    level_name = os.environ.get("FASTMCP_LOG_LEVEL", "INFO").upper()
+    level = getattr(logging, level_name, logging.INFO)
     configure_logging(level=level)
-    # Attach FastMCP's RichHandler to the root logger so all
-    # application loggers (scholar_mcp.*) share the same format.
+    # Attach FastMCP's handler to the root logger so application
+    # loggers (scholar_mcp.*) share the same output format.
     fastmcp_logger = logging.getLogger("fastmcp")
     root = logging.getLogger()
     root.setLevel(level)

--- a/src/scholar_mcp/config.py
+++ b/src/scholar_mcp/config.py
@@ -26,8 +26,6 @@ class ServerConfig:
             for the polite pool. Set ``SCHOLAR_MCP_CONTACT_EMAIL`` to opt in.
         epo_consumer_key: EPO OPS API consumer key.
         epo_consumer_secret: EPO OPS API consumer secret.
-        log_format: Logging output format. ``"console"`` for human-readable,
-            ``"json"`` for structured JSON (e.g. for log aggregators).
     """
 
     read_only: bool = True
@@ -40,7 +38,6 @@ class ServerConfig:
     contact_email: str | None = None
     epo_consumer_key: str | None = None
     epo_consumer_secret: str | None = None
-    log_format: str = "console"
 
     @property
     def epo_configured(self) -> bool:
@@ -48,21 +45,6 @@ class ServerConfig:
         return (
             self.epo_consumer_key is not None and self.epo_consumer_secret is not None
         )
-
-
-def get_log_level() -> int:
-    """Return the configured log level from the environment.
-
-    Reads ``SCHOLAR_MCP_LOG_LEVEL`` (e.g. ``DEBUG``, ``INFO``).
-    Defaults to ``INFO``.
-
-    Returns:
-        Integer log level constant from :mod:`logging`.
-    """
-    import logging
-
-    raw = os.environ.get(f"{_ENV_PREFIX}_LOG_LEVEL", "INFO").upper()
-    return getattr(logging, raw, logging.INFO)
 
 
 def load_config() -> ServerConfig:
@@ -93,5 +75,4 @@ def load_config() -> ServerConfig:
         contact_email=_str("CONTACT_EMAIL"),
         epo_consumer_key=_str("EPO_CONSUMER_KEY"),
         epo_consumer_secret=_str("EPO_CONSUMER_SECRET"),
-        log_format=os.environ.get(f"{p}_LOG_FORMAT", "console").lower(),
     )

--- a/src/scholar_mcp/config.py
+++ b/src/scholar_mcp/config.py
@@ -26,6 +26,8 @@ class ServerConfig:
             for the polite pool. Set ``SCHOLAR_MCP_CONTACT_EMAIL`` to opt in.
         epo_consumer_key: EPO OPS API consumer key.
         epo_consumer_secret: EPO OPS API consumer secret.
+        log_format: Logging output format. ``"console"`` for human-readable,
+            ``"json"`` for structured JSON (e.g. for log aggregators).
     """
 
     read_only: bool = True
@@ -38,6 +40,7 @@ class ServerConfig:
     contact_email: str | None = None
     epo_consumer_key: str | None = None
     epo_consumer_secret: str | None = None
+    log_format: str = "console"
 
     @property
     def epo_configured(self) -> bool:
@@ -90,4 +93,5 @@ def load_config() -> ServerConfig:
         contact_email=_str("CONTACT_EMAIL"),
         epo_consumer_key=_str("EPO_CONSUMER_KEY"),
         epo_consumer_secret=_str("EPO_CONSUMER_SECRET"),
+        log_format=os.environ.get(f"{p}_LOG_FORMAT", "console").lower(),
     )

--- a/src/scholar_mcp/mcp_server.py
+++ b/src/scholar_mcp/mcp_server.py
@@ -437,7 +437,9 @@ def create_server(*, transport: str = "stdio") -> FastMCP:
     # --- Middleware: error handling, timing, logging ---
     mcp.add_middleware(
         ErrorHandlingMiddleware(
-            include_traceback=True,
+            include_traceback=(
+                os.environ.get("FASTMCP_LOG_LEVEL", "INFO").upper() == "DEBUG"
+            ),
             transform_errors=True,
         )
     )

--- a/src/scholar_mcp/mcp_server.py
+++ b/src/scholar_mcp/mcp_server.py
@@ -17,6 +17,12 @@ import sys
 from typing import Any
 
 from fastmcp import FastMCP
+from fastmcp.server.middleware.error_handling import ErrorHandlingMiddleware
+from fastmcp.server.middleware.logging import (
+    LoggingMiddleware,
+    StructuredLoggingMiddleware,
+)
+from fastmcp.server.middleware.timing import TimingMiddleware
 
 from scholar_mcp.config import _ENV_PREFIX, load_config
 
@@ -427,6 +433,29 @@ def create_server(*, transport: str = "stdio") -> FastMCP:
         lifespan=make_service_lifespan,
         auth=auth,
     )
+
+    # --- Middleware: error handling, timing, logging ---
+    mcp.add_middleware(
+        ErrorHandlingMiddleware(
+            include_traceback=True,
+            transform_errors=True,
+        )
+    )
+    mcp.add_middleware(TimingMiddleware())
+    if config.log_format == "json":
+        mcp.add_middleware(
+            StructuredLoggingMiddleware(
+                include_payloads=True,
+                include_payload_length=True,
+            )
+        )
+    else:
+        mcp.add_middleware(
+            LoggingMiddleware(
+                include_payloads=True,
+                max_payload_length=500,
+            )
+        )
 
     register_tools(mcp, transport=transport)
     register_resources(mcp)

--- a/src/scholar_mcp/mcp_server.py
+++ b/src/scholar_mcp/mcp_server.py
@@ -442,7 +442,8 @@ def create_server(*, transport: str = "stdio") -> FastMCP:
         )
     )
     mcp.add_middleware(TimingMiddleware())
-    if config.log_format == "json":
+    rich_logging = os.environ.get("FASTMCP_ENABLE_RICH_LOGGING", "true").lower()
+    if rich_logging in ("0", "false", "no", "off"):
         mcp.add_middleware(
             StructuredLoggingMiddleware(
                 include_payloads=True,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -79,6 +79,27 @@ def test_cache_clear_older_than(tmp_path: Path) -> None:
     assert "30" in result.output
 
 
+def test_verbose_syncs_fastmcp_log_level(monkeypatch) -> None:
+    """The -v flag sets FASTMCP_LOG_LEVEL so middleware logs at DEBUG too."""
+    monkeypatch.delenv("FASTMCP_LOG_LEVEL", raising=False)
+    runner = CliRunner()
+    # --help exits before serve, but cli() still runs and sets the env var
+    runner.invoke(cli, ["-v", "serve", "--help"])
+    import os
+
+    assert os.environ.get("FASTMCP_LOG_LEVEL") == "DEBUG"
+
+
+def test_fastmcp_log_level_not_overridden_if_explicit(monkeypatch) -> None:
+    """Explicit FASTMCP_LOG_LEVEL is respected (setdefault, not setenv)."""
+    monkeypatch.setenv("FASTMCP_LOG_LEVEL", "WARNING")
+    runner = CliRunner()
+    runner.invoke(cli, ["-v", "serve", "--help"])
+    import os
+
+    assert os.environ.get("FASTMCP_LOG_LEVEL") == "WARNING"
+
+
 def test_serve_help() -> None:
     """Existing serve command still works."""
     runner = CliRunner()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -79,25 +79,24 @@ def test_cache_clear_older_than(tmp_path: Path) -> None:
     assert "30" in result.output
 
 
-def test_verbose_syncs_fastmcp_log_level(monkeypatch) -> None:
-    """The -v flag sets FASTMCP_LOG_LEVEL so middleware logs at DEBUG too."""
+def test_verbose_sets_fastmcp_log_level(monkeypatch) -> None:
+    """The -v flag sets FASTMCP_LOG_LEVEL to DEBUG."""
     monkeypatch.delenv("FASTMCP_LOG_LEVEL", raising=False)
     runner = CliRunner()
-    # --help exits before serve, but cli() still runs and sets the env var
     runner.invoke(cli, ["-v", "serve", "--help"])
     import os
 
     assert os.environ.get("FASTMCP_LOG_LEVEL") == "DEBUG"
 
 
-def test_fastmcp_log_level_not_overridden_if_explicit(monkeypatch) -> None:
-    """Explicit FASTMCP_LOG_LEVEL is respected (setdefault, not setenv)."""
+def test_verbose_overrides_fastmcp_log_level(monkeypatch) -> None:
+    """The -v flag overrides an explicit FASTMCP_LOG_LEVEL."""
     monkeypatch.setenv("FASTMCP_LOG_LEVEL", "WARNING")
     runner = CliRunner()
     runner.invoke(cli, ["-v", "serve", "--help"])
     import os
 
-    assert os.environ.get("FASTMCP_LOG_LEVEL") == "WARNING"
+    assert os.environ.get("FASTMCP_LOG_LEVEL") == "DEBUG"
 
 
 def test_serve_help() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 from pathlib import Path
 
 from click.testing import CliRunner
@@ -84,8 +85,6 @@ def test_verbose_sets_fastmcp_log_level(monkeypatch) -> None:
     monkeypatch.delenv("FASTMCP_LOG_LEVEL", raising=False)
     runner = CliRunner()
     runner.invoke(cli, ["-v", "serve", "--help"])
-    import os
-
     assert os.environ.get("FASTMCP_LOG_LEVEL") == "DEBUG"
 
 
@@ -94,8 +93,6 @@ def test_verbose_overrides_fastmcp_log_level(monkeypatch) -> None:
     monkeypatch.setenv("FASTMCP_LOG_LEVEL", "WARNING")
     runner = CliRunner()
     runner.invoke(cli, ["-v", "serve", "--help"])
-    import os
-
     assert os.environ.get("FASTMCP_LOG_LEVEL") == "DEBUG"
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -80,3 +80,21 @@ def test_epo_configured_partial(monkeypatch) -> None:
             monkeypatch.delenv(key, raising=False)
     config = load_config()
     assert config.epo_configured is False
+
+
+def test_log_format_default(monkeypatch):
+    monkeypatch.delenv("SCHOLAR_MCP_LOG_FORMAT", raising=False)
+    cfg = load_config()
+    assert cfg.log_format == "console"
+
+
+def test_log_format_json(monkeypatch):
+    monkeypatch.setenv("SCHOLAR_MCP_LOG_FORMAT", "json")
+    cfg = load_config()
+    assert cfg.log_format == "json"
+
+
+def test_log_format_console_explicit(monkeypatch):
+    monkeypatch.setenv("SCHOLAR_MCP_LOG_FORMAT", "console")
+    cfg = load_config()
+    assert cfg.log_format == "console"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -80,21 +80,3 @@ def test_epo_configured_partial(monkeypatch) -> None:
             monkeypatch.delenv(key, raising=False)
     config = load_config()
     assert config.epo_configured is False
-
-
-def test_log_format_default(monkeypatch):
-    monkeypatch.delenv("SCHOLAR_MCP_LOG_FORMAT", raising=False)
-    cfg = load_config()
-    assert cfg.log_format == "console"
-
-
-def test_log_format_json(monkeypatch):
-    monkeypatch.setenv("SCHOLAR_MCP_LOG_FORMAT", "json")
-    cfg = load_config()
-    assert cfg.log_format == "json"
-
-
-def test_log_format_console_explicit(monkeypatch):
-    monkeypatch.setenv("SCHOLAR_MCP_LOG_FORMAT", "console")
-    cfg = load_config()
-    assert cfg.log_format == "console"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -6,6 +6,12 @@ import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
+from fastmcp.server.middleware.error_handling import ErrorHandlingMiddleware
+from fastmcp.server.middleware.logging import (
+    LoggingMiddleware,
+    StructuredLoggingMiddleware,
+)
+from fastmcp.server.middleware.timing import TimingMiddleware
 
 from scholar_mcp.mcp_server import (
     _build_remote_auth,
@@ -267,3 +273,35 @@ class TestBuildRemoteAuth:
             pytest.raises(RuntimeError, match="failed to fetch"),
         ):
             create_server(transport="http")
+
+
+class TestMiddlewareStack:
+    """Tests for logging/timing/error middleware wiring."""
+
+    def test_default_middleware_stack(self) -> None:
+        """Default config wires ErrorHandling + Timing + LoggingMiddleware."""
+        server = create_server()
+        types = [type(m) for m in server.middleware]
+        assert ErrorHandlingMiddleware in types
+        assert TimingMiddleware in types
+        assert LoggingMiddleware in types
+        assert StructuredLoggingMiddleware not in types
+
+    def test_json_format_uses_structured_logging(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """LOG_FORMAT=json wires StructuredLoggingMiddleware."""
+        monkeypatch.setenv("SCHOLAR_MCP_LOG_FORMAT", "json")
+        server = create_server()
+        types = [type(m) for m in server.middleware]
+        assert StructuredLoggingMiddleware in types
+        assert LoggingMiddleware not in types
+
+    def test_middleware_order(self) -> None:
+        """ErrorHandling is first, Timing second, Logging third."""
+        server = create_server()
+        types = [type(m) for m in server.middleware]
+        err_idx = types.index(ErrorHandlingMiddleware)
+        time_idx = types.index(TimingMiddleware)
+        log_idx = types.index(LoggingMiddleware)
+        assert err_idx < time_idx < log_idx

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -287,11 +287,11 @@ class TestMiddlewareStack:
         assert LoggingMiddleware in types
         assert StructuredLoggingMiddleware not in types
 
-    def test_json_format_uses_structured_logging(
+    def test_rich_disabled_uses_structured_logging(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """LOG_FORMAT=json wires StructuredLoggingMiddleware."""
-        monkeypatch.setenv("SCHOLAR_MCP_LOG_FORMAT", "json")
+        """FASTMCP_ENABLE_RICH_LOGGING=false wires StructuredLoggingMiddleware."""
+        monkeypatch.setenv("FASTMCP_ENABLE_RICH_LOGGING", "false")
         server = create_server()
         types = [type(m) for m in server.middleware]
         assert StructuredLoggingMiddleware in types

--- a/tests/test_tools_books.py
+++ b/tests/test_tools_books.py
@@ -522,3 +522,51 @@ async def test_recommend_books_empty_subject(
         result = await client.call_tool("recommend_books", {"subject": "nonexistent"})
     data = json.loads(result.content[0].text)
     assert data == []
+
+
+async def test_search_books_queued_on_rate_limit(
+    bundle: ServiceBundle,
+) -> None:
+    """search_books returns queued response when rate-limited."""
+    from unittest.mock import AsyncMock
+
+    from scholar_mcp._rate_limiter import RateLimitedError
+
+    bundle.openlibrary.search = AsyncMock(side_effect=RateLimitedError())
+
+    @asynccontextmanager
+    async def lifespan(app: FastMCP):  # type: ignore[type-arg]
+        yield {"bundle": bundle}
+
+    app = FastMCP("test", lifespan=lifespan)
+    register_book_tools(app)
+
+    async with Client(app) as client:
+        result = await client.call_tool("search_books", {"query": "test"})
+    data = json.loads(result.content[0].text)
+    assert data["queued"] is True
+    assert data["tool"] == "search_books"
+
+
+async def test_get_book_queued_on_rate_limit(
+    bundle: ServiceBundle,
+) -> None:
+    """get_book returns queued response when rate-limited."""
+    from unittest.mock import AsyncMock
+
+    from scholar_mcp._rate_limiter import RateLimitedError
+
+    bundle.openlibrary.get_by_isbn = AsyncMock(side_effect=RateLimitedError())
+
+    @asynccontextmanager
+    async def lifespan(app: FastMCP):  # type: ignore[type-arg]
+        yield {"bundle": bundle}
+
+    app = FastMCP("test", lifespan=lifespan)
+    register_book_tools(app)
+
+    async with Client(app) as client:
+        result = await client.call_tool("get_book", {"identifier": "9780201633610"})
+    data = json.loads(result.content[0].text)
+    assert data["queued"] is True
+    assert data["tool"] == "get_book"


### PR DESCRIPTION
## Summary

- Wire FastMCP's built-in `ErrorHandlingMiddleware`, `TimingMiddleware`, and `LoggingMiddleware`/`StructuredLoggingMiddleware` into the server for automatic tool invocation, timing, and error logging
- Use FastMCP's `configure_logging()` for uniform log output across all loggers (application + framework)
- Replace `SCHOLAR_MCP_LOG_LEVEL` and `SCHOLAR_MCP_LOG_FORMAT` with FastMCP's native `FASTMCP_LOG_LEVEL` and `FASTMCP_ENABLE_RICH_LOGGING` (breaking change)
- Add `logger.debug("rate_limited_queued tool=%s", ...)` to all 19 rate-limit queueing sites
- Document logging standard in CLAUDE.md (levels, exception handling policy, message format)

## Breaking changes

- `SCHOLAR_MCP_LOG_LEVEL` env var removed — use `FASTMCP_LOG_LEVEL` (or `-v` CLI flag)
- `SCHOLAR_MCP_LOG_FORMAT` env var removed — use `FASTMCP_ENABLE_RICH_LOGGING=false` for structured/JSON output

## Test plan

- [x] `uv run pytest -x -q` — 650 tests pass
- [x] `uv run ruff check --fix . && uv run ruff format . && uv run ruff format --check .` — clean
- [x] `uv run mypy src/` — no errors
- [x] Patch coverage: new code in config.py (100%), mcp_server.py (84%), cli.py new lines covered; uncovered lines are pre-existing auth/serve paths
- [x] Docs updated: README.md, docs/configuration.md, docs/deployment/docker.md, CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)