### PR TITLE
feat(ci): add prerelease mode to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,13 @@ on:
           - minor
           - major
       prerelease:
-        description: 'Create a pre-release (rc channel — skips PyPI, catalog, registry, linux packages). Uncheck to cut a real release.'
+        description: 'Create a pre-release (skips PyPI, catalog, registry, linux packages). Uncheck to cut a real release.'
         type: boolean
         default: true
+      prerelease_token:
+        description: 'Pre-release channel token (default: rc)'
+        type: string
+        default: rc
 
 permissions:
   contents: read
@@ -56,7 +60,7 @@ jobs:
           git_committer_email: "actions@users.noreply.github.com"
           force: ${{ inputs.force }}
           prerelease: ${{ inputs.prerelease }}
-          prerelease_token: rc
+          prerelease_token: ${{ inputs.prerelease_token || 'rc' }}
 
       - name: Update versioned manifests to released version
         if: steps.release.outputs.released == 'true' && !inputs.prerelease

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,10 @@ on:
           - patch
           - minor
           - major
+      prerelease:
+        description: 'Create a pre-release (rc channel — skips PyPI, catalog, registry, linux packages). Uncheck to cut a real release.'
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -51,9 +55,11 @@ jobs:
           git_committer_name: "github-actions"
           git_committer_email: "actions@users.noreply.github.com"
           force: ${{ inputs.force }}
+          prerelease: ${{ inputs.prerelease }}
+          prerelease_token: rc
 
       - name: Update versioned manifests to released version
-        if: steps.release.outputs.released == 'true'
+        if: steps.release.outputs.released == 'true' && !inputs.prerelease
         env:
           VERSION: ${{ steps.release.outputs.version }}
         run: |
@@ -145,7 +151,7 @@ jobs:
 
   publish-pypi:
     needs: release
-    if: needs.release.outputs.released == 'true'
+    if: needs.release.outputs.released == 'true' && !inputs.prerelease
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -218,10 +224,11 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=latest
             type=raw,value=v${{ steps.version.outputs.version }}
-            type=raw,value=v${{ steps.version.outputs.minor }}
-            type=raw,value=v${{ steps.version.outputs.major }}
+            type=raw,value=latest,enable=${{ !inputs.prerelease }}
+            type=raw,value=v${{ steps.version.outputs.minor }},enable=${{ !inputs.prerelease }}
+            type=raw,value=v${{ steps.version.outputs.major }},enable=${{ !inputs.prerelease }}
+            type=raw,value=unstable,enable=${{ inputs.prerelease }}
           labels: |
             org.opencontainers.image.title=scholar-mcp
             org.opencontainers.image.description=FastMCP server for Semantic Scholar with OpenAlex enrichment and docling PDF conversion
@@ -266,7 +273,7 @@ jobs:
 
   publish-linux-packages:
     needs: release
-    if: needs.release.outputs.released == 'true'
+    if: needs.release.outputs.released == 'true' && !inputs.prerelease
     runs-on: ubuntu-latest
 
     permissions:
@@ -378,7 +385,7 @@ jobs:
 
   publish-claude-plugin-pr:
     needs: release
-    if: needs.release.outputs.released == 'true'
+    if: needs.release.outputs.released == 'true' && !inputs.prerelease
     runs-on: ubuntu-latest
     steps:
       - name: Checkout catalog repo
@@ -426,7 +433,7 @@ jobs:
 
   publish-registry:
     needs: [release, publish-pypi, publish-docker]
-    if: needs.release.outputs.released == 'true'
+    if: needs.release.outputs.released == 'true' && !inputs.prerelease
     runs-on: ubuntu-latest
 
     permissions:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -39,10 +39,11 @@ docker run -v scholar-mcp-data:/data/scholar-mcp \
 
 The image is available for `linux/amd64` and `linux/arm64`. See [Docker deployment](deployment/docker.md) for Docker Compose with docling-serve.
 
-For early adopters who want to test unreleased changes, an `:unstable` tag is published by the release workflow's pre-release mode. It tracks the latest release candidate and may include in-progress features. The floating `:latest`, `:vN`, and `:vN.M` tags only move on stable releases.
+For early adopters who want to try the latest release candidate, an `:unstable` tag is published by the release workflow's pre-release mode. It tracks the latest `rc` build and may include in-progress features. Pre-releases are Docker-only — they are not published to PyPI or as Linux packages. The floating `:latest`, `:vN`, and `:vN.M` tags only move on stable releases.
 
 ```bash
-docker pull ghcr.io/pvliesdonk/scholar-mcp:unstable
+docker run -v scholar-mcp-data:/data/scholar-mcp \
+           ghcr.io/pvliesdonk/scholar-mcp:unstable
 ```
 
 ## Linux packages

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -39,6 +39,12 @@ docker run -v scholar-mcp-data:/data/scholar-mcp \
 
 The image is available for `linux/amd64` and `linux/arm64`. See [Docker deployment](deployment/docker.md) for Docker Compose with docling-serve.
 
+For early adopters who want to test unreleased changes, an `:unstable` tag is published by the release workflow's pre-release mode. It tracks the latest release candidate and may include in-progress features. The floating `:latest`, `:vN`, and `:vN.M` tags only move on stable releases.
+
+```bash
+docker pull ghcr.io/pvliesdonk/scholar-mcp:unstable
+```
+
 ## Linux packages
 
 Download `.deb` or `.rpm` from the [latest release](https://github.com/pvliesdonk/scholar-mcp/releases/latest):


### PR DESCRIPTION
## Summary

- Add a `prerelease` boolean input to `release.yml`'s `workflow_dispatch` (defaults to `true` -- real releases are now an explicit opt-in)
- Thread `prerelease` through to `python-semantic-release@v10.5.3` with `prerelease_token: rc`, producing `vX.Y.Z-rc.N` tags marked as GitHub Pre-releases
- Skip `publish-pypi`, `publish-linux-packages`, `publish-claude-plugin-pr`, `publish-registry`, and the manifest-bump step on pre-release
- Conditional Docker tags via `docker/metadata-action`'s native `enable=` modifier: pre-release pushes `:unstable` + `:vX.Y.Z-rc.N` only; floating stable tags (`:latest`, `:vN.M`, `:vN`) never move on a pre-release
- `build-mcpb` / `publish-mcpb` run unchanged in both modes -- the mcpb bundle reads its version from `needs.release.outputs.version` via `envsubst`, so no committed manifest is needed
- `docs/installation.md` mentions the `:unstable` Docker tag

Port of MV#353.

Closes #108

## Test plan

- [ ] CI passes on this PR
- [ ] Dispatch with `prerelease: true` (default): `vX.Y.Z-rc.N` tag, Pre-release with `.mcpb` + SBOM, Docker `:unstable` + `:vX.Y.Z-rc.N` only, PyPI/linux/catalog/registry skipped
- [ ] Dispatch with `prerelease: false`: normal release behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)