### PR TITLE
ci: post codecov/patch status for fork PRs via workflow_run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
           fi
 
       - name: Save patch coverage result
-        if: matrix.python-version == '3.13' && github.event_name == 'pull_request'
+        if: matrix.python-version == '3.13' && github.event_name == 'pull_request' && always()
         env:
           PATCH_STATE: ${{ steps.diffcover.outputs.state || 'error' }}
           PATCH_DESC: ${{ steps.diffcover.outputs.description || 'diff-cover step did not run' }}
@@ -142,7 +142,7 @@ jobs:
             '{"state":$state,"description":$description}' > patch-coverage.json
 
       - name: Upload patch coverage artifact
-        if: matrix.python-version == '3.13' && github.event_name == 'pull_request'
+        if: matrix.python-version == '3.13' && github.event_name == 'pull_request' && always()
         uses: actions/upload-artifact@v4
         with:
           name: patch-coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,8 +132,29 @@ jobs:
             fi
           fi
 
+      - name: Save patch coverage result
+        if: matrix.python-version == '3.13' && github.event_name == 'pull_request'
+        env:
+          PATCH_STATE: ${{ steps.diffcover.outputs.state || 'error' }}
+          PATCH_DESC: ${{ steps.diffcover.outputs.description || 'diff-cover step did not run' }}
+        run: |
+          jq -n --arg state "$PATCH_STATE" --arg description "$PATCH_DESC" \
+            '{"state":$state,"description":$description}' > patch-coverage.json
+
+      - name: Upload patch coverage artifact
+        if: matrix.python-version == '3.13' && github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: patch-coverage
+          path: patch-coverage.json
+          retention-days: 1
+
       - name: Post codecov/patch status
+        # Fork PRs: GITHUB_TOKEN is read-only for pull_request events from forks regardless
+        # of the permissions block — GitHub security restriction. continue-on-error prevents
+        # the job from failing; coverage-status.yml posts the status via workflow_run instead.
         if: matrix.python-version == '3.13' && github.event_name == 'pull_request' && always()
+        continue-on-error: true
         uses: actions/github-script@v7
         env:
           PATCH_STATE: ${{ steps.diffcover.outputs.state }}

--- a/.github/workflows/coverage-status.yml
+++ b/.github/workflows/coverage-status.yml
@@ -1,0 +1,53 @@
+name: Post Coverage Status
+
+# Posts the codecov/patch commit status for fork PRs, where the test job's
+# GITHUB_TOKEN is read-only and cannot write statuses directly (GitHub security
+# restriction for pull_request events from forks).
+#
+# workflow_run always executes in the base-repo context, so GITHUB_TOKEN here
+# has statuses: write regardless of where the PR originates.
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+jobs:
+  post-status:
+    name: Post codecov/patch status
+    # Only needed for fork PRs — own-branch PRs post the status directly in the
+    # test job. Push events don't upload the artifact so we'd have nothing to read.
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_repository.full_name != github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+      actions: read
+
+    steps:
+      - name: Download patch coverage artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: patch-coverage
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Post codecov/patch status
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const { state, description } = JSON.parse(fs.readFileSync('patch-coverage.json', 'utf8'));
+            const sha = context.payload.workflow_run.head_sha;
+            core.info(`Posting codecov/patch: ${state} — ${description} to ${sha}`);
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha,
+              state,
+              context: 'codecov/patch',
+              description,
+              target_url: 'https://app.codecov.io/gh/pvliesdonk/scholar-mcp',
+            });

--- a/.github/workflows/coverage-status.yml
+++ b/.github/workflows/coverage-status.yml
@@ -27,6 +27,7 @@ jobs:
 
     steps:
       - name: Download patch coverage artifact
+        id: download
         continue-on-error: true
         uses: actions/download-artifact@v4
         with:
@@ -35,7 +36,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Post codecov/patch status
-        if: success()
+        if: steps.download.outcome == 'success'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/coverage-status.yml
+++ b/.github/workflows/coverage-status.yml
@@ -27,6 +27,7 @@ jobs:
 
     steps:
       - name: Download patch coverage artifact
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           name: patch-coverage
@@ -34,6 +35,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Post codecov/patch status
+        if: success()
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Ports the fork PR codecov/patch fix from `pvliesdonk/markdown-vault-mcp@470c061`.
- Fork PRs currently get no `codecov/patch` check because `GITHUB_TOKEN` is read-only for `pull_request` events from forks regardless of `permissions: statuses: write` — a GitHub security restriction.
- Fix: save the diff-cover result as a workflow artifact, mark the inline post step `continue-on-error`, and add a new `coverage-status.yml` triggered by `workflow_run`. `workflow_run` always runs in the base-repo context where the token has `statuses: write`.
- Own-branch PRs continue to post the status inline in the test job and are unaffected.

Closes #109.

## Test plan

- [x] `uv run pytest -x -q` — 682 passed
- [x] `uv run ruff check --fix . && uv run ruff format . && uv run ruff format --check .` clean
- [x] `uv run mypy src/` clean
- [ ] Own-branch PR (this PR): CI run should still post `codecov/patch` inline and pass
- [ ] Fork PR verification must happen post-merge — requires a PR originating from an external fork

## Notes

- This is the first in a stack of 5 PRs restructuring the repo (see #106 / #107 / #108 / #110 / #111). Landing first because it's fully mechanical, unblocks fork-PR contributors, and is independent of the other work.
- No user-facing docs changes (CI plumbing only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)