### PR TITLE
feat(standards): v0.9.0 PR 3/5 — IEEE Relaton loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A [FastMCP](https://github.com/jlowin/fastmcp) server for the scholarly citation
 - **Papers** -- full-text search with year/venue/field/citation filters; single-paper lookup by DOI, S2 ID, arXiv ID, ACM ID, or PubMed ID; author profile and name search; forward citations, backward references, BFS graph traversal, shortest-path bridge discovery; recommendations from positive/negative examples; BibTeX/CSL-JSON/RIS citation generation with OpenAlex venue enrichment.
 - **Patents** -- search across 100+ patent offices via EPO OPS with CPC/applicant/inventor/jurisdiction filters; bibliographic, claims, description, family, legal, and citations sections; NPL-to-paper resolution via Semantic Scholar and paper-to-patent citation discovery. EPO credentials are optional -- other domains work without them.
 - **Books** -- search by title/author/keywords via Open Library (no API key required); lookup by ISBN-10/13, Open Library work ID, or edition ID; subject-based recommendations sorted by popularity; Google Books excerpts and preview links; WorldCat permalinks for library discovery; cover image caching. Papers with an ISBN in `externalIds` are automatically enriched with publisher, edition, cover URL, and subject data from Open Library.
-- **Standards** -- identifier resolution, search, and metadata retrieval for NIST, IETF, W3C, and ETSI standards, with optional full-text fetch and Markdown conversion via docling. Tier 2 ISO and IEC metadata is now synced locally from Relaton YAML dumps via `sync-standards`, with a live-fetch fallback for unsynced identifiers (see [docs/guides/standards.md](docs/guides/standards.md)). IEEE remains tracked in [GitHub issues](https://github.com/pvliesdonk/scholar-mcp/issues).
+- **Standards** -- identifier resolution, search, and metadata retrieval for NIST, IETF, W3C, and ETSI standards, with optional full-text fetch and Markdown conversion via docling. Tier 2 ISO, IEC, and IEEE metadata (including joint standards such as ISO/IEC/IEEE) is synced locally from Relaton YAML dumps via `sync-standards`, with a live-fetch fallback for unsynced identifiers (see [docs/guides/standards.md](docs/guides/standards.md)).
 
 ### Cross-cutting
 
@@ -120,9 +120,10 @@ from community-curated bulk dumps rather than live-scraped at MCP-server
 runtime. Run the sync on first install and periodically thereafter:
 
 ```bash
-scholar-mcp sync-standards            # all bodies
-scholar-mcp sync-standards --body ISO # single body
-scholar-mcp sync-standards --force    # bypass incremental checks
+scholar-mcp sync-standards            # all registered bodies
+scholar-mcp sync-standards --body ISO # only ISO
+scholar-mcp sync-standards --body IEEE # only IEEE
+scholar-mcp sync-standards --force    # re-sync even if upstream SHA is unchanged
 ```
 
 Schedule via cron / launchd / systemd timer — weekly is sufficient;
@@ -244,7 +245,7 @@ All settings are controlled via environment variables with the `SCHOLAR_MCP_` pr
 | `search_standards` | Search standards by identifier, title, or free text, optionally filtered to one body (`NIST`, `IETF`, `W3C`, `ETSI`). |
 | `get_standard` | Retrieve a standard by canonical or fuzzy identifier, optionally fetching and converting the full text via docling. |
 
-> Tier-1 bodies (NIST, IETF, W3C, ETSI) are supported with full metadata and optional full-text conversion. Tier-2 paywalled bodies (ISO, IEC, IEEE) are tracked in [GitHub issues](https://github.com/pvliesdonk/scholar-mcp/issues).
+> Tier-1 bodies (NIST, IETF, W3C, ETSI) are supported with full metadata and optional full-text conversion. Tier-2 bodies (ISO, IEC, IEEE) are populated locally via `scholar-mcp sync-standards`; CEN/CENELEC and Common Criteria remain tracked in [GitHub issues](https://github.com/pvliesdonk/scholar-mcp/issues).
 
 ### Cross-source Utility
 

--- a/docs/guides/standards.md
+++ b/docs/guides/standards.md
@@ -1,15 +1,17 @@
-# Tier 2 standards sync -- ISO & IEC
+# Tier 2 standards sync -- ISO, IEC & IEEE
 
-Scholar MCP caches ISO and IEC standards metadata locally. The source of truth is the
-community-maintained Relaton YAML dumps at
-[`relaton/relaton-data-iso`](https://github.com/relaton/relaton-data-iso)
-and [`relaton/relaton-data-iec`](https://github.com/relaton/relaton-data-iec).
+Scholar MCP caches ISO, IEC, and IEEE standards metadata locally. The source of truth
+is the community-maintained Relaton YAML dumps at
+[`relaton/relaton-data-iso`](https://github.com/relaton/relaton-data-iso),
+[`relaton/relaton-data-iec`](https://github.com/relaton/relaton-data-iec), and
+[`relaton/relaton-data-ieee`](https://github.com/relaton/relaton-data-ieee).
 
 ## Running a sync
 
 ```
 scholar-mcp sync-standards            # all registered bodies
 scholar-mcp sync-standards --body ISO # only ISO
+scholar-mcp sync-standards --body IEEE # only IEEE
 scholar-mcp sync-standards --force    # re-sync even if upstream SHA is unchanged
 ```
 
@@ -103,3 +105,24 @@ FROM standards
 WHERE source IS NOT NULL
 GROUP BY source;
 ```
+
+## IEEE
+
+IEEE metadata comes from the [`relaton/relaton-data-ieee`](https://github.com/relaton/relaton-data-ieee) repository.
+
+### Supported identifier forms
+
+- `IEEE 1003.1-2024`, `IEEE 802.11-2020` — plain IEEE standards
+- `IEEE Std 1588-2019` — the `Std` token is accepted (upstream convention)
+- `IEC/IEEE 61588-2021` — joint standards hosted in the IEEE repo
+- `ISO/IEC/IEEE 42010-2011` — triple-joint standards (ISO + IEC + IEEE committees)
+
+For joint standards the stored `body` field reflects the true joint nature (e.g. `"ISO/IEC/IEEE"`), while dispatch still routes through the `"IEEE"` fetcher key. Per-body filename conventions differ between repositories: ISO/IEC use lowercase-hyphen (`iso-9001-2015.yaml`), IEEE uses uppercase-underscore (`IEEE_1003.1-2024.yaml`, `ISO_IEC_IEEE_42010-2011.yaml`).
+
+### Not yet supported (filed follow-ups)
+
+- `ANSI/IEEE Std 754-1985` and other historical ANSI-co-branded identifiers — see [#127](https://github.com/pvliesdonk/scholar-mcp/issues/127)
+- `AIEE 11-1937` and other pre-IEEE AIEE identifiers — see [#127](https://github.com/pvliesdonk/scholar-mcp/issues/127)
+- `IEEE P802.11-REVme` unpublished drafts — see [#128](https://github.com/pvliesdonk/scholar-mcp/issues/128)
+- Explicit `body="IEC/IEEE"` / `body="ISO/IEC/IEEE"` search dispatch — see [#129](https://github.com/pvliesdonk/scholar-mcp/issues/129). Today, use identifier lookup or `body="IEEE"` which returns joints too.
+- IEEE Xplore authenticated full-text — see [#92](https://github.com/pvliesdonk/scholar-mcp/issues/92)

--- a/docs/specs/2026-04-15-pr3-ieee-design.md
+++ b/docs/specs/2026-04-15-pr3-ieee-design.md
@@ -1,0 +1,220 @@
+# PR 3 — IEEE Relaton Loader (v0.9.0 standards rollout)
+
+**Date:** 2026-04-15
+**Closes:** scholar-mcp#82 (IEEE Tier 2 metadata lookup)
+**Builds on:** scholar-mcp#122 (PR 2: ISO + IEC Relaton loaders), scholar-mcp#121 (PR 1: sync infrastructure)
+**Follow-ups filed:** scholar-mcp#127, scholar-mcp#128, scholar-mcp#129 (see "Out of scope")
+
+## Context
+
+PR 2's design called PR 3 "a trivial config addition once PR 2's `RelatonLoader` ships." While verifying that premise against the real `relaton/relaton-data-ieee` GitHub repository, two pre-existing defects and one fresh requirement surfaced that enlarge the scope beyond a config-only change. This spec captures the combined work.
+
+## Summary
+
+Ship IEEE as a fully-functional Tier 2 Relaton body — both the bulk-sync path (`sync-standards --body IEEE`) and the live-fetch fallback. Fix the pre-existing `docid` / `docidentifier` schema-key mismatch that silently breaks live-fetching of real ISO/IEC standards today, and add a per-body slug-convention strategy so IEEE's `UPPERCASE_UNDERSCORED.yaml` filenames resolve correctly alongside ISO's `lowercase-hyphenated.yaml` form.
+
+## In Scope
+
+1. **IEEE added as a Relaton body.** `_RELATON_CONFIGS["IEEE"]` points at `relaton/relaton-data-ieee`. `StandardsClient._fetchers["IEEE"]` registers a `RelatonLiveFetcher(source="IEEE")` instance. `_select_loaders` in `cli.py` accepts `--body IEEE` and `all` includes IEEE.
+2. **Joint-committee identifiers parsed and stored.** Standards whose `docid` list contains both ISO and IEEE entries produce `body="ISO/IEC/IEEE"`; IEC + IEEE produces `body="IEC/IEEE"`. Existing ISO/IEC joint handling unchanged. Dispatch remains single-key (`"IEEE"`) — joints reachable via identifier lookup or `body="IEEE"` since they share `source="IEEE"`.
+3. **Relaton schema-key fix (pre-existing bug).** `_sync_relaton.py` currently reads `doc.get("docidentifier")`, but real relaton repos expose the top-level key as `docid:`. Unit tests use the old-shape fixtures, so the bug was latent. Fix: `doc.get("docid") or doc.get("docidentifier")`. Apply the same fallback to `bibitem.get(...)` alias paths.
+4. **Per-body slug-convention strategy.** ISO/IEC keep their existing `lowercase-hyphenated.yaml` slug. IEEE produces `UPPERCASE_UNDERSCORED.yaml` (preserving dots and intra-token hyphens): `IEEE 1003.1-2024` → `IEEE_1003.1-2024.yaml`; `ISO/IEC/IEEE 42010-2011` → `ISO_IEC_IEEE_42010-2011.yaml`.
+5. **Trademark-scope filtering.** IEEE `docid` entries often include a trademark variant (`scope: trademark`, identifier contains `™`). These are skipped when picking the canonical identifier.
+6. **Live-smoke test marker.** Introduce pytest `-m live` marker (configured in `pyproject.toml`, not run in CI by default) so one targeted live-fetch test against real GitHub raw URLs catches future schema drift early. Otherwise the `docid`-style bug would have recurred silently.
+
+## Out of Scope
+
+Filed as follow-ups:
+
+- **scholar-mcp#127** — ANSI/IEEE and AIEE historical identifier forms (`ANSI/IEEE Std 754-1985`, `AIEE 11-1937`). Still reachable via all-bodies fallback.
+- **scholar-mcp#128** — IEEE P-prefixed draft identifiers (`IEEE P802.11-REVme`). Separate question about whether `sync-standards` should include drafts at all.
+- **scholar-mcp#129** — Explicit `_fetchers["IEC/IEEE"]` / `_fetchers["ISO/IEC/IEEE"]` dispatch keys. Would require body-column filtering in `search_synced_standards`. Current workaround: `body="IEEE"` returns joints too.
+
+Pre-existing, unchanged:
+
+- **scholar-mcp#92** — IEEE Xplore authenticated full-text path.
+
+Explicitly **not** doing:
+
+- Price field population (all Tier 2 records carry `price=None` per Tier 2 design).
+- Citation formatting for `StandardRecord` (F4 future).
+- Any cache schema migration (existing columns are sufficient).
+
+## Design Decisions
+
+### Schema-key fix applies to all Relaton bodies, not just IEEE
+
+The `docid` / `docidentifier` mismatch was latent because unit tests use `docidentifier:` fixtures and no live smoke test existed. Fixing it in this PR rather than filing a separate bug PR:
+
+- The fix is one-liner with an `or` fallback (`doc.get("docid") or doc.get("docidentifier")`) — no behavior change for fixtures or any existing consumer.
+- PR 3 touches the same function (`_yaml_to_record`) to add IEEE/joint handling. Splitting the schema-key fix into its own PR means two review rounds on the same function.
+- Without the fix, PR 3's IEEE loader would also produce stubs, not full records — the feature would not actually work end-to-end.
+
+### `body` reflects joint nature; dispatch stays single-key
+
+A joint standard like `ISO/IEC/IEEE 42010-2011` stores with `body="ISO/IEC/IEEE"` and `source="IEEE"`. This mirrors PR 2's ISO/IEC policy (`body` describes the standard, `source` describes the loader that wrote it).
+
+Dispatch keys, however, stay at `"IEEE"` only. Joint-bodies don't get their own `_fetchers` entries. Rationale:
+
+- Callers who type a full joint identifier (`ISO/IEC/IEEE 42010-2011`) go through `resolve_identifier_local` → body-prefix match → dispatches to `_fetchers["IEEE"]` which covers the IEEE repo.
+- Callers who search by `body="IEEE"` get IEEE-primary + all joints (both share `source="IEEE"`), which is usually what they want.
+- Callers who want to filter to only triple-joints or only IEC/IEEE joints can filter client-side, or wait for scholar-mcp#129.
+- Adding dispatch keys would require body-column filtering in `search_synced_standards`; the current API only supports `source`-column filtering. That's a bigger schema-query change than this PR warrants.
+
+**Two different `body` values flow through the system — do not confuse them:**
+
+| Where | Value | Purpose |
+|---|---|---|
+| `resolve_identifier_local` return tuple | `"IEEE"` (even for `IEC/IEEE` and `ISO/IEC/IEEE` identifiers) | Dispatch key — must match a `_fetchers` entry |
+| `StandardRecord.body` on the returned / stored row | `"IEEE"`, `"IEC/IEEE"`, or `"ISO/IEC/IEEE"` | Accurate metadata — describes the standard's true joint nature |
+
+Concretely: `resolve_identifier_local("ISO/IEC/IEEE 42010-2011")` returns `("ISO/IEC/IEEE 42010-2011", "IEEE")` — the canonical identifier preserves the joint form, but the dispatch body is flattened to `"IEEE"`. The resulting record has `body="ISO/IEC/IEEE"` because `_canonical_identifier_and_body` inspects the full `docid` list and detects the joint nature.
+
+The existing PR 2 behavior is untouched: `resolve_identifier_local("ISO/IEC 27001:2022")` still returns body `"ISO/IEC"` because `_fetchers["ISO/IEC"]` exists as a dispatch key.
+
+### Per-body slug-convention dispatch, not regex
+
+`_identifier_to_relaton_slug` becomes a dispatcher on identifier prefix:
+
+- `ISO` / `IEC` / `ISO/IEC` → existing lowercase-hyphen logic (unchanged).
+- `IEEE` / `IEC/IEEE` / `ISO/IEC/IEEE` → new uppercase-underscore logic (preserving `.` and `-` inside tokens).
+
+This reads more clearly than a unified regex with many branches and keeps the ISO/IEC path byte-identical to PR 2 (zero regression risk). The function remains single-purpose; a switch on prefix is the right level of abstraction.
+
+### Trademark entries are docid-level, not record-level
+
+An IEEE `docid` list typically contains two `primary: true` entries — one canonical identifier (`IEEE 1003.1-2024`) and one trademark variant (`IEEE 1003.1-2024™`, `scope: trademark`). Both are flagged primary. The canonical-picking logic filters out `scope: trademark` entries before picking the primary. The record itself is still emitted; only the trademark identifier variant is discarded.
+
+Alias entries (non-primary) keep their trademark variants recorded as aliases — useful for fuzzy lookup from a raw citation string that happens to include `™`.
+
+### Fallback order for joint standards
+
+Live-fetch of `ISO/IEC/IEEE 42010-2011` tries the IEEE repo first (confirmed host), then ISO, then IEC. `IEC/IEEE` tries IEEE first, then IEC. Rationale: the IEEE repo is the canonical publisher of these joints in the Relaton ecosystem. ISO and IEC repos may contain copies for cross-reference but aren't authoritative.
+
+Existing pure-ISO and pure-IEC ordering unchanged.
+
+## Module Changes
+
+| File | Change |
+|---|---|
+| `src/scholar_mcp/_sync_relaton.py` | `docid`/`docidentifier` fallback in 3 call sites; `_RELATON_CONFIGS["IEEE"]`; `_canonical_identifier_and_body` extended for IEEE and joint detection; trademark-scope filter in canonical picker |
+| `src/scholar_mcp/_relaton_live.py` | `_identifier_to_relaton_slug` dispatches on prefix to lowercase-hyphen (ISO/IEC) vs. uppercase-underscore (IEEE) logic; `_identifier_prefers_*` helpers extended; repo-order helper accounts for IEEE preference |
+| `src/scholar_mcp/_standards_client.py` | `_fetchers["IEEE"] = RelatonLiveFetcher(http, cache=cache, source="IEEE")`; `resolve_identifier_local` regex groups for `IEEE`, `IEEE Std`, `IEC/IEEE`, `ISO/IEC/IEEE` |
+| `src/scholar_mcp/cli.py` | `_select_loaders` supports `--body IEEE`; `--body all` includes IEEE |
+| `pyproject.toml` | Register pytest `live` marker |
+| `README.md` | IEEE added to supported standards body list + example identifier |
+| `docs/guides/standards.md` | IEEE section: identifier forms, sync example, joint-standards note |
+
+No changes to: `_cache.py`, `_protocols.py`, `_server_deps.py`, `_server_tools.py`.
+
+## Data Flow
+
+### Sync
+
+```
+cli._select_loaders({"IEEE"})
+  → RelatonLoader(body="IEEE", config=_RELATON_CONFIGS["IEEE"])
+      → fetch commit SHA → incremental-check vs. last sync
+      → list data/*.yaml, diff against cache (source="IEEE")
+      → per-file:
+          _yaml_to_record(doc):
+              docid = doc.get("docid") or doc.get("docidentifier") or []
+              canonical = _canonical_identifier_and_body(docid)
+                  - filters scope=trademark entries
+                  - detects joint nature from type presence (ISO/IEC/IEEE)
+              → StandardRecord(body=..., source="IEEE", synced_at=now)
+          cache.upsert_standards([record], source="IEEE", synced=True)
+      → cache.record_sync_run("IEEE", added=N, updated=M, withdrawn=K)
+      → cache.mark_withdrawn(in_cache - in_repo, source="IEEE")
+```
+
+### Live fetch
+
+```
+RelatonLiveFetcher(source="IEEE").get("IEEE 1003.1-2024")
+  → slug = _identifier_to_relaton_slug("IEEE 1003.1-2024") = "IEEE_1003.1-2024"
+  → repos = ["relaton-data-ieee"]  (plus ISO/IEC for joint identifiers)
+  → for each repo:
+      GET raw.githubusercontent.com/relaton/{repo}/main/data/{slug}.yaml
+      404 → next repo
+      5xx / parse error → log WARNING, next repo
+      200 + parsed → _yaml_to_record → return
+  → all repos fail → return stub StandardRecord(title="", full_text_available=False)
+```
+
+## Error Handling
+
+Per the Logging Standard in `CLAUDE.md`:
+
+- **Sync-path YAML parse errors** (one bad file): `logger.warning("relaton_yaml_parse_error file=%s err=%s", ...)`, skip file, increment `errors` counter.
+- **Sync-path HTTP errors on commit-SHA check**: `logger.error("relaton_sync_fetch_error body=%s err=%s", ...)`, body counted as failed; process exits 3 (partial) if other bodies succeeded, 1 if this was the only body.
+- **Canonical-identifier extraction misses** (no primary, all trademark-scoped, unparseable joint): `logger.debug("relaton_yaml_skip reason=%s", ...)`, skip record. Not an error.
+- **Live-fetch 404 in all repos**: return stub record. Caller surfaces canonical form even without metadata.
+- **Live-fetch transient errors**: `logger.warning` + fall through; stub returned on exhaustion.
+
+## Testing
+
+TDD throughout. Each feature commit has its failing test first.
+
+### `tests/test_sync_relaton.py` (parser/loader)
+
+- `test_yaml_to_record_reads_docid_key` — real-shape fixture with `docid:`, asserts full record parses (regression guard for the pre-existing bug).
+- `test_yaml_to_record_falls_back_to_docidentifier_key` — old-shape fixture still works.
+- `test_canonical_identifier_ieee_only` — `[{type: IEEE, primary: true}]` → `("IEEE X-YYYY", "IEEE")`.
+- `test_canonical_identifier_iec_ieee_joint` — IEC + IEEE entries → `("IEC/IEEE X-YYYY", "IEC/IEEE")`.
+- `test_canonical_identifier_iso_iec_ieee_joint` — ISO + IEC + IEEE entries → `("ISO/IEC/IEEE X-YYYY", "ISO/IEC/IEEE")`.
+- `test_canonical_identifier_ieee_skips_trademark_scope` — entries with `scope: trademark` are filtered before primary-picking.
+- `test_relaton_loader_ieee_smoke` — `RelatonLoader("IEEE", ...)` constructs, reports `body="IEEE"`.
+
+### `tests/test_relaton_live.py` (slug + live fetch)
+
+- `test_identifier_to_slug_ieee_plain` — `IEEE 1003.1-2024` → `IEEE_1003.1-2024`.
+- `test_identifier_to_slug_ieee_std_variant` — `IEEE Std 1588-2019` → `IEEE_Std_1588-2019`.
+- `test_identifier_to_slug_iec_ieee_joint` — `IEC/IEEE 61588-2021` → `IEC_IEEE_61588-2021`.
+- `test_identifier_to_slug_iso_iec_ieee_joint` — `ISO/IEC/IEEE 42010-2011` → `ISO_IEC_IEEE_42010-2011`.
+- `test_identifier_to_slug_preserves_iso_lowercase_hyphen` — `ISO 9001:2015` still → `iso-9001-2015` (regression guard).
+- `test_live_fetch_ieee_hit` — mocked 200 response parses to a full record with `body="IEEE"`.
+- `test_live_fetch_ieee_fallback_to_iso_for_joint` — `ISO/IEC/IEEE 42010-2011` IEEE-404 → ISO-200.
+
+### `tests/test_standards_client.py` (regex + dispatch)
+
+- `test_resolve_ieee_plain` — `resolve_identifier_local("IEEE 802.11-2020")` → `("IEEE 802.11-2020", "IEEE")`.
+- `test_resolve_ieee_std_variant` — `IEEE Std 1588-2019` accepted.
+- `test_resolve_iec_ieee_joint` — `IEC/IEEE 61588-2021` → `("IEC/IEEE 61588-2021", "IEC/IEEE")`. Dispatch key is `"IEEE"` but the body field is preserved.
+- `test_resolve_iso_iec_ieee_joint` — triple-joint resolves.
+- `test_standards_client_search_ieee_delegates_to_relaton` — mock cache, `search(body="IEEE")` → forwards `source="IEEE"`.
+- `test_standards_client_fetchers_ieee_instance_registered` — `_fetchers["IEEE"]` is `RelatonLiveFetcher` with `_source="IEEE"`.
+
+### `tests/test_cli_sync.py`
+
+- `test_select_loaders_accepts_ieee` — `--body IEEE` returns IEEE loader only.
+- `test_select_loaders_all_includes_ieee` — `--body all` returns ISO + IEC + IEEE.
+
+### Live smoke (pytest `-m live`, opt-in)
+
+- `test_live_fetch_ieee_1003_1_2024_real` — hits `raw.githubusercontent.com/relaton/relaton-data-ieee/main/data/IEEE_1003.1-2024.yaml`, asserts non-empty title and `body="IEEE"`.
+
+## PR Layout
+
+Single PR with ordered commits:
+
+1. `fix(standards): read docid key in relaton YAML, fall back to docidentifier` — includes the `pyproject.toml` pytest `live` marker registration and one ISO live-smoke test as the regression guard.
+2. `feat(standards): extend relaton parser for IEEE + joint-committee bodies`
+3. `feat(standards): IEEE slug strategy + repo dispatch in RelatonLiveFetcher` — includes the IEEE live-smoke test.
+4. `feat(standards): register IEEE in StandardsClient + CLI + RelatonConfig`
+5. `docs(standards): IEEE body in README and guides`
+
+Each commit green on `uv run pytest -x -q`, `uv run ruff check`, `uv run mypy src/`. No squash on merge — stacked commits ease review.
+
+## Acceptance Gates
+
+Per `CLAUDE.md` "Hard PR Acceptance Gates":
+
+- [ ] CI passes (all tests green)
+- [ ] `uv run ruff check --fix .` + `uv run ruff format .` clean
+- [ ] `uv run mypy src/` clean
+- [ ] Codecov patch coverage ≥ 80 %
+- [ ] `README.md` + `docs/guides/standards.md` updated in the same PR
+- [ ] PR description closes #82; references #127 / #128 / #129
+
+Manifest version bumps are handled by the release workflow; not included here.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,8 +111,11 @@ indent-style = "space"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = ["--strict-markers", "-ra"]
+addopts = ["--strict-markers", "-ra", "-m", "not live"]
 asyncio_mode = "auto"
+markers = [
+    "live: tests that hit real network services; opt-in via `pytest -m live`",
+]
 
 [tool.coverage.run]
 source = ["src/scholar_mcp"]

--- a/src/scholar_mcp/_relaton_live.py
+++ b/src/scholar_mcp/_relaton_live.py
@@ -58,7 +58,7 @@ def _identifier_to_relaton_slug(identifier: str) -> str | None:
     ):
         return _ieee_slug(stripped)
 
-    # ISO/IEC/IEC/ISO slugging (lowercase-hyphen) — PR 2 behavior.
+    # ISO / IEC / ISO/IEC slugging (lowercase-hyphen) — PR 2 behavior.
     if not (
         upper.startswith("ISO/IEC")
         or upper.startswith("ISO ")
@@ -77,7 +77,11 @@ def _identifier_to_relaton_slug(identifier: str) -> str | None:
 
 
 def _ieee_slug(identifier: str) -> str | None:
-    """IEEE filename slug: uppercase, underscores between tokens, dots kept.
+    """IEEE filename slug: underscores between tokens, dots and hyphens kept.
+
+    Input is assumed to be a canonical IEEE identifier with uppercase
+    body prefixes; callers routing from ``resolve_identifier_local`` already
+    satisfy this contract. The function does not recase the input.
 
     Examples:
         IEEE 1003.1-2024        → IEEE_1003.1-2024
@@ -93,8 +97,11 @@ def _ieee_slug(identifier: str) -> str | None:
 def _repo_order_for(identifier: str) -> list[str]:
     """Return the ordered list of relaton-data-* repos to probe.
 
-    The first repo that returns a parseable YAML wins. All 404s → stub
-    record.
+    The first repo whose YAML parses cleanly wins. All other outcomes
+    (404, non-404 error, unparseable YAML) are treated the same by
+    :meth:`RelatonLiveFetcher.get` — it moves on to the next repo. When
+    all repos exhaust without a parseable result, the caller returns a
+    stub record.
     """
     upper = identifier.strip().upper()
     if (
@@ -203,8 +210,9 @@ class RelatonLiveFetcher:
             if record is not None:
                 return record
 
-        # All repos 404 — return a stub so callers can surface
-        # "resolved but catalogue entry unavailable" rather than None.
+        # All repos exhausted without a parseable result — return a stub so
+        # callers can surface "resolved but catalogue entry unavailable"
+        # rather than None.
         upper = identifier.strip().upper()
         if upper.startswith("ISO/IEC/IEEE"):
             body = "ISO/IEC/IEEE"

--- a/src/scholar_mcp/_relaton_live.py
+++ b/src/scholar_mcp/_relaton_live.py
@@ -1,8 +1,12 @@
-"""Single-file live-fetch fallback for ISO / IEC / ISO/IEC identifiers.
+"""Single-file live-fetch fallback for ISO / IEC / IEEE Relaton standards.
 
 Used by :class:`StandardsClient` when ``get_standard(identifier)`` misses
 the cache AND no sync has been run. Avoids the "false negative until sync
 runs" trap by doing one cheap ``raw.githubusercontent.com`` GET per call.
+
+Covers pure ISO, IEC, IEEE plus their joint forms: ISO/IEC, IEC/IEEE,
+ISO/IEC/IEEE. Per-body filename conventions (ISO lowercase-hyphen vs.
+IEEE uppercase-underscore) are handled by :func:`_identifier_to_relaton_slug`.
 
 Lives alongside ``_sync_relaton.py``; the two modules share the same YAML
 mapper so synced and live-fetched records have identical shape.
@@ -29,22 +33,32 @@ _RAW_BASE = "https://raw.githubusercontent.com/relaton"
 
 
 def _identifier_to_relaton_slug(identifier: str) -> str | None:
-    """Convert an ISO, IEC, or ISO/IEC identifier to a Relaton filename slug.
+    """Convert an identifier to its Relaton filename slug.
 
-    Examples:
-        >>> _identifier_to_relaton_slug("ISO 9001:2015")
-        'iso-9001-2015'
-        >>> _identifier_to_relaton_slug("ISO/IEC 27001:2022")
-        'iso-iec-27001-2022'
-        >>> _identifier_to_relaton_slug("IEC 62443-3-3:2020")
-        'iec-62443-3-3-2020'
-        >>> _identifier_to_relaton_slug("ISO 9001:2015/Amd 1:2020")
-        'iso-9001-2015-amd-1-2020'
+    Dispatch on body prefix:
 
-    Returns ``None`` when the prefix is not one of ISO, IEC, or ISO/IEC.
+    - IEEE / IEC/IEEE / ISO/IEC/IEEE → uppercase-underscore form preserving
+      internal dots and intra-token hyphens
+      (``IEEE 1003.1-2024`` → ``IEEE_1003.1-2024``;
+       ``ISO/IEC/IEEE 42010-2011`` → ``ISO_IEC_IEEE_42010-2011``).
+    - ISO / IEC / ISO/IEC → lowercase-hyphen form (unchanged from PR 2).
+
+    Returns ``None`` when the prefix isn't recognized.
     """
     stripped = identifier.strip()
     upper = stripped.upper()
+
+    # IEEE slugging (uppercase-underscore) — check before ISO/IEC since
+    # ISO/IEC/IEEE and IEC/IEEE are IEEE-repo joints.
+    if (
+        upper.startswith("IEEE ")
+        or (upper.startswith("IEEE") and upper[4:5] in {" ", "_"})
+        or upper.startswith("IEC/IEEE")
+        or upper.startswith("ISO/IEC/IEEE")
+    ):
+        return _ieee_slug(stripped)
+
+    # ISO/IEC/IEC/ISO slugging (lowercase-hyphen) — PR 2 behavior.
     if not (
         upper.startswith("ISO/IEC")
         or upper.startswith("ISO ")
@@ -55,27 +69,56 @@ def _identifier_to_relaton_slug(identifier: str) -> str | None:
         return None
 
     slug = stripped.lower()
-    # Normalise "iso/iec" and the rarer reversed form before general substitution
     slug = slug.replace("iec/iso", "iso-iec")
     slug = slug.replace("iso/iec", "iso-iec")
-    # Any whitespace, colon, slash, or ampersand becomes a hyphen
     slug = re.sub(r"[\s:/&]+", "-", slug)
-    # Collapse repeated hyphens and strip leading/trailing
     slug = re.sub(r"-+", "-", slug).strip("-")
     return slug or None
 
 
-def _identifier_prefers_iec(identifier: str) -> bool:
-    """Plain 'IEC xxx' identifiers prefer the IEC repo first."""
+def _ieee_slug(identifier: str) -> str | None:
+    """IEEE filename slug: uppercase, underscores between tokens, dots kept.
+
+    Examples:
+        IEEE 1003.1-2024        → IEEE_1003.1-2024
+        IEEE Std 1588-2019      → IEEE_Std_1588-2019
+        IEC/IEEE 61588-2021     → IEC_IEEE_61588-2021
+        ISO/IEC/IEEE 42010-2011 → ISO_IEC_IEEE_42010-2011
+    """
+    slug = re.sub(r"[/\s]+", "_", identifier.strip())
+    slug = re.sub(r"_+", "_", slug).strip("_")
+    return slug or None
+
+
+def _repo_order_for(identifier: str) -> list[str]:
+    """Return the ordered list of relaton-data-* repos to probe.
+
+    The first repo that returns a parseable YAML wins. All 404s → stub
+    record.
+    """
     upper = identifier.strip().upper()
-    return upper.startswith("IEC ")
+    if (
+        upper.startswith("IEEE ")
+        or (upper.startswith("IEEE") and upper[4:5] in {" ", "_"})
+        or upper.startswith("IEC/IEEE")
+        or upper.startswith("ISO/IEC/IEEE")
+    ):
+        if upper.startswith("ISO/IEC/IEEE"):
+            return ["relaton-data-ieee", "relaton-data-iso", "relaton-data-iec"]
+        if upper.startswith("IEC/IEEE"):
+            return ["relaton-data-ieee", "relaton-data-iec"]
+        return ["relaton-data-ieee"]
+    if upper.startswith("IEC "):
+        return ["relaton-data-iec", "relaton-data-iso"]
+    return ["relaton-data-iso", "relaton-data-iec"]
 
 
 class RelatonLiveFetcher:
     """Fetches a single Relaton YAML file on demand over HTTPS.
 
     Registered into ``StandardsClient._fetchers`` for keys ``ISO``, ``IEC``,
-    and ``ISO/IEC``. Returns ``None`` for identifiers outside that set.
+    ``ISO/IEC``, and ``IEEE``. Returns ``None`` for identifiers the slug
+    helper can't convert (e.g. ``RFC 9000``).
     """
 
     def __init__(
@@ -152,12 +195,7 @@ class RelatonLiveFetcher:
         if slug is None:
             return None
 
-        repos = (
-            ["relaton-data-iec", "relaton-data-iso"]
-            if _identifier_prefers_iec(identifier)
-            else ["relaton-data-iso", "relaton-data-iec"]
-        )
-        for repo in repos:
+        for repo in _repo_order_for(identifier):
             doc = await self._try_repo(repo, slug)
             if doc is None:
                 continue
@@ -165,10 +203,16 @@ class RelatonLiveFetcher:
             if record is not None:
                 return record
 
-        # 404 in both repos — return a stub so callers can surface
-        # "resolved but catalogue entry unavailable" rather than a bare None.
+        # All repos 404 — return a stub so callers can surface
+        # "resolved but catalogue entry unavailable" rather than None.
         upper = identifier.strip().upper()
-        if upper.startswith("ISO/IEC"):
+        if upper.startswith("ISO/IEC/IEEE"):
+            body = "ISO/IEC/IEEE"
+        elif upper.startswith("IEC/IEEE"):
+            body = "IEC/IEEE"
+        elif upper.startswith("IEEE"):
+            body = "IEEE"
+        elif upper.startswith("ISO/IEC"):
             body = "ISO/IEC"
         elif upper.startswith("IEC"):
             body = "IEC"

--- a/src/scholar_mcp/_standards_client.py
+++ b/src/scholar_mcp/_standards_client.py
@@ -54,7 +54,19 @@ _ETSI_RE = re.compile(
     r"(?i)\betsi\s+(EN|TS|TR|ES|EG)\s*(\d{3})\s*[\s-]?\s*(\d{3}(?:-\d+)?)\b"
 )
 
-# ISO joint with IEC (must precede plain ISO/IEC so the joint form wins):
+# IEEE triple-joint with ISO and IEC (must precede other IEEE and joint patterns):
+#   "ISO/IEC/IEEE 42010-2011", "ISO/IEC/IEEE 42010:2011"
+_ISO_IEC_IEEE_JOINT_RE = re.compile(
+    r"(?i)\biso[/\s]*iec[/\s]*ieee\s*"
+    r"(\d{1,5}(?:-\d+)*(?:\.\d+)*)\s*[:\s-]\s*(\d{4})\b"
+)
+# IEEE joint with IEC (must precede plain IEEE and the ISO/IEC joint):
+#   "IEC/IEEE 61588-2021", "IEEE/IEC 61588-2021"
+_IEC_IEEE_JOINT_RE = re.compile(
+    r"(?i)\b(?:iec[/\s]*ieee|ieee[/\s]*iec)\s*"
+    r"(\d{1,5}(?:-\d+)*(?:\.\d+)*)\s*[:\s-]\s*(\d{4})\b"
+)
+# ISO joint with IEC (must precede plain ISO and plain IEC):
 #   "ISO/IEC 27001:2022", "ISO IEC 27001:2022", "IEC/ISO 27001:2022"
 _ISO_IEC_JOINT_RE = re.compile(
     r"(?i)\b(?:iso[/\s]*iec|iec[/\s]*iso)\s*"
@@ -64,6 +76,12 @@ _ISO_IEC_JOINT_RE = re.compile(
 _ISO_RE = re.compile(r"(?i)\biso\s*(\d{1,5}(?:-\d+)*)\s*[:\s-]\s*(\d{4})\b")
 # IEC alone: "IEC 62443-3-3:2020"
 _IEC_RE = re.compile(r"(?i)\biec\s*(\d{1,5}(?:-\d+)*)\s*[:\s-]\s*(\d{4})\b")
+# IEEE alone (with optional 'Std' token):
+#   "IEEE 802.11-2020", "IEEE Std 1588-2019", "IEEE 1003.1-2024"
+_IEEE_RE = re.compile(
+    r"(?i)\bieee(?:\s+std)?\s+"
+    r"(\d{1,5}(?:-\d+)*(?:\.\d+)*)\s*[-\s]\s*(\d{4})\b"
+)
 
 
 def resolve_identifier_local(raw: str) -> tuple[str, str] | None:
@@ -78,6 +96,22 @@ def resolve_identifier_local(raw: str) -> tuple[str, str] | None:
         Tuple of (canonical_identifier, body) or None.
     """
     s = raw.strip()
+
+    # IEEE patterns (check before IETF STD to prevent "IEEE Std X" from matching _IETF_STD_RE)
+    # ISO/IEC/IEEE triple-joint (must precede other IEEE joints and plain IEEE)
+    m = _ISO_IEC_IEEE_JOINT_RE.search(s)
+    if m:
+        return f"ISO/IEC/IEEE {m.group(1)}-{m.group(2)}", "IEEE"
+
+    # IEC/IEEE joint (precedes plain IEEE and the plain ISO/IEC joint)
+    m = _IEC_IEEE_JOINT_RE.search(s)
+    if m:
+        return f"IEC/IEEE {m.group(1)}-{m.group(2)}", "IEEE"
+
+    # IEEE alone (must come before IETF STD check to prevent "IEEE Std X" from matching STD)
+    m = _IEEE_RE.search(s)
+    if m:
+        return f"IEEE {m.group(1)}-{m.group(2)}", "IEEE"
 
     # IETF RFC (check before NIST to avoid "RFC" matching NIST patterns)
     m = _IETF_RFC_RE.search(s)
@@ -1026,10 +1060,11 @@ class StandardsClient:
         from ._relaton_live import RelatonLiveFetcher
 
         self._http = http
-        # Three RelatonLiveFetcher instances so each body key can carry its
-        # own source filter when search() delegates to the cache.
-        # The ISO/IEC variant uses source=None to cover joint-committee
-        # records that may live under either "ISO" or "IEC" in the cache.
+        # Four RelatonLiveFetcher instances (ISO, IEC, IEEE, ISO/IEC) so each
+        # body key can carry its own source filter when search() delegates to
+        # the cache. The ISO/IEC variant uses source=None to cover
+        # joint-committee records and must be listed last so it wins the type
+        # dedup in _one_fetcher_per_type() for all-bodies searches.
         self._fetchers: dict[str, _StandardsFetcher] = {
             "IETF": _IETFFetcher(http, RateLimiter(delay=0.5)),
             "NIST": _NISTFetcher(http, RateLimiter(delay=1.0), cache_dir=cache_dir),
@@ -1037,6 +1072,7 @@ class StandardsClient:
             "ETSI": _ETSIFetcher(http, RateLimiter(delay=1.0)),
             "ISO": RelatonLiveFetcher(http=http, cache=cache, source="ISO"),
             "IEC": RelatonLiveFetcher(http=http, cache=cache, source="IEC"),
+            "IEEE": RelatonLiveFetcher(http=http, cache=cache, source="IEEE"),
             "ISO/IEC": RelatonLiveFetcher(http=http, cache=cache, source=None),
         }
 
@@ -1052,9 +1088,9 @@ class StandardsClient:
         Args:
             query: Identifier, title, or free text.
             body: Optional body filter: "IETF", "NIST", "W3C", "ETSI",
-                "ISO", "IEC", or "ISO/IEC". ISO / IEC / ISO/IEC results
-                come from the locally synced cache; run ``sync-standards``
-                first for non-empty results.
+                "ISO", "IEC", "ISO/IEC", or "IEEE". ISO / IEC / ISO/IEC /
+                IEEE results come from the locally synced cache; run
+                ``sync-standards`` first for non-empty results.
             limit: Maximum results.
 
         Returns:
@@ -1118,10 +1154,11 @@ class StandardsClient:
         fetchers registered under multiple body keys are only invoked once.
 
         For :class:`RelatonLiveFetcher` (registered under ``ISO``, ``IEC``,
-        ``ISO/IEC``), the last-wins overwrite keeps the ``ISO/IEC`` variant
-        whose ``source=None`` returns all synced Relaton records — the ISO-
-        and IEC-scoped instances would be subsumed by it. Insertion order of
-        ``self._fetchers`` (``ISO`` → ``IEC`` → ``ISO/IEC``) is load-bearing.
+        ``IEEE``, ``ISO/IEC``), the last-wins overwrite keeps the ``ISO/IEC``
+        variant whose ``source=None`` returns all synced Relaton records — the
+        ISO-, IEC-, and IEEE-scoped instances would be subsumed by it.
+        Insertion order of ``self._fetchers`` (``ISO`` → ``IEC`` → ``IEEE`` →
+        ``ISO/IEC``) is load-bearing.
 
         Non-Relaton fetchers appear exactly once today; if a second instance
         of any of those types is ever added, it will replace the earlier one

--- a/src/scholar_mcp/_sync_relaton.py
+++ b/src/scholar_mcp/_sync_relaton.py
@@ -150,7 +150,8 @@ def _superseded_by(relations: list[dict[str, Any]] | None) -> str | None:
         if str(rel.get("type", "")).lower() != "obsoleted-by":
             continue
         bibitem = rel.get("bibitem") or {}
-        for ident in bibitem.get("docidentifier", []) or []:
+        idents = bibitem.get("docid") or bibitem.get("docidentifier") or []
+        for ident in idents:
             if ident.get("id"):
                 return str(ident["id"])
     return None
@@ -164,7 +165,8 @@ def _supersedes(relations: list[dict[str, Any]] | None) -> list[str]:
         if str(rel.get("type", "")).lower() != "obsoletes":
             continue
         bibitem = rel.get("bibitem") or {}
-        for ident in bibitem.get("docidentifier", []) or []:
+        idents = bibitem.get("docid") or bibitem.get("docidentifier") or []
+        for ident in idents:
             if ident.get("id"):
                 out.append(str(ident["id"]))
     return out
@@ -200,7 +202,7 @@ def _yaml_to_record(
     Returns:
         Tuple of ``(StandardRecord | None, alias_identifiers)``.
     """
-    docidentifiers = doc.get("docidentifier") or []
+    docidentifiers = doc.get("docid") or doc.get("docidentifier") or []
     canonical = _canonical_identifier_and_body(docidentifiers)
     if canonical is None:
         logger.debug("relaton_yaml_skip reason=%s identifier=%s", "no_canonical", "")

--- a/src/scholar_mcp/_sync_relaton.py
+++ b/src/scholar_mcp/_sync_relaton.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 class RelatonConfig:
     """Per-body Relaton sync configuration."""
 
-    body: str  # "ISO" or "IEC"
+    body: str  # "ISO", "IEC", or "IEEE"
     repo: str  # "relaton/relaton-data-iso"
     branch: str = "main"
 
@@ -40,6 +40,7 @@ class RelatonConfig:
 _RELATON_BODIES: dict[str, RelatonConfig] = {
     "ISO": RelatonConfig(body="ISO", repo="relaton/relaton-data-iso"),
     "IEC": RelatonConfig(body="IEC", repo="relaton/relaton-data-iec"),
+    "IEEE": RelatonConfig(body="IEEE", repo="relaton/relaton-data-ieee"),
 }
 
 
@@ -60,21 +61,43 @@ def _canonical_identifier_and_body(
 ) -> tuple[str, str] | None:
     """Return ``(identifier, body)`` for a Relaton doc, or ``None`` if unknown.
 
-    Joint detection rules:
-    - If the docidentifier list contains BOTH a ``type=ISO`` entry and a
-      ``type=IEC`` entry, the standard is joint → ``body="ISO/IEC"``.
-    - If only one of ``{ISO, IEC}`` types is present → ``body=that type``.
-    - Otherwise the primary entry's ``type`` determines both.
+    Joint detection rules (checked in order of specificity):
+
+    - ISO + IEC + IEEE types present → ``body="ISO/IEC/IEEE"``
+    - IEC + IEEE types present (no ISO) → ``body="IEC/IEEE"``
+    - ISO + IEC types present (no IEEE) → ``body="ISO/IEC"``
+    - IEEE-only → ``body="IEEE"``
+    - ISO-only / IEC-only → respective body
+    - Otherwise fall back to the primary entry's ``type``.
+
+    Entries with ``scope: trademark`` are filtered out before picking the
+    canonical identifier (they hold a ™ variant of the same id).
     """
     if not docidentifiers:
         return None
 
-    iso_entries = [d for d in docidentifiers if str(d.get("type", "")).upper() == "ISO"]
-    iec_entries = [d for d in docidentifiers if str(d.get("type", "")).upper() == "IEC"]
-    primary_entries = [d for d in docidentifiers if d.get("primary")]
+    def _is_trademark(entry: dict[str, Any]) -> bool:
+        return str(entry.get("scope", "")).lower() == "trademark"
+
+    non_tm = [d for d in docidentifiers if not _is_trademark(d)]
+    if not non_tm:
+        return None
+
+    iso_entries = [d for d in non_tm if str(d.get("type", "")).upper() == "ISO"]
+    iec_entries = [d for d in non_tm if str(d.get("type", "")).upper() == "IEC"]
+    ieee_entries = [d for d in non_tm if str(d.get("type", "")).upper() == "IEEE"]
+
+    if iso_entries and iec_entries and ieee_entries:
+        ident = str(ieee_entries[0].get("id", "")).strip()
+        ident = _normalise_joint(ident, "ISO/IEC/IEEE")
+        return ident, "ISO/IEC/IEEE"
+
+    if iec_entries and ieee_entries:
+        ident = str(ieee_entries[0].get("id", "")).strip()
+        ident = _normalise_joint(ident, "IEC/IEEE")
+        return ident, "IEC/IEEE"
 
     if iso_entries and iec_entries:
-        # Joint — prefer an entry whose id already contains the slash form
         joint = next(
             (
                 d
@@ -85,27 +108,42 @@ def _canonical_identifier_and_body(
             iso_entries[0],
         )
         ident = str(joint.get("id", "")).strip()
-        # Normalise reversed joint form
-        ident = ident.replace("IEC/ISO", "ISO/IEC")
-        if not ident.startswith("ISO/IEC"):
-            # docidentifier had plain ISO or IEC text in the entry for a joint doc
-            if ident.startswith("ISO "):
-                ident = "ISO/IEC " + ident[len("ISO ") :]
-            elif ident.startswith("IEC "):
-                ident = "ISO/IEC " + ident[len("IEC ") :]
-            # else: leave as-is (unusual upstream shape)
+        ident = _normalise_joint(ident, "ISO/IEC")
         return ident, "ISO/IEC"
 
+    if ieee_entries:
+        return str(ieee_entries[0].get("id", "")).strip(), "IEEE"
     if iso_entries:
         return str(iso_entries[0].get("id", "")).strip(), "ISO"
     if iec_entries:
         return str(iec_entries[0].get("id", "")).strip(), "IEC"
+
+    primary_entries = [d for d in non_tm if d.get("primary")]
     if primary_entries:
         ident = str(primary_entries[0].get("id", "")).strip()
         body = str(primary_entries[0].get("type", "")).upper()
         if ident and body:
             return ident, body
     return None
+
+
+def _normalise_joint(ident: str, joint_prefix: str) -> str:
+    """Rewrite *ident* so it starts with *joint_prefix*.
+
+    Handles upstream shapes like ``ISO 42010:2011`` (IEEE entry uses ISO
+    prefix) or ``IEC/ISO 27001:2022`` (reversed slash order).
+    """
+    if ident.startswith(joint_prefix):
+        return ident
+    ident = ident.replace("IEC/ISO", "ISO/IEC")
+    ident = ident.replace("IEEE/IEC", "IEC/IEEE")
+    ident = ident.replace("IEEE/ISO/IEC", "ISO/IEC/IEEE")
+    if ident.startswith(joint_prefix):
+        return ident
+    for prefix in ("ISO/IEC/IEEE ", "IEC/IEEE ", "ISO/IEC ", "IEEE ", "IEC ", "ISO "):
+        if ident.startswith(prefix):
+            return f"{joint_prefix} {ident[len(prefix) :]}"
+    return f"{joint_prefix} {ident}"
 
 
 def _first_link_of_type(links: list[dict[str, Any]] | None, wanted: str) -> str | None:
@@ -299,7 +337,7 @@ _GITHUB_API = "https://api.github.com"
 
 
 class RelatonLoader:
-    """One instance per body (ISO or IEC). Conforms to the Loader protocol.
+    """One instance per body (ISO, IEC, or IEEE). Conforms to the Loader protocol.
 
     The full sync algorithm is documented in
     ``docs/specs/2026-04-13-pr2-iso-iec-relaton-design.md``.

--- a/src/scholar_mcp/cli.py
+++ b/src/scholar_mcp/cli.py
@@ -306,6 +306,7 @@ def _select_loaders(
         [
             RelatonLoader("ISO", http=http, token=token),
             RelatonLoader("IEC", http=http, token=token),
+            RelatonLoader("IEEE", http=http, token=token),
         ],
     )
     if body.upper() == "ALL":

--- a/tests/fixtures/standards/relaton_ieee_sample/iec-ieee-61588-2021.yaml
+++ b/tests/fixtures/standards/relaton_ieee_sample/iec-ieee-61588-2021.yaml
@@ -1,0 +1,16 @@
+docid:
+  - id: "IEC/IEEE 61588-2021"
+    type: "IEEE"
+    primary: true
+  - id: "IEC/IEEE 61588-2021"
+    type: "IEC"
+    primary: true
+title:
+  - content: "Precision clock synchronization protocol for networked measurement and control systems"
+    format: "text/plain"
+    type: "main"
+link:
+  - content: "https://ieeexplore.ieee.org/document/9543623"
+    type: "src"
+docstatus:
+  stage: "60.60"

--- a/tests/fixtures/standards/relaton_ieee_sample/ieee-1003-1-2024-with-trademark.yaml
+++ b/tests/fixtures/standards/relaton_ieee_sample/ieee-1003-1-2024-with-trademark.yaml
@@ -1,0 +1,19 @@
+docid:
+  - id: "IEEE 1003.1-2024"
+    type: "IEEE"
+    primary: true
+  - id: "IEEE 1003.1-2024™"
+    type: "IEEE"
+    scope: "trademark"
+    primary: true
+  - id: "979-8-8557-0793-9"
+    type: "ISBN"
+title:
+  - content: "POSIX Base Specifications"
+    format: "text/plain"
+    type: "main"
+link:
+  - content: "https://ieeexplore.ieee.org/document/10555529"
+    type: "src"
+docstatus:
+  stage: "60.60"

--- a/tests/fixtures/standards/relaton_ieee_sample/ieee-1003-1-2024.yaml
+++ b/tests/fixtures/standards/relaton_ieee_sample/ieee-1003-1-2024.yaml
@@ -1,0 +1,18 @@
+docid:
+  - id: "IEEE 1003.1-2024"
+    type: "IEEE"
+    primary: true
+  - id: "10.1109/IEEESTD.2024.10555529"
+    type: "DOI"
+title:
+  - content: "IEEE/Open Group Standard for Information Technology - Portable Operating System Interface (POSIX) Base Specifications, Issue 8"
+    format: "text/plain"
+    type: "main"
+link:
+  - content: "https://ieeexplore.ieee.org/document/10555529"
+    type: "src"
+docstatus:
+  stage: "60.60"
+date:
+  - type: "published"
+    value: "2024-06-14"

--- a/tests/fixtures/standards/relaton_ieee_sample/iso-iec-ieee-42010-2011.yaml
+++ b/tests/fixtures/standards/relaton_ieee_sample/iso-iec-ieee-42010-2011.yaml
@@ -1,0 +1,23 @@
+docid:
+  - id: "ISO/IEC/IEEE 42010-2011"
+    type: "IEEE"
+    primary: true
+  - id: "ISO/IEC/IEEE 42010:2011"
+    type: "ISO"
+    primary: true
+  - id: "ISO/IEC/IEEE 42010:2011"
+    type: "IEC"
+    primary: true
+  - id: "ISO/IEC/IEEE 42010™-2011"
+    type: "IEEE"
+    scope: "trademark"
+    primary: true
+title:
+  - content: "Systems and software engineering - Architecture description"
+    format: "text/plain"
+    type: "main"
+link:
+  - content: "https://ieeexplore.ieee.org/document/6129467"
+    type: "src"
+docstatus:
+  stage: "60.60"

--- a/tests/fixtures/standards/relaton_test_cases/iso-9001-2015-docid-shape.yaml
+++ b/tests/fixtures/standards/relaton_test_cases/iso-9001-2015-docid-shape.yaml
@@ -1,0 +1,30 @@
+docid:
+  - id: "ISO 9001:2015"
+    type: "ISO"
+    primary: true
+  - id: "iso:std:iso:9001:stage-60.60:ed-5:en"
+    type: "URN"
+title:
+  - content: "Quality management systems — Requirements"
+    language: "en"
+    script: "Latn"
+    format: "text/plain"
+    type: "main"
+date:
+  - type: "published"
+    value: "2015-09-15"
+docstatus:
+  stage: "60.60"
+link:
+  - type: "src"
+    content: "https://www.iso.org/standard/62085.html"
+  - type: "obp"
+    content: "https://www.iso.org/obp/ui/#!iso:std:62085:en"
+abstract:
+  - content: "ISO 9001:2015 specifies requirements for a quality management system."
+    language: "en"
+    format: "text/plain"
+editorialgroup:
+  technical_committee:
+    - name: "TC 176/SC 2"
+      number: 2

--- a/tests/test_cli_sync_standards.py
+++ b/tests/test_cli_sync_standards.py
@@ -141,8 +141,9 @@ def test_sync_standards_all_success(
 def test_select_loaders_single_body_filters() -> None:
     """Non-'all' body exercises the filter branch in _select_loaders.
 
-    With ISO/IEC loaders registered, "ISO" returns exactly one loader
-    and "all" returns two (ISO + IEC). "XYZ" returns empty.
+    With ISO/IEC/IEEE loaders registered, "ISO" returns exactly one loader,
+    "IEEE" returns exactly one loader, and "all" returns three
+    (ISO + IEC + IEEE). "XYZ" returns empty.
     """
     import httpx
 
@@ -156,9 +157,14 @@ def test_select_loaders_single_body_filters() -> None:
         assert iso_loaders[0].body == "ISO"
 
         all_loaders = cli_mod._select_loaders("all", http=http, token=None)
-        assert len(all_loaders) == 2
+        assert len(all_loaders) == 3
         bodies = {loader.body for loader in all_loaders}
-        assert bodies == {"ISO", "IEC"}
+        assert bodies == {"ISO", "IEC", "IEEE"}
+
+        ieee_loaders = cli_mod._select_loaders("IEEE", http=http, token=None)
+        assert len(ieee_loaders) == 1
+        assert isinstance(ieee_loaders[0], RelatonLoader)
+        assert ieee_loaders[0].body == "IEEE"
 
         xyz_loaders = cli_mod._select_loaders("XYZ", http=http, token=None)
         assert xyz_loaders == []

--- a/tests/test_relaton_live.py
+++ b/tests/test_relaton_live.py
@@ -318,3 +318,25 @@ async def test_live_fetcher_search_returns_empty_without_cache() -> None:
         results = await fetcher.search("9001")
 
     assert results == []
+
+
+@pytest.mark.live
+@pytest.mark.asyncio
+async def test_live_fetch_iso_9001_2015_real() -> None:
+    """Smoke test: hit the real ISO Relaton repo to catch schema drift.
+
+    Regression guard for the docid/docidentifier schema-key bug that
+    caused live-fetching real ISO standards to silently return stubs.
+    Not run by default; enable with `pytest -m live`.
+    """
+    from scholar_mcp._relaton_live import RelatonLiveFetcher
+
+    async with httpx.AsyncClient(timeout=30.0) as http:
+        fetcher = RelatonLiveFetcher(http=http)
+        record = await fetcher.get("ISO 9001:2015")
+
+    assert record is not None
+    assert record["identifier"] == "ISO 9001:2015"
+    assert record["body"] == "ISO"
+    assert record["title"]
+    assert "Quality management" in record["title"]

--- a/tests/test_relaton_live.py
+++ b/tests/test_relaton_live.py
@@ -472,3 +472,118 @@ async def test_live_fetch_iso_9001_2015_real() -> None:
     assert record["body"] == "ISO"
     assert record["title"]
     assert "Quality management" in record["title"]
+
+
+@pytest.mark.asyncio
+async def test_live_fetch_ieee_all_repos_fail_returns_stub() -> None:
+    """IEEE identifier, IEEE repo 404 → stub with body='IEEE'."""
+    from scholar_mcp._relaton_live import RelatonLiveFetcher
+
+    with respx.mock(assert_all_called=True) as router:
+        router.get(
+            "https://raw.githubusercontent.com/relaton/relaton-data-ieee/main/data/IEEE_1003.1-2024.yaml"
+        ).mock(return_value=httpx.Response(404))
+
+        async with httpx.AsyncClient() as http:
+            fetcher = RelatonLiveFetcher(http=http)
+            record = await fetcher.get("IEEE 1003.1-2024")
+
+    assert record is not None
+    assert record["identifier"] == "IEEE 1003.1-2024"
+    assert record["body"] == "IEEE"
+    assert record["title"] == ""
+    assert record["full_text_available"] is False
+    assert record["status"] == "unknown"
+
+
+@pytest.mark.asyncio
+async def test_live_fetch_iec_ieee_all_repos_fail_returns_stub() -> None:
+    """IEC/IEEE identifier, all repos 404 → stub with body='IEC/IEEE'.
+
+    Also exercises the IEC/IEEE branch of _repo_order_for (IEEE repo
+    tried first, then IEC).
+    """
+    from scholar_mcp._relaton_live import RelatonLiveFetcher
+
+    with respx.mock(assert_all_called=True) as router:
+        router.get(
+            "https://raw.githubusercontent.com/relaton/relaton-data-ieee/main/data/IEC_IEEE_61588-2021.yaml"
+        ).mock(return_value=httpx.Response(404))
+        router.get(
+            "https://raw.githubusercontent.com/relaton/relaton-data-iec/main/data/IEC_IEEE_61588-2021.yaml"
+        ).mock(return_value=httpx.Response(404))
+
+        async with httpx.AsyncClient() as http:
+            fetcher = RelatonLiveFetcher(http=http)
+            record = await fetcher.get("IEC/IEEE 61588-2021")
+
+    assert record is not None
+    assert record["identifier"] == "IEC/IEEE 61588-2021"
+    assert record["body"] == "IEC/IEEE"
+    assert record["title"] == ""
+
+
+@pytest.mark.asyncio
+async def test_live_fetch_iso_iec_ieee_all_repos_fail_returns_stub() -> None:
+    """ISO/IEC/IEEE triple-joint, all three repos 404 → stub with body='ISO/IEC/IEEE'."""
+    from scholar_mcp._relaton_live import RelatonLiveFetcher
+
+    with respx.mock(assert_all_called=True) as router:
+        router.get(
+            "https://raw.githubusercontent.com/relaton/relaton-data-ieee/main/data/ISO_IEC_IEEE_42010-2011.yaml"
+        ).mock(return_value=httpx.Response(404))
+        router.get(
+            "https://raw.githubusercontent.com/relaton/relaton-data-iso/main/data/ISO_IEC_IEEE_42010-2011.yaml"
+        ).mock(return_value=httpx.Response(404))
+        router.get(
+            "https://raw.githubusercontent.com/relaton/relaton-data-iec/main/data/ISO_IEC_IEEE_42010-2011.yaml"
+        ).mock(return_value=httpx.Response(404))
+
+        async with httpx.AsyncClient() as http:
+            fetcher = RelatonLiveFetcher(http=http)
+            record = await fetcher.get("ISO/IEC/IEEE 42010-2011")
+
+    assert record is not None
+    assert record["identifier"] == "ISO/IEC/IEEE 42010-2011"
+    assert record["body"] == "ISO/IEC/IEEE"
+
+
+@pytest.mark.asyncio
+async def test_live_fetch_iec_ieee_iec_repo_wins() -> None:
+    """IEC/IEEE identifier: IEEE repo 404 → IEC repo 200 (fallback path).
+
+    Exercises the second element of the IEC/IEEE repo-order list.
+    """
+    from scholar_mcp._relaton_live import RelatonLiveFetcher
+
+    iec_ieee_yaml = """
+docid:
+  - id: "IEC/IEEE 61588-2021"
+    type: "IEEE"
+    primary: true
+  - id: "IEC/IEEE 61588-2021"
+    type: "IEC"
+    primary: true
+title:
+  - content: "Precision clock synchronization"
+    format: "text/plain"
+    type: "main"
+docstatus:
+  stage: "60.60"
+"""
+
+    with respx.mock(assert_all_called=True) as router:
+        router.get(
+            "https://raw.githubusercontent.com/relaton/relaton-data-ieee/main/data/IEC_IEEE_61588-2021.yaml"
+        ).mock(return_value=httpx.Response(404))
+        router.get(
+            "https://raw.githubusercontent.com/relaton/relaton-data-iec/main/data/IEC_IEEE_61588-2021.yaml"
+        ).mock(return_value=httpx.Response(200, text=iec_ieee_yaml))
+
+        async with httpx.AsyncClient() as http:
+            fetcher = RelatonLiveFetcher(http=http)
+            record = await fetcher.get("IEC/IEEE 61588-2021")
+
+    assert record is not None
+    assert record["body"] == "IEC/IEEE"
+    assert "Precision clock" in record["title"]

--- a/tests/test_relaton_live.py
+++ b/tests/test_relaton_live.py
@@ -320,6 +320,138 @@ async def test_live_fetcher_search_returns_empty_without_cache() -> None:
     assert results == []
 
 
+def test_identifier_to_slug_ieee_plain() -> None:
+    """IEEE identifiers use uppercase-underscore form, preserving dots."""
+    from scholar_mcp._relaton_live import _identifier_to_relaton_slug
+
+    assert _identifier_to_relaton_slug("IEEE 1003.1-2024") == "IEEE_1003.1-2024"
+
+
+def test_identifier_to_slug_ieee_std_variant() -> None:
+    """`IEEE Std 1588-2019` keeps the 'Std' token, underscore-joined."""
+    from scholar_mcp._relaton_live import _identifier_to_relaton_slug
+
+    assert _identifier_to_relaton_slug("IEEE Std 1588-2019") == "IEEE_Std_1588-2019"
+
+
+def test_identifier_to_slug_iec_ieee_joint() -> None:
+    """IEC/IEEE joint → IEC_IEEE_NUMBER-YEAR uppercase."""
+    from scholar_mcp._relaton_live import _identifier_to_relaton_slug
+
+    assert _identifier_to_relaton_slug("IEC/IEEE 61588-2021") == "IEC_IEEE_61588-2021"
+
+
+def test_identifier_to_slug_iso_iec_ieee_joint() -> None:
+    """ISO/IEC/IEEE triple-joint → ISO_IEC_IEEE_NUMBER-YEAR uppercase."""
+    from scholar_mcp._relaton_live import _identifier_to_relaton_slug
+
+    assert (
+        _identifier_to_relaton_slug("ISO/IEC/IEEE 42010-2011")
+        == "ISO_IEC_IEEE_42010-2011"
+    )
+
+
+def test_identifier_to_slug_preserves_iso_lowercase_hyphen() -> None:
+    """Pre-PR-3 ISO/IEC slug form (lowercase-hyphen) must not regress."""
+    from scholar_mcp._relaton_live import _identifier_to_relaton_slug
+
+    assert _identifier_to_relaton_slug("ISO 9001:2015") == "iso-9001-2015"
+    assert _identifier_to_relaton_slug("IEC 62443-3-3:2020") == "iec-62443-3-3-2020"
+    assert _identifier_to_relaton_slug("ISO/IEC 27001:2022") == "iso-iec-27001-2022"
+
+
+@pytest.mark.asyncio
+async def test_live_fetch_ieee_hit() -> None:
+    """Mocked 200 → parses to full IEEE record."""
+    from scholar_mcp._relaton_live import RelatonLiveFetcher
+
+    ieee_yaml = """
+docid:
+  - id: "IEEE 1003.1-2024"
+    type: "IEEE"
+    primary: true
+title:
+  - content: "POSIX Base Specifications"
+    format: "text/plain"
+    type: "main"
+docstatus:
+  stage: "60.60"
+link:
+  - type: "src"
+    content: "https://ieeexplore.ieee.org/document/10555529"
+"""
+
+    with respx.mock(assert_all_called=True) as router:
+        router.get(
+            "https://raw.githubusercontent.com/relaton/relaton-data-ieee/main/data/IEEE_1003.1-2024.yaml"
+        ).mock(return_value=httpx.Response(200, text=ieee_yaml))
+
+        async with httpx.AsyncClient() as http:
+            fetcher = RelatonLiveFetcher(http=http, source="IEEE")
+            record = await fetcher.get("IEEE 1003.1-2024")
+
+    assert record is not None
+    assert record["identifier"] == "IEEE 1003.1-2024"
+    assert record["body"] == "IEEE"
+    assert "POSIX" in record["title"]
+
+
+@pytest.mark.asyncio
+async def test_live_fetch_ieee_joint_falls_back_to_iso() -> None:
+    """ISO/IEC/IEEE joint: IEEE 404 → ISO repo 200 wins."""
+    from scholar_mcp._relaton_live import RelatonLiveFetcher
+
+    joint_yaml = """
+docid:
+  - id: "ISO/IEC/IEEE 42010-2011"
+    type: "IEEE"
+    primary: true
+  - id: "ISO/IEC/IEEE 42010:2011"
+    type: "ISO"
+    primary: true
+  - id: "ISO/IEC/IEEE 42010:2011"
+    type: "IEC"
+    primary: true
+title:
+  - content: "Architecture description"
+    format: "text/plain"
+    type: "main"
+docstatus:
+  stage: "60.60"
+"""
+
+    with respx.mock(assert_all_called=True) as router:
+        router.get(
+            "https://raw.githubusercontent.com/relaton/relaton-data-ieee/main/data/ISO_IEC_IEEE_42010-2011.yaml"
+        ).mock(return_value=httpx.Response(404))
+        router.get(
+            "https://raw.githubusercontent.com/relaton/relaton-data-iso/main/data/ISO_IEC_IEEE_42010-2011.yaml"
+        ).mock(return_value=httpx.Response(200, text=joint_yaml))
+
+        async with httpx.AsyncClient() as http:
+            fetcher = RelatonLiveFetcher(http=http)
+            record = await fetcher.get("ISO/IEC/IEEE 42010-2011")
+
+    assert record is not None
+    assert record["body"] == "ISO/IEC/IEEE"
+
+
+@pytest.mark.live
+@pytest.mark.asyncio
+async def test_live_fetch_ieee_1003_1_2024_real() -> None:
+    """Smoke test: fetch a known IEEE standard from the real repo."""
+    from scholar_mcp._relaton_live import RelatonLiveFetcher
+
+    async with httpx.AsyncClient(timeout=30.0) as http:
+        fetcher = RelatonLiveFetcher(http=http)
+        record = await fetcher.get("IEEE 1003.1-2024")
+
+    assert record is not None
+    assert record["identifier"] == "IEEE 1003.1-2024"
+    assert record["body"] == "IEEE"
+    assert record["title"]
+
+
 @pytest.mark.live
 @pytest.mark.asyncio
 async def test_live_fetch_iso_9001_2015_real() -> None:

--- a/tests/test_standards_client.py
+++ b/tests/test_standards_client.py
@@ -227,6 +227,98 @@ def test_resolve_identifier_bare_number_not_matched() -> None:
     assert resolve_identifier_local("27001:2022") is None
 
 
+# --- Resolver: IEEE ---
+
+
+def test_resolve_ieee_plain() -> None:
+    """Plain IEEE identifier resolves to (canonical, 'IEEE')."""
+    from scholar_mcp._standards_client import resolve_identifier_local
+
+    assert resolve_identifier_local("IEEE 802.11-2020") == ("IEEE 802.11-2020", "IEEE")
+    assert resolve_identifier_local("IEEE 1003.1-2024") == ("IEEE 1003.1-2024", "IEEE")
+
+
+def test_resolve_ieee_std_variant() -> None:
+    """`IEEE Std X-YYYY` form is accepted."""
+    from scholar_mcp._standards_client import resolve_identifier_local
+
+    result = resolve_identifier_local("IEEE Std 1588-2019")
+    assert result is not None
+    identifier, body = result
+    assert body == "IEEE"
+    assert "1588" in identifier
+    assert "2019" in identifier
+
+
+def test_resolve_iec_ieee_joint_dispatches_to_ieee() -> None:
+    """IEC/IEEE joint → canonical form kept, dispatch body is 'IEEE'.
+
+    The dispatch body ('IEEE') must match a StandardsClient._fetchers key.
+    The record's body field (set by _yaml_to_record) will be 'IEC/IEEE'.
+    """
+    from scholar_mcp._standards_client import resolve_identifier_local
+
+    result = resolve_identifier_local("IEC/IEEE 61588-2021")
+    assert result is not None
+    identifier, body = result
+    assert identifier == "IEC/IEEE 61588-2021"
+    assert body == "IEEE"  # dispatch body, not record body
+
+
+def test_resolve_iso_iec_ieee_joint_dispatches_to_ieee() -> None:
+    """ISO/IEC/IEEE triple-joint → dispatch body 'IEEE'."""
+    from scholar_mcp._standards_client import resolve_identifier_local
+
+    result = resolve_identifier_local("ISO/IEC/IEEE 42010-2011")
+    assert result is not None
+    identifier, body = result
+    assert identifier == "ISO/IEC/IEEE 42010-2011"
+    assert body == "IEEE"
+
+
+@pytest.mark.asyncio
+async def test_standards_client_search_ieee_delegates_to_relaton() -> None:
+    """search(body='IEEE') → RelatonLiveFetcher.search() with source='IEEE'."""
+    from unittest.mock import AsyncMock
+
+    from scholar_mcp._record_types import StandardRecord
+    from scholar_mcp._standards_client import StandardsClient
+
+    record: StandardRecord = {
+        "identifier": "IEEE 1003.1-2024",
+        "title": "POSIX Base Specifications",
+        "body": "IEEE",
+        "status": "published",
+        "full_text_available": False,
+    }
+    mock_cache = AsyncMock()
+    mock_cache.search_synced_standards = AsyncMock(return_value=[record])
+
+    async with httpx.AsyncClient() as http:
+        client = StandardsClient(http, cache=mock_cache)
+        results = await client.search("1003", body="IEEE")
+
+    mock_cache.search_synced_standards.assert_awaited_once_with(
+        "1003", source="IEEE", limit=10
+    )
+    assert len(results) == 1
+    assert results[0]["identifier"] == "IEEE 1003.1-2024"
+
+
+@pytest.mark.asyncio
+async def test_standards_client_fetchers_ieee_instance_registered() -> None:
+    """_fetchers['IEEE'] is a RelatonLiveFetcher with source='IEEE'."""
+    from scholar_mcp._relaton_live import RelatonLiveFetcher
+    from scholar_mcp._standards_client import StandardsClient
+
+    async with httpx.AsyncClient() as http:
+        client = StandardsClient(http)
+        fetcher = client._fetchers["IEEE"]
+
+    assert isinstance(fetcher, RelatonLiveFetcher)
+    assert fetcher._source == "IEEE"
+
+
 # ---------------------------------------------------------------------------
 # IETF fetcher tests
 # ---------------------------------------------------------------------------

--- a/tests/test_sync_relaton.py
+++ b/tests/test_sync_relaton.py
@@ -918,3 +918,54 @@ def test_yaml_to_record_falls_back_to_docidentifier_key() -> None:
 
     assert record is not None
     assert record["identifier"] == "ISO 9001:2015"
+
+
+def test_yaml_to_record_plain_ieee() -> None:
+    """Pure IEEE entry → body='IEEE', identifier preserved verbatim."""
+    from scholar_mcp._sync_relaton import _yaml_to_record
+
+    doc = _load_fixture("relaton_ieee_sample/ieee-1003-1-2024.yaml")
+    record, _ = _yaml_to_record(doc)
+
+    assert record is not None
+    assert record["identifier"] == "IEEE 1003.1-2024"
+    assert record["body"] == "IEEE"
+    assert "POSIX" in record["title"]
+
+
+def test_yaml_to_record_iec_ieee_joint() -> None:
+    """docid list with IEC + IEEE entries → body='IEC/IEEE'."""
+    from scholar_mcp._sync_relaton import _yaml_to_record
+
+    doc = _load_fixture("relaton_ieee_sample/iec-ieee-61588-2021.yaml")
+    record, _ = _yaml_to_record(doc)
+
+    assert record is not None
+    assert record["identifier"] == "IEC/IEEE 61588-2021"
+    assert record["body"] == "IEC/IEEE"
+
+
+def test_yaml_to_record_iso_iec_ieee_joint() -> None:
+    """docid list with ISO + IEC + IEEE entries → body='ISO/IEC/IEEE'."""
+    from scholar_mcp._sync_relaton import _yaml_to_record
+
+    doc = _load_fixture("relaton_ieee_sample/iso-iec-ieee-42010-2011.yaml")
+    record, _ = _yaml_to_record(doc)
+
+    assert record is not None
+    assert record["body"] == "ISO/IEC/IEEE"
+    assert "ISO/IEC/IEEE 42010" in record["identifier"]
+    # trademark variant (with ™) is filtered — canonical must NOT include the ™ suffix
+    assert "™" not in record["identifier"]
+
+
+def test_yaml_to_record_ieee_skips_trademark_scope() -> None:
+    """scope: trademark entries are filtered out when picking canonical."""
+    from scholar_mcp._sync_relaton import _yaml_to_record
+
+    doc = _load_fixture("relaton_ieee_sample/ieee-1003-1-2024-with-trademark.yaml")
+    record, _ = _yaml_to_record(doc)
+
+    assert record is not None
+    assert record["identifier"] == "IEEE 1003.1-2024"
+    assert "™" not in record["identifier"]

--- a/tests/test_sync_relaton.py
+++ b/tests/test_sync_relaton.py
@@ -1008,12 +1008,15 @@ def test_yaml_to_record_ieee_skips_trademark_scope() -> None:
 async def test_loader_cold_sync_inserts_ieee_records(
     tmp_path: Path, ieee_tarball: bytes
 ) -> None:
-    """Cold sync of IEEE fixtures inserts all four records with correct body.
+    """Cold sync of IEEE fixtures exercises the full RelatonLoader path.
 
-    Exercises the full RelatonLoader path for IEEE, mirroring the ISO
-    cold-sync test. Guards against wiring regressions between RelatonLoader,
-    _yaml_to_record, and _canonical_identifier_and_body for IEEE inputs
-    including the IEC/IEEE and ISO/IEC/IEEE joint detection.
+    The four fixture YAML files map to three unique canonical identifiers
+    (the trademark fixture and the plain fixture both resolve to
+    ``IEEE 1003.1-2024``; alphabetical iteration means the trademark
+    version inserts first and the plain version updates it). Guards
+    against wiring regressions between RelatonLoader, _yaml_to_record,
+    and _canonical_identifier_and_body for IEEE inputs including the
+    IEC/IEEE and ISO/IEC/IEEE joint detection.
     """
     from scholar_mcp._cache import ScholarCache
     from scholar_mcp._sync_relaton import RelatonLoader

--- a/tests/test_sync_relaton.py
+++ b/tests/test_sync_relaton.py
@@ -889,3 +889,32 @@ async def test_loader_joint_dedup_iec_then_iso(
         assert iso_only is None
     finally:
         await cache.close()
+
+
+def test_yaml_to_record_reads_docid_key() -> None:
+    """Real relaton repos use top-level 'docid:', not 'docidentifier:'.
+
+    Regression guard — the parser must accept both shapes so live-fetched
+    records from raw.githubusercontent.com parse into full records (not
+    fallback stubs).
+    """
+    from scholar_mcp._sync_relaton import _yaml_to_record
+
+    doc = _load_fixture("relaton_test_cases/iso-9001-2015-docid-shape.yaml")
+    record, _ = _yaml_to_record(doc)
+
+    assert record is not None
+    assert record["identifier"] == "ISO 9001:2015"
+    assert record["body"] == "ISO"
+    assert "Quality management" in record["title"]
+
+
+def test_yaml_to_record_falls_back_to_docidentifier_key() -> None:
+    """Old-shape fixtures with 'docidentifier:' still work."""
+    from scholar_mcp._sync_relaton import _yaml_to_record
+
+    doc = _load_fixture("relaton_iso_sample/iso-9001-2015.yaml")
+    record, _ = _yaml_to_record(doc)
+
+    assert record is not None
+    assert record["identifier"] == "ISO 9001:2015"

--- a/tests/test_sync_relaton.py
+++ b/tests/test_sync_relaton.py
@@ -301,6 +301,32 @@ def test_supersedes_empty_when_no_relations() -> None:
     assert _supersedes(None) == []
 
 
+def test_superseded_by_reads_docid_key_in_relation() -> None:
+    """bibitem.docid is accepted (mirrors the top-level docid fix)."""
+    from scholar_mcp._sync_relaton import _superseded_by
+
+    relations = [
+        {
+            "type": "obsoleted-by",
+            "bibitem": {"docid": [{"id": "ISO 9001:2015"}]},
+        }
+    ]
+    assert _superseded_by(relations) == "ISO 9001:2015"
+
+
+def test_supersedes_reads_docid_key_in_relation() -> None:
+    """bibitem.docid is accepted for obsoletes relations too."""
+    from scholar_mcp._sync_relaton import _supersedes
+
+    relations = [
+        {
+            "type": "obsoletes",
+            "bibitem": {"docid": [{"id": "ISO 9001:2008"}]},
+        }
+    ]
+    assert _supersedes(relations) == ["ISO 9001:2008"]
+
+
 # ---------------------------------------------------------------------------
 # _committee coverage
 # ---------------------------------------------------------------------------
@@ -406,6 +432,13 @@ def iso_tarball() -> bytes:
 def iec_tarball() -> bytes:
     return _build_tarball(
         FIXTURES / "relaton_iec_sample", prefix="relaton-data-iec-main"
+    )
+
+
+@pytest.fixture
+def ieee_tarball() -> bytes:
+    return _build_tarball(
+        FIXTURES / "relaton_ieee_sample", prefix="relaton-data-ieee-main"
     )
 
 
@@ -969,3 +1002,61 @@ def test_yaml_to_record_ieee_skips_trademark_scope() -> None:
     assert record is not None
     assert record["identifier"] == "IEEE 1003.1-2024"
     assert "™" not in record["identifier"]
+
+
+@pytest.mark.asyncio
+async def test_loader_cold_sync_inserts_ieee_records(
+    tmp_path: Path, ieee_tarball: bytes
+) -> None:
+    """Cold sync of IEEE fixtures inserts all four records with correct body.
+
+    Exercises the full RelatonLoader path for IEEE, mirroring the ISO
+    cold-sync test. Guards against wiring regressions between RelatonLoader,
+    _yaml_to_record, and _canonical_identifier_and_body for IEEE inputs
+    including the IEC/IEEE and ISO/IEC/IEEE joint detection.
+    """
+    from scholar_mcp._cache import ScholarCache
+    from scholar_mcp._sync_relaton import RelatonLoader
+
+    cache = ScholarCache(tmp_path / "cache.db")
+    await cache.open()
+    try:
+        sha = "deadbeef" * 5
+        with respx.mock(assert_all_called=False) as router:
+            router.get(
+                "https://api.github.com/repos/relaton/relaton-data-ieee/commits/main"
+            ).mock(return_value=httpx.Response(200, json={"sha": sha}))
+            router.get(
+                f"https://api.github.com/repos/relaton/relaton-data-ieee/tarball/{sha}"
+            ).mock(
+                return_value=httpx.Response(
+                    200,
+                    content=ieee_tarball,
+                    headers={"Content-Type": "application/x-gzip"},
+                )
+            )
+
+            async with httpx.AsyncClient() as http:
+                loader = RelatonLoader("IEEE", http=http)
+                report = await loader.sync(cache)
+
+        assert report.added == 3
+        assert report.updated == 1
+        assert report.body == "IEEE"
+        assert report.upstream_ref == sha
+
+        plain = await cache.get_standard("IEEE 1003.1-2024")
+        assert plain is not None
+        assert plain["body"] == "IEEE"
+        assert "POSIX" in plain["title"]
+
+        iec_ieee = await cache.get_standard("IEC/IEEE 61588-2021")
+        assert iec_ieee is not None
+        assert iec_ieee["body"] == "IEC/IEEE"
+
+        iso_iec_ieee = await cache.get_standard("ISO/IEC/IEEE 42010-2011")
+        assert iso_iec_ieee is not None
+        assert iso_iec_ieee["body"] == "ISO/IEC/IEEE"
+        assert "™" not in iso_iec_ieee["identifier"]
+    finally:
+        await cache.close()


### PR DESCRIPTION
## Summary

- Ship IEEE as a Tier 2 Relaton body (sync + live-fetch), including joint-committee handling for `IEC/IEEE` and `ISO/IEC/IEEE` identifiers.
- Fix pre-existing schema-key mismatch: real relaton repos use top-level `docid:`, but PR 2's parser only read `docidentifier:` — live-fetching any real ISO/IEC standard was silently returning empty stubs. `_sync_relaton.py` now reads either key.
- Add per-body slug strategy: ISO/IEC keep the lowercase-hyphen form (`iso-9001-2015.yaml`), IEEE gets a new uppercase-underscore form (`IEEE_1003.1-2024.yaml`, `ISO_IEC_IEEE_42010-2011.yaml`).
- Introduce a pytest `live` marker (opt-in via `-m live`) with one live-smoke test per body to catch future schema drift.

Closes #82. Related follow-ups: #127 (ANSI/AIEE historical forms), #128 (P-drafts), #129 (joint-body dispatch keys), #92 (IEEE Xplore authenticated full-text).

Design spec: `docs/specs/2026-04-15-pr3-ieee-design.md`

## Test Plan

- [ ] `uv run pytest -x -q` — 907 passed, 2 deselected (live tests)
- [ ] `uv run ruff check --fix . && uv run ruff format --check .` — clean
- [ ] `uv run mypy src/` — clean (46 source files)
- [ ] `uv run pytest -m live tests/test_relaton_live.py` — real-network fetch of `ISO 9001:2015` and `IEEE 1003.1-2024` succeeds (both pass locally)
- [ ] Manual: `scholar-mcp sync-standards --body IEEE` end-to-end (requires GitHub token for tarball download)

## Commit layout

Five commits, stacked for reviewability:

1. `fix(standards): read docid key in relaton YAML, fall back to docidentifier` — schema-key fix + `live` marker + ISO regression guard.
2. `feat(standards): extend relaton parser for IEEE + joint-committee bodies` — parser detects IEEE-only / IEC/IEEE / ISO/IEC/IEEE, filters `scope: trademark` entries.
3. `feat(standards): IEEE slug strategy + repo dispatch in RelatonLiveFetcher` — per-body slug dispatcher, IEEE repo added to probe order.
4. `feat(standards): register IEEE in StandardsClient + CLI + RelatonConfig` — `_fetchers["IEEE"]`, regex groups for IEEE / IEC/IEEE / ISO/IEC/IEEE (all dispatching to body `"IEEE"`), `_select_loaders` extension.
5. `docs(standards): IEEE body in README and standards guide` — user-facing docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)