### PR TITLE
docs: reposition scholar-mcp as a scholarly-sources MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ All settings are controlled via environment variables with the `SCHOLAR_MCP_` pr
 
 > Tier-1 bodies (NIST, IETF, W3C, ETSI) are supported with full metadata and optional full-text conversion. Tier-2 paywalled bodies (ISO, IEC, IEEE) are tracked in [GitHub issues](https://github.com/pvliesdonk/scholar-mcp/issues).
 
-### Cross-source utility
+### Cross-source Utility
 
 | Tool | Description |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -10,22 +10,29 @@
 [![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://pvliesdonk.github.io/scholar-mcp/)
 [![llms.txt](https://img.shields.io/badge/llms.txt-available-green)](https://pvliesdonk.github.io/scholar-mcp/llms.txt)
 
-A [FastMCP](https://github.com/jlowin/fastmcp) server providing structured academic literature access via [Semantic Scholar](https://www.semanticscholar.org/), with [OpenAlex](https://openalex.org/) enrichment and optional [docling-serve](https://github.com/DS4SD/docling-serve) PDF conversion.
+A [FastMCP](https://github.com/jlowin/fastmcp) server for the scholarly citation landscape -- **papers**, **patents**, **books**, and **standards** -- giving LLMs a unified way to search, cross-reference, and retrieve prior art across all four source types via [Semantic Scholar](https://www.semanticscholar.org/), [EPO Open Patent Services](https://www.epo.org/en/searching-for-patents/data/web-services/ops), [Open Library](https://openlibrary.org/), and standards bodies (NIST, IETF, W3C, ETSI), with [OpenAlex](https://openalex.org/) enrichment and optional [docling-serve](https://github.com/DS4SD/docling-serve) PDF/full-text conversion.
 
 ## Features
 
-- **Search & retrieval** -- full-text paper search with year, venue, field-of-study, and citation-count filters; single-paper lookup by DOI, S2 ID, arXiv ID, and more; author profile and name search
-- **Citation graph** -- forward citations, backward references, BFS graph traversal up to configurable depth, and shortest-path bridge paper discovery
-- **Recommendations** -- paper recommendations from positive (and optional negative) examples via the S2 recommendation API
-- **Citation generation** -- format paper metadata as BibTeX, CSL-JSON, or RIS citations with automatic entry type inference, author name parsing, and OpenAlex venue enrichment
-- **Book search** -- search and fetch book metadata via [Open Library](https://openlibrary.org/) (no API key required); papers with an ISBN are automatically enriched with publisher, edition, cover URL, and subject data
-- **OpenAlex enrichment** -- augment paper metadata with open-access URLs, affiliations, funders, concepts, and OA status
-- **Patent search & cross-referencing** -- search and retrieve patents via [EPO Open Patent Services](https://www.epo.org/en/searching-for-patents/data/web-services/ops) covering 100+ patent offices, with cited reference extraction, NPL-to-paper resolution via Semantic Scholar, and paper-to-patent citation discovery; EPO credentials are optional -- paper search works without them
-- **PDF conversion** -- download open-access PDFs and convert to Markdown via [docling-serve](https://github.com/DS4SD/docling-serve), with optional VLM enrichment for formulas and figures; automatic fallback to ArXiv, PubMed Central, and Unpaywall when Semantic Scholar has no OA link; direct URL download for PDFs found elsewhere
-- **Intelligent caching** -- SQLite-backed cache with per-table TTLs (30 days for papers/authors, 7 days for citations/references) and identifier aliasing
-- **Authentication** -- bearer token, OIDC (OAuth 2.1), or both simultaneously (multi-auth)
-- **Multi-transport** -- stdio (Claude Desktop), HTTP (streamable-http), and SSE transports
-- **Linux packages** -- `.deb` and `.rpm` packages with systemd service and security hardening
+### Source domains
+
+- **Papers** -- full-text search with year/venue/field/citation filters; single-paper lookup by DOI, S2 ID, arXiv ID, ACM ID, or PubMed ID; author profile and name search; forward citations, backward references, BFS graph traversal, shortest-path bridge discovery; recommendations from positive/negative examples; BibTeX/CSL-JSON/RIS citation generation with OpenAlex venue enrichment.
+- **Patents** -- search across 100+ patent offices via EPO OPS with CPC/applicant/inventor/jurisdiction filters; bibliographic, claims, description, family, legal, and citations sections; NPL-to-paper resolution via Semantic Scholar and paper-to-patent citation discovery. EPO credentials are optional -- other domains work without them.
+- **Books** -- search by title/author/keywords via Open Library (no API key required); lookup by ISBN-10/13, Open Library work ID, or edition ID; subject-based recommendations sorted by popularity. Papers with an ISBN in `externalIds` are automatically enriched with publisher, edition, cover URL, and subject data.
+- **Standards** -- identifier resolution, search, and metadata retrieval for NIST, IETF, W3C, and ETSI standards, with optional full-text fetch and Markdown conversion via docling. Tier-2 paywalled bodies (ISO, IEC, IEEE) are tracked in [GitHub issues](https://github.com/pvliesdonk/scholar-mcp/issues).
+
+### Cross-cutting
+
+- **OpenAlex enrichment** -- augment paper metadata with open-access URLs, affiliations, funders, concepts, and OA status.
+- **PDF conversion** -- download open-access PDFs and convert to Markdown via [docling-serve](https://github.com/DS4SD/docling-serve), with optional VLM enrichment for formulas and figures; automatic fallback to ArXiv, PubMed Central, and Unpaywall when Semantic Scholar has no OA link; direct URL download for PDFs found elsewhere.
+- **Intelligent caching** -- SQLite-backed cache with per-table TTLs (30 days for papers/authors, 7 days for citations/references) and identifier aliasing.
+- **Authentication** -- bearer token, OIDC (OAuth 2.1), or both simultaneously (multi-auth).
+- **Multi-transport** -- stdio (Claude Desktop), HTTP (streamable-http), and SSE transports.
+- **Linux packages** -- `.deb` and `.rpm` packages with systemd service and security hardening.
+
+### Coverage by domain
+
+Per-domain depth is uneven. Papers currently have the richest tool surface (citation graph, recommendations, cross-referencing to all three other domains); standards are the leanest. That reflects public data availability, not a value hierarchy — writing a paper typically needs all four source types for citations and prior art. Parity work is tracked in [GitHub issues](https://github.com/pvliesdonk/scholar-mcp/issues) and [milestones](https://github.com/pvliesdonk/scholar-mcp/milestones); the roadmap shows intent, not a completeness commitment.
 
 ## Installation
 
@@ -139,7 +146,11 @@ All settings are controlled via environment variables with the `SCHOLAR_MCP_` pr
 
 ## MCP Tools
 
-### Search & Retrieval
+27 tools, organised by scholarly source type.
+
+### Papers
+
+#### Search & retrieval
 
 | Tool | Description |
 |---|---|
@@ -147,7 +158,7 @@ All settings are controlled via environment variables with the `SCHOLAR_MCP_` pr
 | `get_paper` | Fetch full metadata for a single paper by DOI, S2 ID, arXiv ID, ACM ID, or PubMed ID. |
 | `get_author` | Fetch author profile with publications, or search by name. |
 
-### Citation Graph
+#### Citation graph
 
 | Tool | Description |
 |---|---|
@@ -156,13 +167,26 @@ All settings are controlled via environment variables with the `SCHOLAR_MCP_` pr
 | `get_citation_graph` | BFS traversal from seed papers, returning nodes + edges up to configurable depth. |
 | `find_bridge_papers` | Shortest citation path between two papers. |
 
-### Recommendations
+#### Recommendations & citation generation
 
 | Tool | Description |
 |---|---|
 | `recommend_papers` | Paper recommendations from 1--5 positive examples and optional negative examples. |
+| `generate_citations` | Generate BibTeX, CSL-JSON, or RIS citations for up to 100 papers, with automatic entry type inference and optional OpenAlex venue enrichment. |
+| `enrich_paper` | Augment Semantic Scholar metadata with OpenAlex fields (affiliations, funders, OA status, concepts). |
 
-### Book Search
+### Patents
+
+| Tool | Description |
+|---|---|
+| `search_patents` | Search patents across 100+ patent offices via EPO OPS with CPC / applicant / inventor / jurisdiction / date filters. |
+| `get_patent` | Fetch bibliographic / claims / description / family / legal / citations sections for a single patent by publication number. Citations include NPL-to-paper resolution via Semantic Scholar. |
+| `get_citing_patents` | Find patents that cite a given academic paper (best-effort; EPO OPS citation search coverage is incomplete). |
+| `fetch_patent_pdf` | Download a patent PDF via authenticated EPO OPS and optionally convert to Markdown. |
+
+> Patent tools are hidden when `SCHOLAR_MCP_EPO_CONSUMER_KEY` and `SCHOLAR_MCP_EPO_CONSUMER_SECRET` are not set. `fetch_patent_pdf` is also write-tagged and hidden when `SCHOLAR_MCP_READ_ONLY=true`.
+
+### Books
 
 | Tool | Description |
 |---|---|
@@ -172,28 +196,21 @@ All settings are controlled via environment variables with the `SCHOLAR_MCP_` pr
 
 > Papers with an ISBN in their `externalIds` are automatically enriched with `book_metadata` (publisher, edition, cover URL, subjects, and more) from Open Library when fetched via `get_paper`, `get_citations`, `get_references`, or `get_citation_graph`.
 
-### Utility
+### Standards
 
 | Tool | Description |
 |---|---|
-| `batch_resolve` | Resolve up to 100 identifiers to full metadata in one call, with OpenAlex fallback. |
-| `enrich_paper` | Augment S2 metadata with OpenAlex fields (affiliations, funders, OA status, concepts). |
+| `resolve_standard_identifier` | Normalise a messy citation string (e.g. `"rfc9000"`, `"nist 800-53"`) to canonical form and body. |
+| `search_standards` | Search standards by identifier, title, or free text, optionally filtered to one body (`NIST`, `IETF`, `W3C`, `ETSI`). |
+| `get_standard` | Retrieve a standard by canonical or fuzzy identifier, optionally fetching and converting the full text via docling. |
 
-### Citation Generation
+> Tier-1 bodies (NIST, IETF, W3C, ETSI) are supported with full metadata and optional full-text conversion. Tier-2 paywalled bodies (ISO, IEC, IEEE) are tracked in [GitHub issues](https://github.com/pvliesdonk/scholar-mcp/issues).
 
-| Tool | Description |
-|---|---|
-| `generate_citations` | Generate BibTeX, CSL-JSON, or RIS citations for up to 100 papers, with automatic entry type inference and optional OpenAlex venue enrichment. |
-
-### Patent Search (requires EPO OPS credentials)
+### Cross-source utility
 
 | Tool | Description |
 |---|---|
-| `search_patents` | Search patents across 100+ patent offices via EPO OPS. |
-| `get_patent` | Fetch bibliographic metadata for a single patent by publication number. |
-| `fetch_patent_pdf` | Download a patent PDF via authenticated EPO OPS and optionally convert to Markdown. |
-
-> Patent tools are hidden when `SCHOLAR_MCP_EPO_CONSUMER_KEY` and `SCHOLAR_MCP_EPO_CONSUMER_SECRET` are not set. `fetch_patent_pdf` is also write-tagged and hidden when `SCHOLAR_MCP_READ_ONLY=true`.
+| `batch_resolve` | Resolve up to 100 mixed identifiers (paper DOIs, patent numbers, ISBNs) to full metadata in one call, routing each to the right backend with OpenAlex fallback. |
 
 ### PDF Conversion (requires docling-serve)
 
@@ -204,7 +221,7 @@ All settings are controlled via environment variables with the `SCHOLAR_MCP_` pr
 | `fetch_and_convert` | Full pipeline: fetch PDF (with fallback), convert to Markdown, return both. |
 | `fetch_pdf_by_url` | Download a PDF from any URL and optionally convert to Markdown. |
 
-> PDF tools are write-tagged and hidden when `SCHOLAR_MCP_READ_ONLY=true` (the default).
+> PDF tools are write-tagged and hidden when `SCHOLAR_MCP_READ_ONLY=true` (the default). `fetch_patent_pdf` (above) and the `get_standard` full-text mode cover the patent and standards equivalents.
 
 ### Task Polling
 
@@ -213,7 +230,7 @@ All settings are controlled via environment variables with the `SCHOLAR_MCP_` pr
 | `get_task_result` | Poll for the result of a background task by ID. |
 | `list_tasks` | List all active background tasks. |
 
-> Long-running operations (PDF download/conversion) and rate-limited S2 requests return `{"queued": true, "task_id": "..."}` immediately. Use `get_task_result` to poll for the result.
+> Long-running operations (PDF download/conversion) and rate-limited backend requests return `{"queued": true, "task_id": "..."}` immediately. Use `get_task_result` to poll for the result.
 
 ## Docker Compose
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,10 +7,10 @@ A [FastMCP](https://github.com/jlowin/fastmcp) server for the scholarly citation
 Scholar MCP exposes 27 tools that let LLM-powered applications search, cross-reference, and retrieve scholarly sources across four peer domains:
 
 - **Papers** -- full-text search (year, venue, field, citation filters); single-paper lookup by DOI / S2 ID / arXiv / ACM / PubMed; author profile and name search; forward citations, backward references, BFS citation graph, shortest-path bridge discovery; recommendations from positive/negative examples; BibTeX/CSL-JSON/RIS citation generation; OpenAlex enrichment (affiliations, funders, OA status, and concepts).
-- **Patents** -- search across 100+ patent offices via EPO OPS with CPC / applicant / inventor / jurisdiction filters; biblio, claims, description, family, legal and citations sections; NPL-to-paper resolution via Semantic Scholar and paper-to-patent citation discovery.
+- **Patents** -- search across 100+ patent offices via EPO OPS with CPC / applicant / inventor / jurisdiction filters; biblio, claims, description, family, legal and citations sections; NPL-to-paper resolution via Semantic Scholar and paper-to-patent citation discovery; patent PDF download via EPO OPS.
 - **Books** -- search by title/author/keywords via Open Library; lookup by ISBN or Open Library ID; subject recommendations. Papers with an ISBN are automatically enriched with publisher/edition/cover/subject metadata.
 - **Standards** -- identifier resolution, search, and metadata retrieval for NIST, IETF, W3C, and ETSI, with optional full-text fetch and Markdown conversion via docling.
-- **Cross-source utility** -- resolve up to 100 mixed identifiers (paper DOIs, patent numbers, ISBNs) to full metadata in one call.
+- **Cross-source Utility** -- resolve up to 100 mixed identifiers (paper DOIs, patent numbers, ISBNs) to full metadata in one call.
 - **PDF conversion** -- download PDFs and convert to Markdown via [docling-serve](https://github.com/DS4SD/docling-serve), with optional VLM enrichment for formulas and figures; automatic fallback to ArXiv, PubMed Central, and Unpaywall; direct URL download for alternative versions.
 - **Async task queue** -- long-running operations return immediately with a task ID; poll for results with `get_task_result`.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,19 +1,23 @@
 # Scholar MCP Server
 
-A [FastMCP](https://github.com/jlowin/fastmcp) server providing structured academic literature access via [Semantic Scholar](https://www.semanticscholar.org/), with [OpenAlex](https://openalex.org/) enrichment and optional [docling-serve](https://github.com/DS4SD/docling-serve) PDF conversion.
+A [FastMCP](https://github.com/jlowin/fastmcp) server for the scholarly citation landscape -- **papers**, **patents**, **books**, and **standards** -- giving LLMs a unified way to search, cross-reference, and retrieve prior art across all four source types via [Semantic Scholar](https://www.semanticscholar.org/), [EPO Open Patent Services](https://www.epo.org/en/searching-for-patents/data/web-services/ops), [Open Library](https://openlibrary.org/), and standards bodies, with [OpenAlex](https://openalex.org/) enrichment and optional [docling-serve](https://github.com/DS4SD/docling-serve) PDF/full-text conversion.
 
 ## What it does
 
-Scholar MCP exposes 19 tools that let LLM-powered applications search, explore, and retrieve academic papers:
+Scholar MCP exposes 27 tools that let LLM-powered applications search, cross-reference, and retrieve scholarly sources across four peer domains:
 
-- **Search & retrieval** -- find papers by keyword, look up by DOI/arXiv/S2 ID, search authors
-- **Citation graph** -- traverse forward citations, backward references, build citation graphs, discover bridge papers between fields
-- **Recommendations** -- get paper suggestions from positive and negative examples
-- **OpenAlex enrichment** -- augment Semantic Scholar metadata with affiliations, funders, OA status, and concepts
-- **PDF conversion** -- download PDFs and convert to Markdown via [docling-serve](https://github.com/DS4SD/docling-serve), with optional VLM enrichment for formulas and figures; automatic fallback to ArXiv, PubMed Central, and Unpaywall; direct URL download for alternative versions
-- **Async task queue** -- long-running operations return immediately with a task ID; poll for results with `get_task_result`
+- **Papers** -- full-text search (year, venue, field, citation filters); single-paper lookup by DOI / S2 ID / arXiv / ACM / PubMed; author profile and name search; forward citations, backward references, BFS citation graph, shortest-path bridge discovery; recommendations from positive/negative examples; BibTeX/CSL-JSON/RIS citation generation.
+- **Patents** -- search across 100+ patent offices via EPO OPS with CPC / applicant / inventor / jurisdiction filters; biblio, claims, description, family, legal and citations sections; NPL-to-paper resolution via Semantic Scholar and paper-to-patent citation discovery.
+- **Books** -- search by title/author/keywords via Open Library; lookup by ISBN or Open Library ID; subject recommendations. Papers with an ISBN are automatically enriched with publisher/edition/cover/subject metadata.
+- **Standards** -- identifier resolution, search, and metadata retrieval for NIST, IETF, W3C, and ETSI, with optional full-text fetch and Markdown conversion via docling.
+- **OpenAlex enrichment** -- augment Semantic Scholar metadata with affiliations, funders, OA status, and concepts.
+- **PDF conversion** -- download PDFs and convert to Markdown via [docling-serve](https://github.com/DS4SD/docling-serve), with optional VLM enrichment for formulas and figures; automatic fallback to ArXiv, PubMed Central, and Unpaywall; direct URL download for alternative versions.
+- **Async task queue** -- long-running operations return immediately with a task ID; poll for results with `get_task_result`.
 
 Results are cached in a local SQLite database with per-table TTLs to minimize API calls and speed up repeated lookups.
+
+!!! info "Coverage by domain"
+    Per-domain depth is uneven — papers currently have the richest tool surface, standards the leanest. That reflects public data availability, not a value hierarchy: writing a paper typically needs all four source types for citations and prior art. Parity work is tracked in [GitHub issues](https://github.com/pvliesdonk/scholar-mcp/issues) and [milestones](https://github.com/pvliesdonk/scholar-mcp/milestones) — the roadmap shows intent, not a completeness commitment.
 
 ## Quick start
 
@@ -45,29 +49,30 @@ See [Installation](installation.md) for all methods including Linux packages.
 ## Architecture
 
 ```
-┌──────────────────────────────────────────────┐
-│               MCP Client                     │
-│     (Claude Desktop, Claude Code, etc.)      │
-└──────────────┬───────────────────────────────┘
-               │ stdio / HTTP / SSE
-┌──────────────▼───────────────────────────────┐
-│           scholar-mcp (FastMCP)              │
-│                                              │
-│  ┌─────────┐ ┌──────────┐ ┌──────────────┐  │
-│  │ Search  │ │ Citation │ │    PDF       │  │
-│  │ Tools   │ │ Graph    │ │ Conversion   │  │
-│  └────┬────┘ └────┬─────┘ └──────┬───────┘  │
-│       │           │              │           │
-│  ┌────▼───────────▼──────────────▼────────┐  │
-│  │          SQLite Cache (TTL)            │  │
-│  └────┬───────────┬──────────────┬────────┘  │
-└───────┼───────────┼──────────────┼───────────┘
-        │           │              │
-   ┌────▼────┐ ┌────▼─────┐ ┌─────▼──────┐
-   │Semantic │ │ OpenAlex │ │  docling-  │
-   │Scholar  │ │   API    │ │   serve    │
-   │  API    │ │          │ │ (optional) │
-   └─────────┘ └──────────┘ └────────────┘
+┌───────────────────────────────────────────────────────────────┐
+│                       MCP Client                              │
+│             (Claude Desktop, Claude Code, etc.)               │
+└──────────────────────────┬────────────────────────────────────┘
+                           │ stdio / HTTP / SSE
+┌──────────────────────────▼────────────────────────────────────┐
+│                  scholar-mcp (FastMCP)                        │
+│                                                               │
+│  ┌────────┐ ┌────────┐ ┌────────┐ ┌───────────┐ ┌──────────┐  │
+│  │ Papers │ │Patents │ │ Books  │ │ Standards │ │   PDF    │  │
+│  │  (10)  │ │  (4)   │ │  (3)   │ │    (3)    │ │   (4)    │  │
+│  └────┬───┘ └────┬───┘ └────┬───┘ └─────┬─────┘ └─────┬────┘  │
+│       │         │          │           │             │       │
+│  ┌────▼─────────▼──────────▼───────────▼─────────────▼────┐  │
+│  │                  SQLite Cache (TTL)                    │  │
+│  └───┬──────┬──────────┬───────┬──────────┬─────────┬─────┘  │
+└──────┼──────┼──────────┼───────┼──────────┼─────────┼────────┘
+       │      │          │       │          │         │
+  ┌────▼───┐ ┌▼────────┐ ┌▼────┐ ┌▼──────┐ ┌▼───────┐ ┌▼──────┐
+  │Semantic│ │OpenAlex │ │ EPO │ │ Open  │ │ NIST / │ │docling│
+  │Scholar │ │   API   │ │ OPS │ │Library│ │  IETF /│ │ -serve│
+  │  API   │ │         │ │     │ │       │ │  W3C / │ │(opt.) │
+  │        │ │         │ │     │ │       │ │  ETSI  │ │       │
+  └────────┘ └─────────┘ └─────┘ └───────┘ └────────┘ └───────┘
 ```
 
 ## Next steps

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,11 +6,11 @@ A [FastMCP](https://github.com/jlowin/fastmcp) server for the scholarly citation
 
 Scholar MCP exposes 27 tools that let LLM-powered applications search, cross-reference, and retrieve scholarly sources across four peer domains:
 
-- **Papers** -- full-text search (year, venue, field, citation filters); single-paper lookup by DOI / S2 ID / arXiv / ACM / PubMed; author profile and name search; forward citations, backward references, BFS citation graph, shortest-path bridge discovery; recommendations from positive/negative examples; BibTeX/CSL-JSON/RIS citation generation.
+- **Papers** -- full-text search (year, venue, field, citation filters); single-paper lookup by DOI / S2 ID / arXiv / ACM / PubMed; author profile and name search; forward citations, backward references, BFS citation graph, shortest-path bridge discovery; recommendations from positive/negative examples; BibTeX/CSL-JSON/RIS citation generation; OpenAlex enrichment (affiliations, funders, OA status, and concepts).
 - **Patents** -- search across 100+ patent offices via EPO OPS with CPC / applicant / inventor / jurisdiction filters; biblio, claims, description, family, legal and citations sections; NPL-to-paper resolution via Semantic Scholar and paper-to-patent citation discovery.
 - **Books** -- search by title/author/keywords via Open Library; lookup by ISBN or Open Library ID; subject recommendations. Papers with an ISBN are automatically enriched with publisher/edition/cover/subject metadata.
 - **Standards** -- identifier resolution, search, and metadata retrieval for NIST, IETF, W3C, and ETSI, with optional full-text fetch and Markdown conversion via docling.
-- **OpenAlex enrichment** -- augment Semantic Scholar metadata with affiliations, funders, OA status, and concepts.
+- **Cross-source utility** -- resolve up to 100 mixed identifiers (paper DOIs, patent numbers, ISBNs) to full metadata in one call.
 - **PDF conversion** -- download PDFs and convert to Markdown via [docling-serve](https://github.com/DS4SD/docling-serve), with optional VLM enrichment for formulas and figures; automatic fallback to ArXiv, PubMed Central, and Unpaywall; direct URL download for alternative versions.
 - **Async task queue** -- long-running operations return immediately with a task ID; poll for results with `get_task_result`.
 
@@ -62,6 +62,8 @@ See [Installation](installation.md) for all methods including Linux packages.
 │  │  (10)  │ │  (4)   │ │  (3)   │ │    (3)    │ │   (4)    │  │
 │  └────┬───┘ └────┬───┘ └────┬───┘ └─────┬─────┘ └─────┬────┘  │
 │       │         │          │           │             │       │
+│       + Cross-source Utility (1) · Task Polling (2)          │
+│                                                               │
 │  ┌────▼─────────▼──────────▼───────────▼─────────────▼────┐  │
 │  │                  SQLite Cache (TTL)                    │  │
 │  └───┬──────┬──────────┬───────┬──────────┬─────────┬─────┘  │

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -1,6 +1,6 @@
 # Tools
 
-Scholar MCP provides 27 tools organised by scholarly source type: **Papers**, **Patents**, **Books**, and **Standards** are peer source domains; the remaining sections (Utility, PDF Conversion, Task Polling) are cross-cutting. All tools return JSON.
+Scholar MCP provides 27 tools organised by scholarly source type: **Papers**, **Patents**, **Books**, and **Standards** are peer source domains; the remaining sections (Cross-source Utility, PDF Conversion, Task Polling) are cross-cutting. All tools return JSON.
 
 !!! info "Coverage by domain"
     Per-domain depth is uneven — papers currently have the richest tool surface (citation graph, recommendations, cross-referencing to all three other domains); standards are the leanest. That reflects public data availability, not a value hierarchy. Parity work is tracked in [GitHub issues](https://github.com/pvliesdonk/scholar-mcp/issues) and [milestones](https://github.com/pvliesdonk/scholar-mcp/milestones).
@@ -207,6 +207,55 @@ Paper recommendations based on positive (and optional negative) examples.
 
 ---
 
+## Papers — Enrichment
+
+### `enrich_paper`
+
+Augment Semantic Scholar metadata with OpenAlex data.
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `identifier` | string | *(required)* | S2 paper ID or `DOI:xxx` |
+| `fields` | list[string] | *(required)* | Fields to retrieve: `affiliations`, `funders`, `oa_status`, `concepts` |
+
+**Available fields:**
+
+| Field | Description |
+|---|---|
+| `affiliations` | Institution display names from author affiliations |
+| `funders` | Funding organization names |
+| `oa_status` | Open access status string (e.g. `gold`, `green`, `hybrid`); also includes `is_oa` boolean |
+| `concepts` | List of `{"name": "...", "score": 0.95}` topic concepts |
+
+Results are cached for 30 days.
+
+---
+
+## Papers — Citation Generation
+
+### `generate_citations`
+
+Generate formatted citations for one or more papers. Resolves papers via Semantic Scholar, optionally enriches with OpenAlex metadata, and formats as BibTeX, CSL-JSON, or RIS.
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `paper_ids` | list[string] | *(required)* | Paper identifiers (S2 IDs, DOIs, arXiv IDs, etc.). Max 100. |
+| `citation_format` | string | `"bibtex"` | Output format: `bibtex`, `csl-json`, or `ris` |
+| `enrich` | boolean | `true` | Attempt OpenAlex enrichment for missing venue data |
+
+**BibTeX output** includes entry type inference (`@article`, `@inproceedings`, `@misc`, `@book`), proper author formatting (`{Last}, First`), title casing preservation, DOI, arXiv eprint fields, and special character escaping. Papers with `book_metadata` (ISBN or publisher) are emitted as `@book` entries with `publisher`, `edition`, and `isbn` fields.
+
+**CSL-JSON output** returns `{"citations": [...], "errors": [...]}` -- the citations array contains standard CSL-JSON objects compatible with Zotero, Mendeley, Pandoc, and other CSL processors. Book entries use `type: "book"` with `publisher` and `ISBN` fields.
+
+**RIS output** uses standard RIS tags (`TY`, `AU`, `TI`, `PY`, `JO`/`BT`, `DO`, `UR`, `AB`, `ER`). Book entries use `TY - BOOK` with `PB` (publisher) and `SN` (ISBN) tags.
+
+Papers that fail to resolve are reported inline (BibTeX/RIS: as comments, CSL-JSON: in the errors array) rather than failing the entire request. When all papers fail, a structured error is returned: `{"error": "no_papers_resolved", "failed": [...]}`.
+
+!!! tip "Enrichment"
+    When `enrich` is enabled and a paper has no venue but has a DOI, the tool queries OpenAlex to fill in the venue name. This improves citation quality for papers where Semantic Scholar has incomplete metadata.
+
+---
+
 ## Books
 
 Book tools use [Open Library](https://openlibrary.org/) as their data source. No API key is required. Rate limits are handled automatically; if the Open Library API is temporarily unavailable, calls queue and return a task ID (see [Async Task Queue](#async-task-queue)).
@@ -315,7 +364,7 @@ Enrichment failures are silently skipped — if Open Library is unreachable or t
 
 ---
 
-## Utility
+## Cross-source Utility
 
 ### `batch_resolve`
 
@@ -332,53 +381,6 @@ Resolve up to 100 paper, patent, or book identifiers to full metadata in a singl
 - **Patent results** have a `"patent"` key and `"source_type": "patent"`. Patent numbers are auto-detected by their two-letter country prefix (e.g. `EP`, `US`, `WO`) and routed to the EPO OPS API.
 - **Book results** have a `"book"` key and `"source_type": "book"`. ISBNs (prefixed with `ISBN:`) are routed to Open Library.
 - **Unresolved items** have an `"error"` key.
-
----
-
-### `enrich_paper`
-
-Augment Semantic Scholar metadata with OpenAlex data.
-
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `identifier` | string | *(required)* | S2 paper ID or `DOI:xxx` |
-| `fields` | list[string] | *(required)* | Fields to retrieve: `affiliations`, `funders`, `oa_status`, `concepts` |
-
-**Available fields:**
-
-| Field | Description |
-|---|---|
-| `affiliations` | Institution display names from author affiliations |
-| `funders` | Funding organization names |
-| `oa_status` | Open access status string (e.g. `gold`, `green`, `hybrid`); also includes `is_oa` boolean |
-| `concepts` | List of `{"name": "...", "score": 0.95}` topic concepts |
-
-Results are cached for 30 days.
-
----
-
-## Papers — Citation Generation
-
-### `generate_citations`
-
-Generate formatted citations for one or more papers. Resolves papers via Semantic Scholar, optionally enriches with OpenAlex metadata, and formats as BibTeX, CSL-JSON, or RIS.
-
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `paper_ids` | list[string] | *(required)* | Paper identifiers (S2 IDs, DOIs, arXiv IDs, etc.). Max 100. |
-| `citation_format` | string | `"bibtex"` | Output format: `bibtex`, `csl-json`, or `ris` |
-| `enrich` | boolean | `true` | Attempt OpenAlex enrichment for missing venue data |
-
-**BibTeX output** includes entry type inference (`@article`, `@inproceedings`, `@misc`, `@book`), proper author formatting (`{Last}, First`), title casing preservation, DOI, arXiv eprint fields, and special character escaping. Papers with `book_metadata` (ISBN or publisher) are emitted as `@book` entries with `publisher`, `edition`, and `isbn` fields.
-
-**CSL-JSON output** returns `{"citations": [...], "errors": [...]}` -- the citations array contains standard CSL-JSON objects compatible with Zotero, Mendeley, Pandoc, and other CSL processors. Book entries use `type: "book"` with `publisher` and `ISBN` fields.
-
-**RIS output** uses standard RIS tags (`TY`, `AU`, `TI`, `PY`, `JO`/`BT`, `DO`, `UR`, `AB`, `ER`). Book entries use `TY - BOOK` with `PB` (publisher) and `SN` (ISBN) tags.
-
-Papers that fail to resolve are reported inline (BibTeX/RIS: as comments, CSL-JSON: in the errors array) rather than failing the entire request. When all papers fail, a structured error is returned: `{"error": "no_papers_resolved", "failed": [...]}`.
-
-!!! tip "Enrichment"
-    When `enrich` is enabled and a paper has no venue but has a DOI, the tool queries OpenAlex to fill in the venue name. This improves citation quality for papers where Semantic Scholar has incomplete metadata.
 
 ---
 
@@ -500,6 +502,24 @@ Find patents that cite a given academic paper. Coverage is incomplete -- relies 
 
 !!! warning "Incomplete coverage"
     Not all patent-to-paper citations are captured by EPO OPS. Use this tool for discovery, not exhaustive analysis.
+
+---
+
+### `fetch_patent_pdf`
+
+Download a patent PDF via authenticated EPO OPS and optionally convert to Markdown.
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `patent_number` | string | *(required)* | Patent number in any format (e.g. `EP3491801B1`, `US10123456B2`, `WO2024/123456`) |
+| `use_vlm` | bool | `false` | Enable VLM enrichment for formulas and figures |
+
+**Returns:** `{"pdf_path": "/data/scholar-mcp/pdfs/<stem>.pdf", "markdown": "...", "md_path": "/data/scholar-mcp/md/<stem>.md"}` when docling is configured, or just `{"pdf_path": "..."}` without it.
+
+Not all patents have full text available via OPS — WO and older EP patents sometimes lack PDFs. Returns `{"error": "pdf_not_available"}` in that case.
+
+!!! note "Write-tagged"
+    This tool is write-tagged and hidden when `SCHOLAR_MCP_READ_ONLY=true`. It also requires EPO OPS credentials.
 
 ---
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -1,6 +1,9 @@
 # Tools
 
-Scholar MCP provides 25 tools across ten categories. All tools return JSON.
+Scholar MCP provides 27 tools organised by scholarly source type: **Papers**, **Patents**, **Books**, and **Standards** are peer source domains; the remaining sections (Utility, PDF Conversion, Task Polling) are cross-cutting. All tools return JSON.
+
+!!! info "Coverage by domain"
+    Per-domain depth is uneven — papers currently have the richest tool surface (citation graph, recommendations, cross-referencing to all three other domains); standards are the leanest. That reflects public data availability, not a value hierarchy. Parity work is tracked in [GitHub issues](https://github.com/pvliesdonk/scholar-mcp/issues) and [milestones](https://github.com/pvliesdonk/scholar-mcp/milestones).
 
 All tools include [MCP tool annotations](https://spec.modelcontextprotocol.io/specification/2025-03-26/server/tools/#annotations):
 
@@ -23,7 +26,7 @@ When a tool queues an operation, it returns:
 
 Poll with `get_task_result` to check status and retrieve the result. Task results expire after 10 minutes (S2 tools) or 1 hour (PDF tools).
 
-## Search & Retrieval
+## Papers — Search & Retrieval
 
 ### `search_papers`
 
@@ -83,7 +86,7 @@ Fetch an author profile or search by name.
 
 ---
 
-## Citation Graph
+## Papers — Citation Graph
 
 ### `get_citations`
 
@@ -184,7 +187,7 @@ Or `{"found": false}` if no path exists within `max_depth`.
 
 ---
 
-## Recommendations
+## Papers — Recommendations
 
 ### `recommend_papers`
 
@@ -204,7 +207,7 @@ Paper recommendations based on positive (and optional negative) examples.
 
 ---
 
-## Book Search
+## Books
 
 Book tools use [Open Library](https://openlibrary.org/) as their data source. No API key is required. Rate limits are handled automatically; if the Open Library API is temporarily unavailable, calls queue and return a task ID (see [Async Task Queue](#async-task-queue)).
 
@@ -354,7 +357,7 @@ Results are cached for 30 days.
 
 ---
 
-## Citation Generation
+## Papers — Citation Generation
 
 ### `generate_citations`
 
@@ -379,7 +382,7 @@ Papers that fail to resolve are reported inline (BibTeX/RIS: as comments, CSL-JS
 
 ---
 
-## Patent Search
+## Patents
 
 !!! note "Credentials required"
     Patent tools require EPO OPS credentials. When `SCHOLAR_MCP_EPO_CONSUMER_KEY` and `SCHOLAR_MCP_EPO_CONSUMER_SECRET` are not set, these tools are automatically hidden. See [EPO OPS configuration](../configuration.md#epo-open-patent-services) for setup instructions.
@@ -497,6 +500,46 @@ Find patents that cite a given academic paper. Coverage is incomplete -- relies 
 
 !!! warning "Incomplete coverage"
     Not all patent-to-paper citations are captured by EPO OPS. Use this tool for discovery, not exhaustive analysis.
+
+---
+
+## Standards
+
+Scholar MCP supports Tier 1 standards bodies (NIST, IETF, W3C, ETSI) with full metadata and
+optional full-text conversion. Tier 2 paywalled bodies (ISO, IEC, IEEE) are tracked in
+[GitHub issues](https://github.com/pvliesdonk/scholar-mcp/issues).
+
+### `resolve_standard_identifier`
+
+Normalise a messy citation string to its canonical form and body.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `raw` | string | — | Messy citation string (e.g. `"rfc9000"`, `"nist 800-53"`) |
+
+---
+
+### `search_standards`
+
+Search standards by identifier, title, or free text.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `query` | string | — | Identifier, title, or free text |
+| `body` | string | null | Filter to one body: `NIST`, `IETF`, `W3C`, `ETSI` |
+| `limit` | integer | 10 | Max results (max 50) |
+
+---
+
+### `get_standard`
+
+Retrieve a standard by identifier (canonical or fuzzy). Optionally fetches and converts
+full text via docling.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `identifier` | string | — | Canonical or fuzzy identifier |
+| `fetch_full_text` | boolean | false | Fetch and convert full text via docling |
 
 ---
 
@@ -639,38 +682,3 @@ The `hint` field gives expected duration — keep polling until the task complet
 List all active (non-expired) background tasks.
 
 **Returns:** JSON list of `{"task_id": "...", "status": "..."}` dicts.
-
----
-
-## Standards
-
-Scholar MCP supports Tier 1 standards bodies (NIST, IETF, W3C, ETSI) with full metadata and
-optional full-text conversion. Tier 2 paywalled bodies (ISO, IEC, IEEE) are planned for v0.9.0.
-
-### `search_standards`
-
-Search standards by identifier, title, or free text.
-
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `query` | string | — | Identifier, title, or free text |
-| `body` | string | null | Filter to one body: `NIST`, `IETF`, `W3C`, `ETSI` |
-| `limit` | integer | 10 | Max results (max 50) |
-
-### `get_standard`
-
-Retrieve a standard by identifier (canonical or fuzzy). Optionally fetches and converts
-full text via docling.
-
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `identifier` | string | — | Canonical or fuzzy identifier |
-| `fetch_full_text` | boolean | false | Fetch and convert full text via docling |
-
-### `resolve_standard_identifier`
-
-Normalise a messy citation string to its canonical form and body.
-
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `raw` | string | — | Messy citation string (e.g. `"rfc9000"`, `"nist 800-53"`) |

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.pvliesdonk/scholar-mcp",
   "title": "Scholar MCP Server",
-  "description": "Academic literature search, citation graphs, and PDF conversion via Semantic Scholar.",
+  "description": "Scholarly-sources MCP server for papers, patents, books, and standards — search, cross-reference, and retrieve prior art across Semantic Scholar, EPO OPS, Open Library, and standards bodies.",
   "version": "1.6.0",
   "repository": {
     "url": "https://github.com/pvliesdonk/scholar-mcp",


### PR DESCRIPTION
## Summary

- Reframes papers, patents, books, and standards as peer source domains of the scholarly citation landscape, not a paper product with sidecars.
- Fixes stale tool counts (19 / 25 → 27) across README, docs/index.md, and docs/tools/index.md.
- Reorders the tool reference so Papers / Patents / Books / Standards are peer top-level sections; Standards moves up from dead-last to its natural slot between Patents and PDF Conversion.
- Adds the missing Standards block to README.
- Updates server.json description to match the new framing.
- Roadmap pointer is GitHub issues + milestones, not a separate doc — per-domain depth is real but is roadmap work, not a value hierarchy.
- No code or behavior changes.

Closes #110.

## Stack

- Stacked on [#112](https://github.com/pvliesdonk/scholar-mcp/pull/112) (fork codecov fix). Retarget to main once #112 merges.
- Next in the stack will be PR 3 (Claude Code plugin + mcpb bundle port, #106).

## Test plan

- [x] `uv run pytest -x -q` — 682 passed
- [x] `uv run ruff check --fix . && uv run ruff format . && uv run ruff format --check .` clean
- [x] `uv run mypy src/` clean
- [ ] Render docs locally to confirm the tool table + architecture diagram look right (reviewer's call)

🤖 Generated with [Claude Code](https://claude.com/claude-code)