### PR TITLE
feat(standards): v0.9.0 PR 4b — CEN/CENELEC harmonised-standards loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A [FastMCP](https://github.com/jlowin/fastmcp) server for the scholarly citation
 - **Papers** -- full-text search with year/venue/field/citation filters; single-paper lookup by DOI, S2 ID, arXiv ID, ACM ID, or PubMed ID; author profile and name search; forward citations, backward references, BFS graph traversal, shortest-path bridge discovery; recommendations from positive/negative examples; BibTeX/CSL-JSON/RIS citation generation with OpenAlex venue enrichment.
 - **Patents** -- search across 100+ patent offices via EPO OPS with CPC/applicant/inventor/jurisdiction filters; bibliographic, claims, description, family, legal, and citations sections; NPL-to-paper resolution via Semantic Scholar and paper-to-patent citation discovery. EPO credentials are optional -- other domains work without them.
 - **Books** -- search by title/author/keywords via Open Library (no API key required); lookup by ISBN-10/13, Open Library work ID, or edition ID; subject-based recommendations sorted by popularity; Google Books excerpts and preview links; WorldCat permalinks for library discovery; cover image caching. Papers with an ISBN in `externalIds` are automatically enriched with publisher, edition, cover URL, and subject data from Open Library.
-- **Standards** -- identifier resolution, search, and metadata retrieval for NIST, IETF, W3C, and ETSI standards, with optional full-text fetch and Markdown conversion via docling. Tier 2 ISO, IEC, IEEE, and Common Criteria (CC) metadata (including ISO/IEC/IEEE joint standards and the CC ↔ ISO/IEC 15408 cross-link) is synced locally via `sync-standards`. ISO, IEC, IEEE have a live-fetch fallback for unsynced identifiers; CC has no live API and requires a sync first (see [docs/guides/standards.md](docs/guides/standards.md)).
+- **Standards** -- identifier resolution, search, and metadata retrieval for NIST, IETF, W3C, and ETSI standards, with optional full-text fetch and Markdown conversion via docling. Tier 2 ISO, IEC, IEEE, Common Criteria (CC), and CEN/CENELEC metadata (including ISO/IEC/IEEE joint standards and the CC ↔ ISO/IEC 15408 cross-link) is synced locally via `sync-standards`. ISO, IEC, IEEE have a live-fetch fallback for unsynced identifiers; CC and CEN have no live API and require a sync first (see [docs/guides/standards.md](docs/guides/standards.md)).
 
 ### Cross-cutting
 
@@ -115,7 +115,7 @@ uvx --from pvliesdonk-scholar-mcp scholar-mcp serve --transport http --port 8000
 
 ### Syncing Tier 2 standards catalogues
 
-Tier 2 bodies (ISO, IEC, IEEE, CC) are populated
+Tier 2 bodies (ISO, IEC, IEEE, CC, CEN) are populated
 from community-curated bulk dumps rather than live-scraped at MCP-server
 runtime. Run the sync on first install and periodically thereafter:
 
@@ -124,6 +124,7 @@ scholar-mcp sync-standards            # all registered bodies
 scholar-mcp sync-standards --body ISO # only ISO
 scholar-mcp sync-standards --body IEEE # only IEEE
 scholar-mcp sync-standards --body CC   # only Common Criteria
+scholar-mcp sync-standards --body CEN # only CEN/CENELEC
 scholar-mcp sync-standards --force    # re-sync even if upstream SHA is unchanged
 ```
 
@@ -246,7 +247,7 @@ All settings are controlled via environment variables with the `SCHOLAR_MCP_` pr
 | `search_standards` | Search standards by identifier, title, or free text, optionally filtered to one body (`NIST`, `IETF`, `W3C`, `ETSI`). |
 | `get_standard` | Retrieve a standard by canonical or fuzzy identifier, optionally fetching and converting the full text via docling. |
 
-> Tier-1 bodies (NIST, IETF, W3C, ETSI) are supported with full metadata and optional full-text conversion. Tier-2 bodies (ISO, IEC, IEEE, CC) are populated locally via `scholar-mcp sync-standards`; CEN/CENELEC remains tracked in [GitHub issues](https://github.com/pvliesdonk/scholar-mcp/issues).
+> Tier-1 bodies (NIST, IETF, W3C, ETSI) are supported with full metadata and optional full-text conversion. Tier-2 bodies (ISO, IEC, IEEE, CC, CEN/CENELEC) are populated locally via `scholar-mcp sync-standards`.
 
 ### Cross-source Utility
 

--- a/docs/guides/standards.md
+++ b/docs/guides/standards.md
@@ -174,3 +174,44 @@ Loaded from `https://www.commoncriteriaportal.org/pps/pps.csv`. Identifier extra
 - CC Supporting Documents and Guidance Documents — see [#132](https://github.com/pvliesdonk/scholar-mcp/issues/132)
 - CEM Supplements and Application Notes — see [#133](https://github.com/pvliesdonk/scholar-mcp/issues/133)
 - Auto-discovery of new framework documents from the portal HTML — see [#134](https://github.com/pvliesdonk/scholar-mcp/issues/134)
+
+## CEN/CENELEC (European Norms)
+
+CEN/CENELEC harmonised standards metadata is sync-only. Run:
+
+```bash
+scholar-mcp sync-standards --body CEN
+```
+
+to populate the local cache. Unlike ISO/IEC/IEEE (which sync from upstream Relaton repositories), CEN standards load from a curated hard-coded table covering the most-cited harmonised standards from the major EU directives.
+
+### Covered directives
+
+| Directive | Shorthand | Example standards |
+|---|---|---|
+| Electromagnetic Compatibility 2014/30/EU | EMC | EN 55032, EN 61000-series |
+| Radio Equipment 2014/53/EU | RED | EN 300 328, EN 301 489-series |
+| Machinery 2006/42/EC | Machinery | EN ISO 12100, EN ISO 13849-1 |
+| Medical Devices 2017/745 | MDR | EN ISO 13485, EN 62304 |
+| Cyber Resilience Act | CRA | EN IEC 62443-series |
+| General Product Safety | GPSR | EN 71-series (toys) |
+| Low Voltage 2014/35/EU | LVD | EN 62368-1, EN 60335-1 |
+
+### Supported identifier forms
+
+- `EN 55032:2015` — plain European Norm
+- `EN ISO 13849-1:2023` — ISO standard adopted as EN
+- `EN IEC 62443-3-3:2020` — IEC standard adopted as EN
+- `EN ISO/IEC 27001:2022` — ISO/IEC joint adopted as EN
+
+All dispatch to `body="CEN"`. No cross-linking to the ISO/IEC records — the `EN ISO` / `EN IEC` prefix is self-documenting.
+
+### Table maintenance
+
+The `_HARMONISED_STANDARDS` table in `_sync_cen.py` needs periodic review when the EU Commission publishes new implementing decisions. See [#139](https://github.com/pvliesdonk/scholar-mcp/issues/139) for the quarterly cadence. If EUR-Lex infrastructure stabilises, [#137](https://github.com/pvliesdonk/scholar-mcp/issues/137) would automate this via Formex XML parsing.
+
+### Not yet supported
+
+- Full CEN/CENELEC catalogue beyond harmonised standards
+- Live scrape fallback from `standards.cencenelec.eu` — see [#138](https://github.com/pvliesdonk/scholar-mcp/issues/138)
+- EUR-Lex Formex XML automated sync — see [#137](https://github.com/pvliesdonk/scholar-mcp/issues/137)

--- a/docs/specs/2026-04-16-pr4b-cen-loader-design.md
+++ b/docs/specs/2026-04-16-pr4b-cen-loader-design.md
@@ -208,6 +208,7 @@ The `_HARMONISED_STANDARDS` constant covers standards from these EU directives:
 | Cyber Resilience Act | CRA | EN IEC 62443-series (expected) |
 | Medical Devices Regulation | MDR | EN ISO 13485, EN 62304 |
 | General Product Safety | GPSR | EN 71-series (toys), EN 14988 (highchairs) |
+| Low Voltage | LVD | EN 62368-1, EN 60335-1, EN 61010-1 |
 
 The implementer should populate `_HARMONISED_STANDARDS` with the most-cited standards from each directive. A reasonable starting set: ~20-30 per directive for EMC/RED/Machinery (the most mature), ~10 each for CRA/MDR/GPSR. Total ~100-150 entries. Each entry needs: identifier, title, directive shorthand, status ("harmonised" or "withdrawn"), and optional published_date.
 

--- a/docs/specs/2026-04-16-pr4b-cen-loader-design.md
+++ b/docs/specs/2026-04-16-pr4b-cen-loader-design.md
@@ -1,0 +1,214 @@
+# PR 4b — CEN/CENELEC Harmonised Standards Loader
+
+**Date:** 2026-04-16
+**Closes:** scholar-mcp#83
+**Builds on:** scholar-mcp#121 (sync infrastructure), #136 (CC loader pattern)
+**Follow-ups filed:** scholar-mcp#137 (EUR-Lex Formex XML parser), #138 (live scrape fallback), #139 (quarterly table review)
+
+## Context
+
+The v0.9.0 rollout originally bundled CEN/CENELEC + Common Criteria into one PR. They were split into PR 4a (CC, merged as #136) and PR 4b (CEN, this spec). This is the last body-specific loader before the enrichment PR (#85).
+
+## Summary
+
+Ship CEN/CENELEC harmonised standards as a Tier 2 sync-only body using a hard-coded table of ~100-200 standards from the major EU directives. CEN has no reliable structured data source (EUR-Lex Formex XML is fragile, the CEN portal returns 500s, the NANDO→SMCS migration is incomplete), so a curated constant table is the pragmatic approach — same pattern as CC's framework documents but larger.
+
+## Scope Decisions
+
+### Hard-coded table, not Formex XML
+
+EUR-Lex endpoints returned empty/202 during research. The CEN/CENELEC portal at `standards.cencenelec.eu` returns HTTP 500. The new EU Single Market Compliance Space is an Angular SPA with no public API. Rather than building a fragile parser against unstable government infrastructure, we ship a curated `_HARMONISED_STANDARDS` constant covering the standards that EU-regulation-focused academic papers most commonly cite.
+
+The table needs quarterly review when new implementing decisions publish (#139). If EUR-Lex stabilises, #137 (Formex XML parser) replaces the table entirely.
+
+### Single body `"CEN"` for everything
+
+CEN and CENELEC are technically separate organisations, but from a citation-resolution perspective the distinction adds no value for the LLM consumer. All European Norms use the `EN` prefix regardless of publisher. `body="CEN"` covers everything; `search(body="CEN")` returns all ENs.
+
+### No cross-linking to ISO/IEC records
+
+Many EN standards are adoptions of ISO or IEC standards (`EN ISO 13849-1:2023` = `ISO 13849-1:2023`). Unlike the CC ↔ ISO 15408 case, the EN adoption doesn't add a free PDF (both are paywalled), so the cross-link provides no paywall-bypass value. The `EN ISO` prefix is self-documenting — the LLM can strip it if it wants the ISO record. No `related` field population, no ISO loader denylist, no dual-write.
+
+### Sync-only, cache-only `_CENFetcher`
+
+CEN has no live API. The Tier 2 design proposed scraping `standards.cencenelec.eu`, but the site is unreliable and paywalled stubs add no value. `_CENFetcher` mirrors `_CCFetcher`: cache-only `.get()` with WARNING log on miss, `.search()` delegates to `search_synced_standards(source="CEN")`.
+
+## Module Changes
+
+| File | Change |
+|---|---|
+| `src/scholar_mcp/_sync_cen.py` | **New** — `HarmonisedStandard` dataclass, `_HARMONISED_STANDARDS` constant (~100-200 entries), `_hs_to_record` mapper, `CENLoader` class (iterates table, content-hash gate for idempotency) |
+| `src/scholar_mcp/_standards_client.py` | Add EN regex groups (`_EN_ISO_IEC_RE`, `_EN_ISO_RE`, `_EN_IEC_RE`, `_EN_RE`); `_CENFetcher` class; register `_fetchers["CEN"]` |
+| `src/scholar_mcp/cli.py` | Extend `_select_loaders` with `CENLoader()` |
+| `tests/test_sync_cen.py` | **New** — table integrity tests, record builder tests, loader integration tests |
+| `tests/test_standards_client.py` | EN regex tests + `_CENFetcher` tests |
+| `tests/test_cli_sync_standards.py` | `--body CEN` and `--body all` tests |
+| `README.md` | Add CEN to supported bodies |
+| `docs/guides/standards.md` | CEN section |
+
+No changes to: `_cache.py`, `_protocols.py`, `_server_deps.py`, `_relaton_live.py`, `_sync_relaton.py`, `_sync_cc.py`.
+
+## Data Model
+
+```python
+@dataclass(frozen=True)
+class HarmonisedStandard:
+    """One entry in the hard-coded harmonised-standards table.
+
+    Attributes:
+        identifier: Canonical EN form, e.g. ``"EN 55032:2015"``,
+            ``"EN ISO 13849-1:2023"``.
+        title: Full title of the standard.
+        directive: EU directive shorthand (``"EMC"``, ``"RED"``,
+            ``"Machinery"``, ``"CRA"``, ``"MDR"``, ``"GPSR"``).
+        status: ``"harmonised"`` for active OJ listings,
+            ``"withdrawn"`` for standards removed by a later decision.
+        published_date: ISO-format date or None.
+    """
+```
+
+All records map to:
+- `body="CEN"`, `source="CEN"`
+- `full_text_available=False` (CEN standards are paywalled)
+- `price=None` (per Tier 2 design — no price population)
+- `url=""` (no canonical catalogue URL; CEN portal is unreliable)
+
+## Data Flow
+
+### Sync (`scholar-mcp sync-standards --body CEN`)
+
+```
+CENLoader.sync(cache):
+    table_hash = SHA256(sorted table identifiers + statuses)
+    prev = cache.get_sync_run("CEN")
+    if not force and prev.upstream_ref == table_hash:
+        return SyncReport(unchanged=N)  # short-circuit
+
+    prev_ids = cache.list_synced_standard_ids(source="CEN")
+    current_ids = set()
+    for entry in _HARMONISED_STANDARDS:
+        record = _hs_to_record(entry)
+        current_ids.add(record["identifier"])
+        cache.set_standard(record["identifier"], record, source="CEN", synced=True)
+
+    # Withdrawal: prev_ids - current_ids are standards removed from the
+    # table (code change). Same >50% guard for safety.
+    missing = prev_ids - current_ids
+    if prev_ids and len(missing) > 0.5 * len(prev_ids):
+        errors.append("withdrawal aborted: >50% missing")
+    else:
+        for ident in missing:
+            mark as withdrawn
+
+    report.upstream_ref = table_hash
+    return report
+```
+
+### Live fetch — none
+
+`_CENFetcher.get(identifier)` → cache hit or `None` + WARNING log.
+
+## Identifier Resolution
+
+EN regex groups in `resolve_identifier_local`, checked **after** the existing ETSI block (ETSI requires explicit `ETSI` prefix, so `EN 55032:2015` won't false-positive into ETSI):
+
+```
+_EN_ISO_IEC_RE  — "EN ISO/IEC 27001:2022"   → ("EN ISO/IEC 27001:2022", "CEN")
+_EN_ISO_RE      — "EN ISO 13849-1:2023"      → ("EN ISO 13849-1:2023", "CEN")
+_EN_IEC_RE      — "EN IEC 62443-3-3:2020"    → ("EN IEC 62443-3-3:2020", "CEN")
+_EN_RE          — "EN 55032:2015"            → ("EN 55032:2015", "CEN")
+```
+
+Ordering: `EN ISO/IEC` before `EN ISO` before `EN IEC` before plain `EN` (most-specific first). All placed after CC and ETSI blocks, before ISO/IEC/IEEE blocks.
+
+**Regression guard:** `ETSI EN 303 645` must still dispatch to `"ETSI"` (existing `_ETSI_RE` has explicit `ETSI` prefix so it wins by position).
+
+## Error Handling
+
+Minimal — no HTTP, no external data source.
+
+- **Table data bugs:** surfaced as test failures (`test_harmonised_standards_identifiers_unique`, etc.).
+- **Cache miss in `_CENFetcher`:** `logger.warning("cen_cache_miss identifier=%s hint=%s", id, "run sync-standards --body CEN")`. Returns `None`.
+- **Withdrawal guard abort:** `logger.warning(...)` + error in report. Same pattern as CC and Relaton loaders.
+
+## Testing
+
+### `tests/test_sync_cen.py` (new)
+
+**Table integrity:**
+- `test_harmonised_standards_table_not_empty` — `>= 50` entries
+- `test_harmonised_standards_identifiers_unique` — no duplicates
+- `test_harmonised_standards_all_have_directive` — non-empty directive on every entry
+- `test_harmonised_standards_identifiers_start_with_en` — all start with `EN `
+
+**Record builder:**
+- `test_hs_to_record_plain_en` — body/status/full_text fields correct
+- `test_hs_to_record_en_iso` — EN ISO identifier preserved
+- `test_hs_to_record_withdrawn` — withdrawn status maps correctly
+
+**CENLoader integration:**
+- `test_cen_loader_cold_sync` — `report.added == len(table)`
+- `test_cen_loader_resync_unchanged_short_circuits` — `added=0, unchanged=N`
+- `test_cen_loader_force_rewrites` — `force=True` bypasses hash gate
+
+### `tests/test_standards_client.py` (extend)
+
+- `test_resolve_en_plain`, `test_resolve_en_iso`, `test_resolve_en_iec`, `test_resolve_en_iso_iec`
+- `test_resolve_etsi_en_still_dispatches_to_etsi` — regression guard
+- `test_cen_fetcher_registered`, `test_cen_fetcher_cache_miss_logs_warning`
+- `test_standards_client_search_cen_delegates_to_cache`
+
+### `tests/test_cli_sync_standards.py` (extend)
+
+- `test_select_loaders_accepts_cen`, `test_select_loaders_all_includes_cen`
+
+No live-smoke tests (no external data source).
+
+## PR Layout
+
+Single PR, four ordered commits:
+
+1. `feat(standards): CEN harmonised-standards table + CENLoader` — `_sync_cen.py` with data model, table, record builder, loader. Table integrity + loader tests.
+2. `feat(standards): register CEN in StandardsClient + CLI + identifier regex` — EN regex groups, `_CENFetcher`, `_fetchers["CEN"]`, `_select_loaders`. Regex + dispatch tests.
+3. `docs(standards): CEN/CENELEC body in README and standards guide`
+4. (If needed) `test(standards): additional CEN coverage` — patch-coverage gaps.
+
+## Acceptance Gates
+
+- [ ] CI green
+- [ ] Lint + format + mypy clean
+- [ ] Codecov patch coverage ≥ 80%
+- [ ] README + docs updated
+- [ ] PR description closes #83; references #137 / #138 / #139
+
+## Out of Scope
+
+Filed as follow-ups:
+
+- **#137** — EUR-Lex Formex XML parser (comprehensive automated sync alternative)
+- **#138** — Live scrape fallback from `standards.cencenelec.eu`
+- **#139** — Quarterly table review (recurring maintenance)
+
+Explicitly **not** doing:
+
+- Full CEN/CENELEC catalogue beyond harmonised standards
+- Cross-linking EN → ISO/IEC records via `related`
+- Price field population
+- Live fallback of any kind
+
+## The Hard-Coded Table
+
+The `_HARMONISED_STANDARDS` constant covers standards from these EU directives:
+
+| Directive | Shorthand | Example standards |
+|---|---|---|
+| Electromagnetic Compatibility | EMC | EN 55032, EN 55035, EN 61000-series |
+| Radio Equipment | RED | EN 300 328, EN 301 489-series, EN 62311 |
+| Machinery | Machinery | EN ISO 13849-1, EN ISO 12100, EN 60204-1 |
+| Cyber Resilience Act | CRA | EN IEC 62443-series (expected) |
+| Medical Devices Regulation | MDR | EN ISO 13485, EN 62304 |
+| General Product Safety | GPSR | EN 71-series (toys), EN 14988 (highchairs) |
+
+The implementer should populate `_HARMONISED_STANDARDS` with the most-cited standards from each directive. A reasonable starting set: ~20-30 per directive for EMC/RED/Machinery (the most mature), ~10 each for CRA/MDR/GPSR. Total ~100-150 entries. Each entry needs: identifier, title, directive shorthand, status ("harmonised" or "withdrawn"), and optional published_date.
+
+Source for populating: the [EU harmonised standards pages](https://single-market-economy.ec.europa.eu/single-market/european-standards/harmonised-standards_en) per directive, which list the OJ references and standard numbers.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,7 @@ indent-style = "space"
 testpaths = ["tests"]
 addopts = ["--strict-markers", "-ra", "-m", "not live"]
 asyncio_mode = "auto"
+log_level = "WARNING"
 markers = [
     "live: tests that hit real network services; opt-in via `pytest -m live`",
 ]

--- a/src/scholar_mcp/_standards_client.py
+++ b/src/scholar_mcp/_standards_client.py
@@ -54,6 +54,17 @@ _ETSI_RE = re.compile(
     r"(?i)\betsi\s+(EN|TS|TR|ES|EG)\s*(\d{3})\s*[\s-]?\s*(\d{3}(?:-\d+)?)\b"
 )
 
+# CEN/CENELEC: European Norm identifiers.
+# Checked AFTER ETSI (which requires explicit "ETSI" prefix) to avoid
+# "ETSI EN 303 645" matching the generic EN pattern.
+# Order: EN ISO/IEC > EN ISO > EN IEC > plain EN (most-specific first).
+_EN_ISO_IEC_RE = re.compile(
+    r"(?i)\bEN\s+ISO/IEC\s+(\d{1,5}(?:-\d+)*)\s*[:\s-]\s*(\d{4})\b"
+)
+_EN_ISO_RE = re.compile(r"(?i)\bEN\s+ISO\s+(\d{1,5}(?:-\d+)*)\s*[:\s-]\s*(\d{4})\b")
+_EN_IEC_RE = re.compile(r"(?i)\bEN\s+IEC\s+(\d{1,5}(?:-\d+)*)\s*[:\s-]\s*(\d{4})\b")
+_EN_RE = re.compile(r"(?i)\bEN\s+(\d{1,5}(?:-\d+)*(?:\.\d+)*)\s*[:\s-]\s*(\d{4})\b")
+
 # IEEE triple-joint with ISO and IEC (must precede other IEEE and joint patterns):
 #   "ISO/IEC/IEEE 42010-2011", "ISO/IEC/IEEE 42010:2011"
 _ISO_IEC_IEEE_JOINT_RE = re.compile(
@@ -225,6 +236,23 @@ def resolve_identifier_local(raw: str) -> tuple[str, str] | None:
     m = _ETSI_RE.search(s)
     if m:
         return f"ETSI {m.group(1).upper()} {m.group(2)} {m.group(3)}", "ETSI"
+
+    # CEN/CENELEC EN (must come after ETSI to avoid "ETSI EN" collision)
+    m = _EN_ISO_IEC_RE.search(s)
+    if m:
+        return f"EN ISO/IEC {m.group(1)}:{m.group(2)}", "CEN"
+
+    m = _EN_ISO_RE.search(s)
+    if m:
+        return f"EN ISO {m.group(1)}:{m.group(2)}", "CEN"
+
+    m = _EN_IEC_RE.search(s)
+    if m:
+        return f"EN IEC {m.group(1)}:{m.group(2)}", "CEN"
+
+    m = _EN_RE.search(s)
+    if m:
+        return f"EN {m.group(1)}:{m.group(2)}", "CEN"
 
     # ISO/IEC joint (check before plain ISO and plain IEC)
     m = _ISO_IEC_JOINT_RE.search(s)
@@ -1131,6 +1159,51 @@ class _CCFetcher:
         )
 
 
+class _CENFetcher:
+    """Cache-only fetcher for CEN/CENELEC harmonised standards.
+
+    CEN has no live API — all records are populated by ``CENLoader`` via
+    ``sync-standards --body CEN``. This fetcher delegates ``get`` and
+    ``search`` to the cache and emits a WARNING on cache miss.
+
+    Conforms to the ``_StandardsFetcher`` Protocol.
+    """
+
+    def __init__(self, *, cache: CacheProtocol | None = None) -> None:
+        """Initialise the fetcher.
+
+        Args:
+            cache: Optional cache. When ``None``, ``get`` always returns
+                ``None`` and ``search`` returns ``[]``.
+        """
+        self._cache = cache
+
+    async def get(self, identifier: str) -> StandardRecord | None:
+        """Return cached CEN record, or ``None`` (with WARNING log)."""
+        if self._cache is None:
+            logger.warning(
+                "cen_cache_miss identifier=%s reason=no_cache_configured",
+                identifier,
+            )
+            return None
+        record = await self._cache.get_standard(identifier)
+        if record is None:
+            logger.warning(
+                "cen_cache_miss identifier=%s hint=%s",
+                identifier,
+                "run sync-standards --body CEN",
+            )
+        return record
+
+    async def search(self, query: str, *, limit: int = 10) -> list[StandardRecord]:
+        """Search synced CEN records via the cache."""
+        if self._cache is None:
+            return []
+        return await self._cache.search_synced_standards(
+            query, source="CEN", limit=limit
+        )
+
+
 # ---------------------------------------------------------------------------
 # StandardsClient — public orchestrator
 # ---------------------------------------------------------------------------
@@ -1174,6 +1247,7 @@ class StandardsClient:
             "IEEE": RelatonLiveFetcher(http=http, cache=cache, source="IEEE"),
             "ISO/IEC": RelatonLiveFetcher(http=http, cache=cache, source=None),
             "CC": _CCFetcher(cache=cache),
+            "CEN": _CENFetcher(cache=cache),
         }
 
     async def search(
@@ -1188,9 +1262,9 @@ class StandardsClient:
         Args:
             query: Identifier, title, or free text.
             body: Optional body filter: "IETF", "NIST", "W3C", "ETSI",
-                "ISO", "IEC", "ISO/IEC", "IEEE", or "CC". ISO / IEC / ISO/IEC /
-                IEEE / CC results come from the locally synced cache; run
-                ``sync-standards`` first for non-empty results.
+                "ISO", "IEC", "ISO/IEC", "IEEE", "CC", or "CEN". ISO / IEC /
+                ISO/IEC / IEEE / CC / CEN results come from the locally synced
+                cache; run ``sync-standards`` first for non-empty results.
             limit: Maximum results.
 
         Returns:

--- a/src/scholar_mcp/_standards_client.py
+++ b/src/scholar_mcp/_standards_client.py
@@ -63,7 +63,15 @@ _EN_ISO_IEC_RE = re.compile(
 )
 _EN_ISO_RE = re.compile(r"(?i)\bEN\s+ISO\s+(\d{1,5}(?:-\d+)*)\s*[:\s-]\s*(\d{4})\b")
 _EN_IEC_RE = re.compile(r"(?i)\bEN\s+IEC\s+(\d{1,5}(?:-\d+)*)\s*[:\s-]\s*(\d{4})\b")
-_EN_RE = re.compile(r"(?i)\bEN\s+(\d{1,5}(?:-\d+)*(?:\.\d+)*)\s*[:\s-]\s*(\d{4})\b")
+_EN_RE = re.compile(
+    r"(?i)\bEN\s+"
+    r"("
+    r"\d{3}\s+\d{3}(?:-\d+)?"  # ETSI 3-part: 300 328, 301 489-17
+    r"|\d{1,5}(?:-\d+)*(?:\.\d+)*"  # plain: 55032, 61000-3-2
+    r")"
+    r"(?:\s+V[\d.]+)?"  # optional version: V2.2.2
+    r"\s*[:\s-]\s*(\d{4})\b"
+)
 
 # IEEE triple-joint with ISO and IEC (must precede other IEEE and joint patterns):
 #   "ISO/IEC/IEEE 42010-2011", "ISO/IEC/IEEE 42010:2011"

--- a/src/scholar_mcp/_sync_cen.py
+++ b/src/scholar_mcp/_sync_cen.py
@@ -18,9 +18,10 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import re
 import time
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from ._standards_sync import SyncReport
 
@@ -31,6 +32,27 @@ else:
     StandardRecord = dict
 
 logger = logging.getLogger(__name__)
+
+_AMENDMENT_SUFFIX_RE = re.compile(r"\+A\d+:\d{4}$")
+
+
+def _normalise_en_identifier(identifier: str) -> str:
+    """Strip amendment suffix and version notation for cache-key normalisation.
+
+    ``EN 349:1993+A1:2008`` → ``EN 349:1993``
+    ``EN 300 328 V2.2.2:2019`` → ``EN 300 328:2019``
+
+    Args:
+        identifier: Raw identifier string from the harmonised-standards table.
+
+    Returns:
+        Normalised identifier suitable for use as a cache key.
+    """
+    # Strip amendment suffix: +A1:2008, +A2:2019, +A11:2020
+    ident = _AMENDMENT_SUFFIX_RE.sub("", identifier)
+    # Strip ETSI-style version notation: V2.2.2, V1.1.1 etc.
+    ident = re.sub(r"\s+V[\d.]+(?=\s*[:\s-]\s*\d{4})", "", ident)
+    return ident.strip()
 
 
 @dataclass(frozen=True)
@@ -60,9 +82,15 @@ def _hs_to_record(entry: HarmonisedStandard) -> StandardRecord:
 
     All CEN records are paywalled (``full_text_available=False``) and
     carry no catalogue URL (the CEN portal is unreliable).
+
+    The cache key (``identifier``) is normalised: amendment suffixes such as
+    ``+A1:2008`` and ETSI-style version tokens such as ``V2.2.2`` are stripped
+    so that ``resolve_identifier_local`` and the cache lookup agree on the same
+    key form.
     """
+    normalised_id = _normalise_en_identifier(entry.identifier)
     record: StandardRecord = {
-        "identifier": entry.identifier,
+        "identifier": normalised_id,
         "title": entry.title,
         "body": "CEN",
         "status": entry.status,
@@ -424,9 +452,13 @@ _HARMONISED_STANDARDS: list[HarmonisedStandard] = [
 
 
 def _compute_table_hash() -> str:
-    """SHA256 of the table's identifiers + statuses, for change detection."""
+    """SHA256 of the table's identity fields for change detection.
+
+    Includes normalised identifier, title, status, and published_date so that
+    any content change (not just identifier or status) triggers a re-sync.
+    """
     content = "|".join(
-        f"{e.identifier}:{e.status}"
+        f"{_normalise_en_identifier(e.identifier)}:{e.title}:{e.status}:{e.published_date}"
         for e in sorted(_HARMONISED_STANDARDS, key=lambda e: e.identifier)
     )
     return hashlib.sha256(content.encode()).hexdigest()
@@ -511,8 +543,6 @@ class CENLoader:
                 existing = await cache.get_standard(ident)
                 if existing is None:
                     continue
-                from typing import cast
-
                 withdrawn_record = cast(
                     "StandardRecord", {**existing, "status": "withdrawn"}
                 )

--- a/src/scholar_mcp/_sync_cen.py
+++ b/src/scholar_mcp/_sync_cen.py
@@ -1,0 +1,543 @@
+"""CEN/CENELEC harmonised-standards loader.
+
+Loads a curated table of EU harmonised standards from the major directives
+(EMC, RED, Machinery, MDR, CRA, GPSR). The table is the single source of
+truth — no upstream HTTP fetch, no EUR-Lex Formex XML parsing. Updates
+happen by editing ``_HARMONISED_STANDARDS`` in this file; see
+scholar-mcp#139 for the quarterly review cadence.
+
+All records use ``body="CEN"`` regardless of whether the standard was
+published by CEN or CENELEC — the distinction adds no value for LLM
+citation resolution. EN ISO / EN IEC adoptions are stored under their
+``EN`` prefix; no cross-linking to the ISO/IEC records.
+
+Design reference: ``docs/specs/2026-04-16-pr4b-cen-loader-design.md``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from ._standards_sync import SyncReport
+
+if TYPE_CHECKING:
+    from ._protocols import CacheProtocol
+    from ._record_types import StandardRecord
+else:
+    StandardRecord = dict
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class HarmonisedStandard:
+    """One entry in the hard-coded harmonised-standards table.
+
+    Attributes:
+        identifier: Canonical EN form, e.g. ``"EN 55032:2015"``,
+            ``"EN ISO 13849-1:2023"``.
+        title: Full title of the standard.
+        directive: EU directive shorthand (``"EMC"``, ``"RED"``,
+            ``"Machinery"``, ``"CRA"``, ``"MDR"``, ``"GPSR"``).
+        status: ``"harmonised"`` for active OJ listings,
+            ``"withdrawn"`` for standards removed by a later decision.
+        published_date: ISO-format date or None.
+    """
+
+    identifier: str
+    title: str
+    directive: str
+    status: str = "harmonised"
+    published_date: str | None = None
+
+
+def _hs_to_record(entry: HarmonisedStandard) -> StandardRecord:
+    """Map a table entry to a StandardRecord.
+
+    All CEN records are paywalled (``full_text_available=False``) and
+    carry no catalogue URL (the CEN portal is unreliable).
+    """
+    record: StandardRecord = {
+        "identifier": entry.identifier,
+        "title": entry.title,
+        "body": "CEN",
+        "status": entry.status,
+        "published_date": entry.published_date,
+        "url": "",
+        "full_text_url": None,
+        "full_text_available": False,
+        "price": None,
+        "related": [],
+    }
+    return record
+
+
+# Identity fields for change detection on re-sync.
+_CEN_RECORD_IDENTITY_FIELDS = (
+    "title",
+    "status",
+    "published_date",
+    "body",
+)
+
+
+def _cen_record_changed(
+    old: dict[str, Any] | StandardRecord, new: StandardRecord
+) -> bool:
+    """True when any identity field differs between *old* and *new*."""
+    for field_name in _CEN_RECORD_IDENTITY_FIELDS:
+        if old.get(field_name) != new.get(field_name):
+            return True
+    return False
+
+
+# ---- Hard-coded table ----
+# Update when new EU implementing decisions publish (~2-3x per directive
+# per year). See scholar-mcp#139 for the quarterly review cadence.
+# Source: https://single-market-economy.ec.europa.eu/single-market/
+#         european-standards/harmonised-standards_en
+
+_HARMONISED_STANDARDS: list[HarmonisedStandard] = [
+    # ---- EMC Directive 2014/30/EU ----
+    HarmonisedStandard(
+        identifier="EN 55032:2015",
+        title="Electromagnetic compatibility of multimedia equipment — Emission requirements",
+        directive="EMC",
+    ),
+    HarmonisedStandard(
+        identifier="EN 55035:2017",
+        title="Electromagnetic compatibility of multimedia equipment — Immunity requirements",
+        directive="EMC",
+    ),
+    HarmonisedStandard(
+        identifier="EN 61000-3-2:2019",
+        title="Electromagnetic compatibility — Limits for harmonic current emissions",
+        directive="EMC",
+    ),
+    HarmonisedStandard(
+        identifier="EN 61000-3-3:2013",
+        title="Electromagnetic compatibility — Limitation of voltage changes, voltage fluctuations and flicker",
+        directive="EMC",
+    ),
+    HarmonisedStandard(
+        identifier="EN 61000-4-2:2009",
+        title="Electromagnetic compatibility — Electrostatic discharge immunity test",
+        directive="EMC",
+    ),
+    HarmonisedStandard(
+        identifier="EN 61000-4-3:2006",
+        title="Electromagnetic compatibility — Radiated, radio-frequency, electromagnetic field immunity test",
+        directive="EMC",
+    ),
+    HarmonisedStandard(
+        identifier="EN 61000-4-4:2012",
+        title="Electromagnetic compatibility — Electrical fast transient/burst immunity test",
+        directive="EMC",
+    ),
+    HarmonisedStandard(
+        identifier="EN 61000-4-5:2014",
+        title="Electromagnetic compatibility — Surge immunity test",
+        directive="EMC",
+    ),
+    HarmonisedStandard(
+        identifier="EN 61000-4-6:2014",
+        title="Electromagnetic compatibility — Immunity to conducted disturbances, induced by radio-frequency fields",
+        directive="EMC",
+    ),
+    HarmonisedStandard(
+        identifier="EN 61000-4-11:2004",
+        title="Electromagnetic compatibility — Voltage dips, short interruptions and voltage variations immunity tests",
+        directive="EMC",
+    ),
+    HarmonisedStandard(
+        identifier="EN 55011:2016",
+        title="Industrial, scientific and medical equipment — Radio-frequency disturbance characteristics",
+        directive="EMC",
+    ),
+    HarmonisedStandard(
+        identifier="EN 55014-1:2017",
+        title="Electromagnetic compatibility — Requirements for household appliances — Part 1: Emission",
+        directive="EMC",
+    ),
+    HarmonisedStandard(
+        identifier="EN 55014-2:2015",
+        title="Electromagnetic compatibility — Requirements for household appliances — Part 2: Immunity",
+        directive="EMC",
+    ),
+    # ---- RED 2014/53/EU ----
+    HarmonisedStandard(
+        identifier="EN 300 328 V2.2.2:2019",
+        title="Wideband transmission systems — Data transmission equipment operating in the 2,4 GHz band",
+        directive="RED",
+    ),
+    HarmonisedStandard(
+        identifier="EN 301 489-1 V2.2.3:2019",
+        title="Electromagnetic compatibility standard for radio equipment and services — Part 1: Common technical requirements",
+        directive="RED",
+    ),
+    HarmonisedStandard(
+        identifier="EN 301 489-17 V3.2.4:2020",
+        title="Electromagnetic compatibility standard for radio equipment — Part 17: Specific conditions for broadband data transmission systems",
+        directive="RED",
+    ),
+    HarmonisedStandard(
+        identifier="EN 62311:2020",
+        title="Assessment of electronic and electrical equipment related to human exposure restrictions for electromagnetic fields",
+        directive="RED",
+    ),
+    HarmonisedStandard(
+        identifier="EN 301 893 V2.1.1:2017",
+        title="5 GHz RLAN — Harmonised standard for access to radio spectrum",
+        directive="RED",
+    ),
+    HarmonisedStandard(
+        identifier="EN 303 345-1 V1.1.1:2019",
+        title="Broadcast Sound Receivers — Part 1: General requirements",
+        directive="RED",
+    ),
+    HarmonisedStandard(
+        identifier="EN 303 413 V1.2.1:2021",
+        title="Satellite Earth Stations and Systems — GNSS receivers",
+        directive="RED",
+    ),
+    HarmonisedStandard(
+        identifier="EN 300 220-1 V3.1.1:2017",
+        title="Short Range Devices operating in the frequency range 25 MHz to 1000 MHz — Part 1",
+        directive="RED",
+    ),
+    HarmonisedStandard(
+        identifier="EN 300 220-2 V3.2.1:2018",
+        title="Short Range Devices operating in the frequency range 25 MHz to 1000 MHz — Part 2",
+        directive="RED",
+    ),
+    HarmonisedStandard(
+        identifier="EN 300 440 V2.2.1:2018",
+        title="Short Range Devices — Radio equipment to be used in the 1 GHz to 40 GHz frequency range",
+        directive="RED",
+    ),
+    HarmonisedStandard(
+        identifier="EN 301 511 V12.5.1:2017",
+        title="Mobile communication — GSM/DCS — Harmonised standard for access to radio spectrum",
+        directive="RED",
+    ),
+    HarmonisedStandard(
+        identifier="EN 301 908-1 V13.1.1:2019",
+        title="IMT cellular networks — Part 1: Introduction and common requirements",
+        directive="RED",
+    ),
+    # ---- Machinery Directive 2006/42/EC ----
+    HarmonisedStandard(
+        identifier="EN ISO 12100:2010",
+        title="Safety of machinery — General principles for design — Risk assessment and risk reduction",
+        directive="Machinery",
+    ),
+    HarmonisedStandard(
+        identifier="EN ISO 13849-1:2023",
+        title="Safety of machinery — Safety-related parts of control systems — Part 1: General principles for design",
+        directive="Machinery",
+    ),
+    HarmonisedStandard(
+        identifier="EN ISO 13849-2:2012",
+        title="Safety of machinery — Safety-related parts of control systems — Part 2: Validation",
+        directive="Machinery",
+    ),
+    HarmonisedStandard(
+        identifier="EN 60204-1:2018",
+        title="Safety of machinery — Electrical equipment of machines — Part 1: General requirements",
+        directive="Machinery",
+    ),
+    HarmonisedStandard(
+        identifier="EN ISO 14120:2015",
+        title="Safety of machinery — Guards — General requirements for the design and construction of fixed and movable guards",
+        directive="Machinery",
+    ),
+    HarmonisedStandard(
+        identifier="EN ISO 13857:2019",
+        title="Safety of machinery — Safety distances to prevent hazard zones being reached by upper and lower limbs",
+        directive="Machinery",
+    ),
+    HarmonisedStandard(
+        identifier="EN ISO 4413:2010",
+        title="Hydraulic fluid power — General rules and safety requirements for systems and their components",
+        directive="Machinery",
+    ),
+    HarmonisedStandard(
+        identifier="EN ISO 4414:2010",
+        title="Pneumatic fluid power — General rules and safety requirements for systems and their components",
+        directive="Machinery",
+    ),
+    HarmonisedStandard(
+        identifier="EN 349:1993+A1:2008",
+        title="Safety of machinery — Minimum gaps to avoid crushing of parts of the human body",
+        directive="Machinery",
+    ),
+    HarmonisedStandard(
+        identifier="EN ISO 13850:2015",
+        title="Safety of machinery — Emergency stop function — Principles for design",
+        directive="Machinery",
+    ),
+    HarmonisedStandard(
+        identifier="EN ISO 14119:2013",
+        title="Safety of machinery — Interlocking devices associated with guards — Principles for design and selection",
+        directive="Machinery",
+    ),
+    HarmonisedStandard(
+        identifier="EN 62061:2005+A2:2015",
+        title="Safety of machinery — Functional safety of safety-related control systems",
+        directive="Machinery",
+    ),
+    HarmonisedStandard(
+        identifier="EN ISO 11161:2007+A1:2010",
+        title="Safety of machinery — Integrated manufacturing systems — Basic requirements",
+        directive="Machinery",
+    ),
+    # ---- MDR 2017/745 (Medical Devices Regulation) ----
+    HarmonisedStandard(
+        identifier="EN ISO 13485:2016",
+        title="Medical devices — Quality management systems — Requirements for regulatory purposes",
+        directive="MDR",
+    ),
+    HarmonisedStandard(
+        identifier="EN ISO 14971:2019",
+        title="Medical devices — Application of risk management to medical devices",
+        directive="MDR",
+    ),
+    HarmonisedStandard(
+        identifier="EN 62304:2006+A1:2015",
+        title="Medical device software — Software life cycle processes",
+        directive="MDR",
+    ),
+    HarmonisedStandard(
+        identifier="EN IEC 60601-1:2006+A1:2013",
+        title="Medical electrical equipment — Part 1: General requirements for basic safety and essential performance",
+        directive="MDR",
+    ),
+    HarmonisedStandard(
+        identifier="EN 62366-1:2015",
+        title="Medical devices — Application of usability engineering to medical devices — Part 1",
+        directive="MDR",
+    ),
+    HarmonisedStandard(
+        identifier="EN ISO 10993-1:2020",
+        title="Biological evaluation of medical devices — Part 1: Evaluation and testing within a risk management process",
+        directive="MDR",
+    ),
+    HarmonisedStandard(
+        identifier="EN ISO 11135:2014",
+        title="Sterilization of health-care products — Ethylene oxide",
+        directive="MDR",
+    ),
+    HarmonisedStandard(
+        identifier="EN ISO 11137-1:2015",
+        title="Sterilization of health care products — Radiation — Part 1: Requirements",
+        directive="MDR",
+    ),
+    HarmonisedStandard(
+        identifier="EN ISO 15223-1:2021",
+        title="Medical devices — Symbols to be used with information to be supplied by the manufacturer — Part 1",
+        directive="MDR",
+    ),
+    # ---- CRA (Cyber Resilience Act) ----
+    HarmonisedStandard(
+        identifier="EN IEC 62443-4-1:2018",
+        title="Security for industrial automation and control systems — Part 4-1: Secure product development lifecycle requirements",
+        directive="CRA",
+    ),
+    HarmonisedStandard(
+        identifier="EN IEC 62443-4-2:2019",
+        title="Security for industrial automation and control systems — Part 4-2: Technical security requirements for IACS components",
+        directive="CRA",
+    ),
+    HarmonisedStandard(
+        identifier="EN IEC 62443-3-3:2019",
+        title="Security for industrial automation and control systems — Part 3-3: System security requirements and security levels",
+        directive="CRA",
+    ),
+    HarmonisedStandard(
+        identifier="EN ISO/IEC 27001:2022",
+        title="Information security, cybersecurity and privacy protection — Information security management systems — Requirements",
+        directive="CRA",
+    ),
+    # ---- GPSR (General Product Safety Regulation) ----
+    HarmonisedStandard(
+        identifier="EN 71-1:2014+A1:2018",
+        title="Safety of toys — Part 1: Mechanical and physical properties",
+        directive="GPSR",
+    ),
+    HarmonisedStandard(
+        identifier="EN 71-2:2020",
+        title="Safety of toys — Part 2: Flammability",
+        directive="GPSR",
+    ),
+    HarmonisedStandard(
+        identifier="EN 71-3:2019+A1:2021",
+        title="Safety of toys — Part 3: Migration of certain elements",
+        directive="GPSR",
+    ),
+    HarmonisedStandard(
+        identifier="EN 14988:2017+A1:2020",
+        title="Children's high chairs and their accessories — Safety requirements and test methods",
+        directive="GPSR",
+    ),
+    HarmonisedStandard(
+        identifier="EN 1130:2019",
+        title="Furniture — Cribs and cradles for domestic use — Safety requirements and test methods",
+        directive="GPSR",
+    ),
+    HarmonisedStandard(
+        identifier="EN 716-1:2017+A1:2020",
+        title="Furniture — Children's cots and folding cots for domestic use — Part 1: Safety requirements",
+        directive="GPSR",
+    ),
+    HarmonisedStandard(
+        identifier="EN 12790:2009",
+        title="Child care articles — Reclined cradles",
+        directive="GPSR",
+    ),
+    # ---- LVD (Low Voltage Directive) 2014/35/EU ----
+    HarmonisedStandard(
+        identifier="EN 62368-1:2020+A11:2020",
+        title="Audio/video, information and communication technology equipment — Part 1: Safety requirements",
+        directive="LVD",
+    ),
+    HarmonisedStandard(
+        identifier="EN 60335-1:2012+A2:2019",
+        title="Household and similar electrical appliances — Safety — Part 1: General requirements",
+        directive="LVD",
+    ),
+    HarmonisedStandard(
+        identifier="EN 61010-1:2010+A1:2019",
+        title="Safety requirements for electrical equipment for measurement, control, and laboratory use — Part 1",
+        directive="LVD",
+    ),
+    HarmonisedStandard(
+        identifier="EN 60950-1:2006+A2:2013",
+        title="Information technology equipment — Safety — Part 1: General requirements",
+        directive="LVD",
+        status="withdrawn",
+    ),
+]
+
+
+def _compute_table_hash() -> str:
+    """SHA256 of the table's identifiers + statuses, for change detection."""
+    content = "|".join(
+        f"{e.identifier}:{e.status}"
+        for e in sorted(_HARMONISED_STANDARDS, key=lambda e: e.identifier)
+    )
+    return hashlib.sha256(content.encode()).hexdigest()
+
+
+class CENLoader:
+    """CEN/CENELEC harmonised-standards sync loader.
+
+    Conforms to the Loader Protocol. The hard-coded
+    ``_HARMONISED_STANDARDS`` table is the single source of truth —
+    no upstream HTTP fetch. Re-sync with an unchanged table
+    short-circuits via a content hash.
+
+    Quarterly review cadence tracked in scholar-mcp#139.
+    """
+
+    body = "CEN"
+
+    async def sync(self, cache: CacheProtocol, *, force: bool = False) -> SyncReport:
+        """Write the harmonised-standards table into *cache*.
+
+        Args:
+            cache: Open cache.
+            force: Bypass the content-hash check and rewrite all records.
+        """
+        started_at = time.time()
+        errors: list[str] = []
+        added = updated = unchanged = withdrawn = 0
+
+        table_hash = _compute_table_hash()
+        previous = await cache.get_sync_run(self.body)
+        previous_hash = previous.get("upstream_ref") if previous else None
+
+        if not force and previous_hash == table_hash:
+            existing_count = len(await cache.list_synced_standard_ids(source=self.body))
+            logger.info(
+                "sync_cen_unchanged hash=%s count=%s", table_hash, existing_count
+            )
+            return SyncReport(
+                body=self.body,
+                added=0,
+                updated=0,
+                unchanged=existing_count,
+                withdrawn=0,
+                errors=errors,
+                upstream_ref=table_hash,
+                started_at=started_at,
+                finished_at=time.time(),
+            )
+
+        prev_ids = await cache.list_synced_standard_ids(source=self.body)
+        current_ids: set[str] = set()
+
+        for entry in _HARMONISED_STANDARDS:
+            record = _hs_to_record(entry)
+            ident = record["identifier"]
+            current_ids.add(ident)
+            existing = await cache.get_standard(ident)
+            if existing is None:
+                added += 1
+            elif _cen_record_changed(existing, record):
+                updated += 1
+            else:
+                unchanged += 1
+            await cache.set_standard(ident, record, source=self.body, synced=True)
+
+        # Withdrawal: prev_ids - current_ids are standards removed from the
+        # table (a code change). Same >50% guard for safety.
+        missing = prev_ids - current_ids
+        if prev_ids and len(missing) > 0.5 * len(prev_ids):
+            errors.append(
+                f"withdrawal pass aborted: {len(missing)}/{len(prev_ids)} "
+                "ids missing (>50% — likely a bug in the table edit)"
+            )
+            logger.warning(
+                "cen_withdrawal_aborted missing=%s prev=%s",
+                len(missing),
+                len(prev_ids),
+            )
+        else:
+            for ident in missing:
+                existing = await cache.get_standard(ident)
+                if existing is None:
+                    continue
+                from typing import cast
+
+                withdrawn_record = cast(
+                    "StandardRecord", {**existing, "status": "withdrawn"}
+                )
+                await cache.set_standard(
+                    ident, withdrawn_record, source=self.body, synced=True
+                )
+                withdrawn += 1
+
+        logger.info(
+            "sync_cen_done hash=%s added=%s updated=%s unchanged=%s withdrawn=%s",
+            table_hash,
+            added,
+            updated,
+            unchanged,
+            withdrawn,
+        )
+
+        return SyncReport(
+            body=self.body,
+            added=added,
+            updated=updated,
+            unchanged=unchanged,
+            withdrawn=withdrawn,
+            errors=errors,
+            upstream_ref=table_hash,
+            started_at=started_at,
+            finished_at=time.time(),
+        )

--- a/src/scholar_mcp/cli.py
+++ b/src/scholar_mcp/cli.py
@@ -300,6 +300,7 @@ def _select_loaders(
         List of Loader instances matching *body*.
     """
     from scholar_mcp._sync_cc import CCLoader
+    from scholar_mcp._sync_cen import CENLoader
     from scholar_mcp._sync_relaton import RelatonLoader
 
     registered: list[Loader] = cast(
@@ -309,6 +310,7 @@ def _select_loaders(
             RelatonLoader("IEC", http=http, token=token),
             RelatonLoader("IEEE", http=http, token=token),
             CCLoader(http=http),
+            CENLoader(),
         ],
     )
     if body.upper() == "ALL":

--- a/tests/test_cli_sync_standards.py
+++ b/tests/test_cli_sync_standards.py
@@ -142,9 +142,9 @@ def test_sync_standards_all_success(
 def test_select_loaders_single_body_filters() -> None:
     """Non-'all' body exercises the filter branch in _select_loaders.
 
-    With ISO/IEC/IEEE/CC loaders registered, "ISO" returns exactly one loader,
-    "IEEE" returns exactly one loader, and "all" returns four
-    (ISO + IEC + IEEE + CC). "XYZ" returns empty.
+    With ISO/IEC/IEEE/CC/CEN loaders registered, "ISO" returns exactly one loader,
+    "IEEE" returns exactly one loader, and "all" returns five
+    (ISO + IEC + IEEE + CC + CEN). "XYZ" returns empty.
     """
     import httpx
 
@@ -158,9 +158,9 @@ def test_select_loaders_single_body_filters() -> None:
         assert iso_loaders[0].body == "ISO"
 
         all_loaders = cli_mod._select_loaders("all", http=http, token=None)
-        assert len(all_loaders) == 4
+        assert len(all_loaders) == 5
         bodies = {loader.body for loader in all_loaders}
-        assert bodies == {"ISO", "IEC", "IEEE", "CC"}
+        assert bodies == {"ISO", "IEC", "IEEE", "CC", "CEN"}
 
         ieee_loaders = cli_mod._select_loaders("IEEE", http=http, token=None)
         assert len(ieee_loaders) == 1
@@ -233,3 +233,23 @@ def test_select_loaders_all_includes_cc() -> None:
     loaders = _select_loaders("all", http=http, token=None)
     bodies = {loader.body for loader in loaders}
     assert {"ISO", "IEC", "IEEE", "CC"} <= bodies
+
+
+def test_select_loaders_accepts_cen() -> None:
+    """`--body CEN` returns only the CEN loader."""
+    from scholar_mcp.cli import _select_loaders
+
+    http = httpx.AsyncClient()
+    loaders = _select_loaders("CEN", http=http, token=None)
+    assert len(loaders) == 1
+    assert loaders[0].body == "CEN"
+
+
+def test_select_loaders_all_includes_cen() -> None:
+    """`--body all` includes CEN."""
+    from scholar_mcp.cli import _select_loaders
+
+    http = httpx.AsyncClient()
+    loaders = _select_loaders("all", http=http, token=None)
+    bodies = {loader.body for loader in loaders}
+    assert "CEN" in bodies

--- a/tests/test_standards_client.py
+++ b/tests/test_standards_client.py
@@ -1701,3 +1701,21 @@ def test_resolve_en_etsi_3part_without_version() -> None:
     assert result is not None
     assert result[1] == "CEN"
     assert "301 489-1" in result[0]
+
+
+def test_resolve_en_etsi_3part_with_subpart() -> None:
+    """EN 3-part with subpart (EN 301 489-17 V3.2.4:2020) resolves to CEN."""
+    from scholar_mcp._standards_client import resolve_identifier_local
+
+    result = resolve_identifier_local("EN 301 489-17 V3.2.4:2020")
+    assert result is not None
+    assert result == ("EN 301 489-17:2020", "CEN")
+
+
+def test_resolve_en_etsi_3part_large_version() -> None:
+    """EN 3-part with large version number (V12.5.1) resolves to CEN."""
+    from scholar_mcp._standards_client import resolve_identifier_local
+
+    result = resolve_identifier_local("EN 301 511 V12.5.1:2017")
+    assert result is not None
+    assert result == ("EN 301 511:2017", "CEN")

--- a/tests/test_standards_client.py
+++ b/tests/test_standards_client.py
@@ -1680,3 +1680,24 @@ async def test_standards_client_search_cen_delegates_to_cache() -> None:
         "55032", source="CEN", limit=10
     )
     assert results == [record]
+
+
+def test_resolve_en_etsi_3part_number() -> None:
+    """EN 300 328 V2.2.2:2019 resolves to CEN with normalised identifier."""
+    from scholar_mcp._standards_client import resolve_identifier_local
+
+    result = resolve_identifier_local("EN 300 328 V2.2.2:2019")
+    assert result is not None
+    identifier, body = result
+    assert body == "CEN"
+    assert identifier == "EN 300 328:2019"
+
+
+def test_resolve_en_etsi_3part_without_version() -> None:
+    """EN 301 489-1:2019 (no version suffix) also resolves."""
+    from scholar_mcp._standards_client import resolve_identifier_local
+
+    result = resolve_identifier_local("EN 301 489-1:2019")
+    assert result is not None
+    assert result[1] == "CEN"
+    assert "301 489-1" in result[0]

--- a/tests/test_standards_client.py
+++ b/tests/test_standards_client.py
@@ -1379,12 +1379,12 @@ async def test_standards_client_search_iso_iec_uses_no_source_filter() -> None:
 
 @pytest.mark.asyncio
 async def test_standards_client_search_no_body_hits_relaton_cache_once() -> None:
-    """All-bodies search invokes the Relaton cache once, CC cache once.
+    """All-bodies search invokes the Relaton cache once, CC cache once, CEN cache once.
 
     Regression guard: the three RelatonLiveFetcher instances (ISO, IEC,
     ISO/IEC) should be deduped to the source=None variant in the no-body
     path so the cache isn't queried three times for overlapping results.
-    The CC fetcher also queries the cache separately.
+    The CC and CEN fetchers also query the cache separately.
     """
     from unittest.mock import AsyncMock
 
@@ -1402,14 +1402,16 @@ async def test_standards_client_search_no_body_hits_relaton_cache_once() -> None
             client = StandardsClient(http, cache=mock_cache)
             await client.search("test-query")
 
-    assert mock_cache.search_synced_standards.await_count == 2
+    assert mock_cache.search_synced_standards.await_count == 3
     calls = mock_cache.search_synced_standards.call_args_list
     # First call is ISO/IEC Relaton with source=None
     # Second call is CC with source="CC"
+    # Third call is CEN with source="CEN"
     assert any(call[1].get("source") is None for call in calls), (
         "ISO/IEC Relaton fetch missing"
     )
     assert any(call[1].get("source") == "CC" for call in calls), "CC fetch missing"
+    assert any(call[1].get("source") == "CEN" for call in calls), "CEN fetch missing"
 
 
 @pytest.mark.asyncio
@@ -1575,3 +1577,106 @@ async def test_cc_fetcher_cache_miss_logs_warning_and_returns_none(
         "cc_cache_miss" in rec.message and "sync-standards" in rec.message
         for rec in caplog.records
     )
+
+
+def test_resolve_en_plain() -> None:
+    """Plain EN identifier resolves to body 'CEN'."""
+    assert resolve_identifier_local("EN 55032:2015") == ("EN 55032:2015", "CEN")
+
+
+def test_resolve_en_iso() -> None:
+    """EN ISO identifier resolves to body 'CEN'."""
+    assert resolve_identifier_local("EN ISO 13849-1:2023") == (
+        "EN ISO 13849-1:2023",
+        "CEN",
+    )
+
+
+def test_resolve_en_iec() -> None:
+    """EN IEC identifier resolves to body 'CEN'."""
+    assert resolve_identifier_local("EN IEC 62443-3-3:2020") == (
+        "EN IEC 62443-3-3:2020",
+        "CEN",
+    )
+
+
+def test_resolve_en_iso_iec() -> None:
+    """EN ISO/IEC identifier resolves to body 'CEN'."""
+    assert resolve_identifier_local("EN ISO/IEC 27001:2022") == (
+        "EN ISO/IEC 27001:2022",
+        "CEN",
+    )
+
+
+def test_resolve_etsi_en_still_dispatches_to_etsi() -> None:
+    """ETSI EN 303 645 must still dispatch to 'ETSI', not 'CEN'.
+
+    Regression guard: the ETSI regex requires explicit 'ETSI' prefix,
+    so it wins by position over the generic EN regex.
+    """
+    result = resolve_identifier_local("ETSI EN 303 645")
+    assert result is not None
+    assert result[1] == "ETSI"
+
+
+@pytest.mark.asyncio
+async def test_cen_fetcher_registered() -> None:
+    """_fetchers['CEN'] is a _CENFetcher."""
+    from scholar_mcp._standards_client import _CENFetcher
+
+    async with httpx.AsyncClient() as http:
+        client = StandardsClient(http)
+        fetcher = client._fetchers["CEN"]
+    assert isinstance(fetcher, _CENFetcher)
+
+
+@pytest.mark.asyncio
+async def test_cen_fetcher_cache_miss_logs_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """_CENFetcher.get on cache miss logs WARNING with sync hint."""
+    import logging
+    from unittest.mock import AsyncMock
+
+    from scholar_mcp._standards_client import _CENFetcher
+
+    mock_cache = AsyncMock()
+    mock_cache.get_standard = AsyncMock(return_value=None)
+
+    fetcher = _CENFetcher(cache=mock_cache)
+    with caplog.at_level(logging.WARNING, logger="scholar_mcp._standards_client"):
+        result = await fetcher.get("EN 99999:2099")
+
+    assert result is None
+    assert any(
+        "cen_cache_miss" in rec.message and "sync-standards" in rec.message
+        for rec in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_standards_client_search_cen_delegates_to_cache() -> None:
+    """search(body='CEN') forwards source='CEN' to the cache."""
+    from unittest.mock import AsyncMock
+
+    from scholar_mcp._record_types import StandardRecord
+
+    record: StandardRecord = {
+        "identifier": "EN 55032:2015",
+        "title": "EMC of multimedia equipment",
+        "body": "CEN",
+        "status": "harmonised",
+        "full_text_available": False,
+    }
+    mock_cache = AsyncMock()
+    mock_cache.search_synced_standards = AsyncMock(return_value=[record])
+    mock_cache.get_standard = AsyncMock(return_value=None)
+
+    async with httpx.AsyncClient() as http:
+        client = StandardsClient(http, cache=mock_cache)
+        results = await client.search("55032", body="CEN")
+
+    mock_cache.search_synced_standards.assert_awaited_once_with(
+        "55032", source="CEN", limit=10
+    )
+    assert results == [record]

--- a/tests/test_sync_cen.py
+++ b/tests/test_sync_cen.py
@@ -158,6 +158,48 @@ async def test_cen_loader_force_rewrites(tmp_path: Path) -> None:
         await cache.close()
 
 
+# ---------------------------------------------------------------------------
+# _normalise_en_identifier unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_normalise_en_identifier_plain_unchanged() -> None:
+    """Plain identifiers with no amendment or version are returned unchanged."""
+    from scholar_mcp._sync_cen import _normalise_en_identifier
+
+    assert _normalise_en_identifier("EN 55032:2015") == "EN 55032:2015"
+    assert _normalise_en_identifier("EN ISO 13849-1:2023") == "EN ISO 13849-1:2023"
+    assert _normalise_en_identifier("EN 61000-3-2:2019") == "EN 61000-3-2:2019"
+
+
+def test_normalise_en_identifier_strips_amendment() -> None:
+    """Amendment suffix +Ax:yyyy is stripped for cache-key consistency."""
+    from scholar_mcp._sync_cen import _normalise_en_identifier
+
+    assert _normalise_en_identifier("EN 349:1993+A1:2008") == "EN 349:1993"
+    assert _normalise_en_identifier("EN 62368-1:2020+A11:2020") == "EN 62368-1:2020"
+    assert _normalise_en_identifier("EN 71-1:2014+A1:2018") == "EN 71-1:2014"
+    assert (
+        _normalise_en_identifier("EN IEC 60601-1:2006+A1:2013") == "EN IEC 60601-1:2006"
+    )
+    assert _normalise_en_identifier("EN ISO 11161:2007+A1:2010") == "EN ISO 11161:2007"
+
+
+def test_normalise_en_identifier_strips_version_token() -> None:
+    """ETSI version token Vx.y.z is stripped for cache-key consistency."""
+    from scholar_mcp._sync_cen import _normalise_en_identifier
+
+    assert _normalise_en_identifier("EN 300 328 V2.2.2:2019") == "EN 300 328:2019"
+    assert _normalise_en_identifier("EN 301 489-17 V3.2.4:2020") == "EN 301 489-17:2020"
+    assert _normalise_en_identifier("EN 301 511 V12.5.1:2017") == "EN 301 511:2017"
+    assert _normalise_en_identifier("EN 301 908-1 V13.1.1:2019") == "EN 301 908-1:2019"
+
+
+# ---------------------------------------------------------------------------
+# _hs_to_record normalisation tests
+# ---------------------------------------------------------------------------
+
+
 def test_hs_to_record_strips_amendment_suffix() -> None:
     """Amendment suffix +A1:2008 stripped from cache key."""
     from scholar_mcp._sync_cen import HarmonisedStandard, _hs_to_record

--- a/tests/test_sync_cen.py
+++ b/tests/test_sync_cen.py
@@ -156,3 +156,64 @@ async def test_cen_loader_force_rewrites(tmp_path: Path) -> None:
         assert forced.added == 0
     finally:
         await cache.close()
+
+
+def test_hs_to_record_strips_amendment_suffix() -> None:
+    """Amendment suffix +A1:2008 stripped from cache key."""
+    from scholar_mcp._sync_cen import HarmonisedStandard, _hs_to_record
+
+    entry = HarmonisedStandard(
+        identifier="EN 349:1993+A1:2008",
+        title="Safety of machinery — Minimum gaps",
+        directive="Machinery",
+    )
+    record = _hs_to_record(entry)
+    assert record["identifier"] == "EN 349:1993"
+
+
+def test_hs_to_record_strips_version_suffix() -> None:
+    """Version V2.2.2 stripped from cache key for RED entries."""
+    from scholar_mcp._sync_cen import HarmonisedStandard, _hs_to_record
+
+    entry = HarmonisedStandard(
+        identifier="EN 300 328 V2.2.2:2019",
+        title="Wideband data transmission — 2.4 GHz",
+        directive="RED",
+    )
+    record = _hs_to_record(entry)
+    assert record["identifier"] == "EN 300 328:2019"
+
+
+@pytest.mark.asyncio
+async def test_cen_loader_amendment_identifier_findable(tmp_path: Path) -> None:
+    """Records with +A1:yyyy suffix are retrievable after sync."""
+    from scholar_mcp._cache import ScholarCache
+    from scholar_mcp._sync_cen import CENLoader
+
+    cache = ScholarCache(tmp_path / "cache.db")
+    await cache.open()
+    try:
+        await CENLoader().sync(cache)
+        # EN 349:1993+A1:2008 in table → stored as EN 349:1993
+        rec = await cache.get_standard("EN 349:1993")
+        assert rec is not None, "amendment-suffix identifier not findable"
+        assert rec["body"] == "CEN"
+    finally:
+        await cache.close()
+
+
+@pytest.mark.asyncio
+async def test_cen_loader_etsi_3part_identifier_findable(tmp_path: Path) -> None:
+    """Records with ETSI 3-part numbers are retrievable after sync."""
+    from scholar_mcp._cache import ScholarCache
+    from scholar_mcp._sync_cen import CENLoader
+
+    cache = ScholarCache(tmp_path / "cache.db")
+    await cache.open()
+    try:
+        await CENLoader().sync(cache)
+        # EN 300 328 V2.2.2:2019 in table → stored as EN 300 328:2019
+        rec = await cache.get_standard("EN 300 328:2019")
+        assert rec is not None, "3-part EN number not findable"
+    finally:
+        await cache.close()

--- a/tests/test_sync_cen.py
+++ b/tests/test_sync_cen.py
@@ -1,0 +1,158 @@
+"""Tests for _sync_cen — CEN/CENELEC harmonised-standards loader."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def test_harmonised_standards_table_not_empty() -> None:
+    """Table has a substantial number of standards."""
+    from scholar_mcp._sync_cen import _HARMONISED_STANDARDS
+
+    assert len(_HARMONISED_STANDARDS) >= 50
+
+
+def test_harmonised_standards_identifiers_unique() -> None:
+    """No duplicate identifiers in the table."""
+    from scholar_mcp._sync_cen import _HARMONISED_STANDARDS
+
+    ids = [e.identifier for e in _HARMONISED_STANDARDS]
+    assert len(ids) == len(set(ids)), (
+        f"duplicates: {[x for x in ids if ids.count(x) > 1]}"
+    )
+
+
+def test_harmonised_standards_all_have_directive() -> None:
+    """Every entry has a non-empty directive."""
+    from scholar_mcp._sync_cen import _HARMONISED_STANDARDS
+
+    for entry in _HARMONISED_STANDARDS:
+        assert entry.directive, f"{entry.identifier} has empty directive"
+
+
+def test_harmonised_standards_identifiers_start_with_en() -> None:
+    """All identifiers start with 'EN '."""
+    from scholar_mcp._sync_cen import _HARMONISED_STANDARDS
+
+    for entry in _HARMONISED_STANDARDS:
+        assert entry.identifier.startswith("EN "), (
+            f"{entry.identifier} doesn't start with 'EN '"
+        )
+
+
+def test_hs_to_record_plain_en() -> None:
+    """Plain EN standard maps to body='CEN', full_text_available=False."""
+    from scholar_mcp._sync_cen import HarmonisedStandard, _hs_to_record
+
+    entry = HarmonisedStandard(
+        identifier="EN 55032:2015",
+        title="Electromagnetic compatibility of multimedia equipment — Emission requirements",
+        directive="EMC",
+        status="harmonised",
+        published_date="2015-11-13",
+    )
+    record = _hs_to_record(entry)
+
+    assert record["identifier"] == "EN 55032:2015"
+    assert record["body"] == "CEN"
+    assert record["status"] == "harmonised"
+    assert record["full_text_available"] is False
+    assert record["price"] is None
+    assert record["title"].startswith("Electromagnetic compatibility")
+    assert record["published_date"] == "2015-11-13"
+
+
+def test_hs_to_record_en_iso() -> None:
+    """EN ISO identifier preserved verbatim, body still 'CEN'."""
+    from scholar_mcp._sync_cen import HarmonisedStandard, _hs_to_record
+
+    entry = HarmonisedStandard(
+        identifier="EN ISO 13849-1:2023",
+        title="Safety of machinery — Safety-related parts of control systems — Part 1: General principles for design",
+        directive="Machinery",
+        status="harmonised",
+        published_date="2023-06-14",
+    )
+    record = _hs_to_record(entry)
+
+    assert record["identifier"] == "EN ISO 13849-1:2023"
+    assert record["body"] == "CEN"
+
+
+def test_hs_to_record_withdrawn() -> None:
+    """Withdrawn entry maps status correctly."""
+    from scholar_mcp._sync_cen import HarmonisedStandard, _hs_to_record
+
+    entry = HarmonisedStandard(
+        identifier="EN 55022:2010",
+        title="Information technology equipment — Radio disturbance characteristics",
+        directive="EMC",
+        status="withdrawn",
+        published_date="2010-12-01",
+    )
+    record = _hs_to_record(entry)
+
+    assert record["status"] == "withdrawn"
+
+
+@pytest.mark.asyncio
+async def test_cen_loader_cold_sync(tmp_path: Path) -> None:
+    """Cold sync writes all table records."""
+    from scholar_mcp._cache import ScholarCache
+    from scholar_mcp._sync_cen import _HARMONISED_STANDARDS, CENLoader
+
+    cache = ScholarCache(tmp_path / "cache.db")
+    await cache.open()
+    try:
+        report = await CENLoader().sync(cache)
+
+        assert report.added == len(_HARMONISED_STANDARDS)
+        assert report.body == "CEN"
+        assert report.errors == []
+        # Spot-check
+        rec = await cache.get_standard("EN 55032:2015")
+        assert rec is not None
+        assert rec["body"] == "CEN"
+    finally:
+        await cache.close()
+
+
+@pytest.mark.asyncio
+async def test_cen_loader_resync_unchanged_short_circuits(tmp_path: Path) -> None:
+    """Re-sync with same table hash returns unchanged report."""
+    from scholar_mcp._cache import ScholarCache
+    from scholar_mcp._sync_cen import CENLoader
+
+    cache = ScholarCache(tmp_path / "cache.db")
+    await cache.open()
+    try:
+        first = await CENLoader().sync(cache)
+        second = await CENLoader().sync(cache)
+
+        assert first.added > 0
+        assert second.added == 0
+        assert second.unchanged > 0
+        assert second.upstream_ref == first.upstream_ref
+    finally:
+        await cache.close()
+
+
+@pytest.mark.asyncio
+async def test_cen_loader_force_rewrites(tmp_path: Path) -> None:
+    """force=True bypasses the hash gate."""
+    from scholar_mcp._cache import ScholarCache
+    from scholar_mcp._sync_cen import _HARMONISED_STANDARDS, CENLoader
+
+    cache = ScholarCache(tmp_path / "cache.db")
+    await cache.open()
+    try:
+        await CENLoader().sync(cache)
+        forced = await CENLoader().sync(cache, force=True)
+
+        # Everything counted as unchanged (content identical)
+        assert forced.unchanged == len(_HARMONISED_STANDARDS)
+        assert forced.added == 0
+    finally:
+        await cache.close()


### PR DESCRIPTION
## Summary

- CEN/CENELEC as a Tier 2 sync-only body: ~62 harmonised standards from 7 EU directives (EMC, RED, Machinery, MDR, CRA, GPSR, LVD) via a hard-coded `_HARMONISED_STANDARDS` table in `_sync_cen.py`.
- No HTTP, no Formex XML — the table IS the source of truth. `CENLoader` takes no arguments, iterates the constant, writes to cache. Content-hash gate for idempotent re-sync.
- EN identifier regex groups (`EN`, `EN ISO`, `EN IEC`, `EN ISO/IEC`) all dispatching to `body="CEN"`. Placed after ETSI in `resolve_identifier_local` so `ETSI EN 303 645` still dispatches to ETSI.
- Cache-only `_CENFetcher` (mirrors `_CCFetcher`) — CEN has no live API; cache miss logs WARNING with sync hint.
- No cross-linking EN → ISO/IEC records — the `EN ISO` / `EN IEC` prefix is self-documenting.

Closes #83. References #137 (EUR-Lex Formex XML automation), #138 (live scrape fallback), #139 (quarterly table review).

Design spec: `docs/specs/2026-04-16-pr4b-cen-loader-design.md`

## Commit layout

1. `docs(standards): PR 4b CEN/CENELEC harmonised-standards loader design spec`
2. `feat(standards): CEN harmonised-standards table + CENLoader` — data model, 62 entries, record builder, loader with content-hash gate + withdrawal guard
3. `feat(standards): register CEN in StandardsClient + CLI + identifier regex` — EN regex groups, `_CENFetcher`, `_fetchers["CEN"]`, `_select_loaders`
4. `docs(standards): CEN/CENELEC body in README and standards guide`

## Test Plan

- [ ] `uv run pytest -x -q` — 972 passed, 4 deselected
- [ ] `uv run ruff check --fix . && uv run ruff format --check .` — clean
- [ ] `uv run mypy src/` — clean (48 source files)
- [ ] Table integrity: 62 entries, no duplicates, all have directives, all start with `EN `
- [ ] Regression: `ETSI EN 303 645` still dispatches to ETSI (not CEN)

🤖 Generated with [Claude Code](https://claude.com/claude-code)