### PR TITLE
fix(sync): guard against plain strings in Relaton YAML list fields

### DIFF
--- a/src/scholar_mcp/_sync_relaton.py
+++ b/src/scholar_mcp/_sync_relaton.py
@@ -97,10 +97,12 @@ def _canonical_identifier_and_body(
     if not docidentifiers:
         return None
 
-    def _is_trademark(entry: dict[str, Any]) -> bool:
+    def _is_trademark(entry: Any) -> bool:
+        if not isinstance(entry, dict):
+            return False
         return str(entry.get("scope", "")).lower() == "trademark"
 
-    non_tm = [d for d in docidentifiers if not _is_trademark(d)]
+    non_tm = [d for d in docidentifiers if isinstance(d, dict) and not _is_trademark(d)]
     if not non_tm:
         return None
 
@@ -171,6 +173,8 @@ def _first_link_of_type(links: list[dict[str, Any]] | None, wanted: str) -> str 
     if not links:
         return None
     for link in links:
+        if not isinstance(link, dict):
+            continue
         if str(link.get("type", "")).lower() == wanted:
             content = link.get("content")
             if isinstance(content, str) and content:
@@ -195,6 +199,8 @@ def _published_date(dates: list[dict[str, Any]] | None) -> str | None:
     if not dates:
         return None
     for entry in dates:
+        if not isinstance(entry, dict):
+            continue
         if str(entry.get("type", "")).lower() == "published":
             value = entry.get("value")
             if isinstance(value, str):
@@ -206,12 +212,16 @@ def _superseded_by(relations: list[dict[str, Any]] | None) -> str | None:
     if not relations:
         return None
     for rel in relations:
+        if not isinstance(rel, dict):
+            continue
         if str(rel.get("type", "")).lower() != "obsoleted-by":
             continue
         bibitem = rel.get("bibitem") or {}
+        if not isinstance(bibitem, dict):
+            continue
         idents = bibitem.get("docid") or bibitem.get("docidentifier") or []
         for ident in idents:
-            if ident.get("id"):
+            if isinstance(ident, dict) and ident.get("id"):
                 return str(ident["id"])
     return None
 
@@ -221,12 +231,16 @@ def _supersedes(relations: list[dict[str, Any]] | None) -> list[str]:
     if not relations:
         return out
     for rel in relations:
+        if not isinstance(rel, dict):
+            continue
         if str(rel.get("type", "")).lower() != "obsoletes":
             continue
         bibitem = rel.get("bibitem") or {}
+        if not isinstance(bibitem, dict):
+            continue
         idents = bibitem.get("docid") or bibitem.get("docidentifier") or []
         for ident in idents:
-            if ident.get("id"):
+            if isinstance(ident, dict) and ident.get("id"):
                 out.append(str(ident["id"]))
     return out
 
@@ -318,6 +332,8 @@ def _yaml_to_record(
 
     aliases: list[str] = []
     for entry in docidentifiers:
+        if not isinstance(entry, dict):
+            continue
         alias = entry.get("id")
         if not isinstance(alias, str):
             continue

--- a/tests/test_sync_relaton.py
+++ b/tests/test_sync_relaton.py
@@ -1413,3 +1413,157 @@ docstatus:
         assert await cache.get_standard("ISO 9001:2015") is not None
     finally:
         await cache.close()
+
+
+# ---------------------------------------------------------------------------
+# isinstance guard tests — ISO edge cases with non-dict list entries
+# ---------------------------------------------------------------------------
+
+
+def test_yaml_to_record_string_docidentifier_entries_skipped() -> None:
+    """docidentifier list containing plain strings should not raise."""
+    from scholar_mcp._sync_relaton import _yaml_to_record
+
+    doc = {
+        "docid": [
+            "ISO 9001:2015",  # plain string — must be skipped, not crash
+            {"id": "ISO 9001:2015", "type": "ISO", "primary": True},
+        ],
+        "title": [{"content": "Quality management"}],
+    }
+    record, aliases = _yaml_to_record(doc)
+
+    assert record is not None
+    assert record["identifier"] == "ISO 9001:2015"
+    # The plain string entry should not appear in aliases
+    assert "ISO 9001:2015" not in aliases
+
+
+def test_yaml_to_record_string_relation_entries_skipped() -> None:
+    """relation list containing plain strings should not raise."""
+    from scholar_mcp._sync_relaton import _yaml_to_record
+
+    doc = {
+        "docid": [{"id": "ISO 9001:2008", "type": "ISO", "primary": True}],
+        "title": [{"content": "Quality management (old)"}],
+        "docstatus": {"stage": "95.99"},
+        "relation": [
+            "obsoleted-by ISO 9001:2015",  # plain string — must be skipped
+            {
+                "type": "obsoleted-by",
+                "bibitem": {
+                    "docid": [{"id": "ISO 9001:2015", "type": "ISO"}],
+                },
+            },
+        ],
+    }
+    record, _ = _yaml_to_record(doc)
+
+    assert record is not None
+    assert record["superseded_by"] == "ISO 9001:2015"
+
+
+def test_yaml_to_record_string_bibitem_skipped() -> None:
+    """relation entry with bibitem as a string should not raise."""
+    from scholar_mcp._sync_relaton import _yaml_to_record
+
+    doc = {
+        "docid": [{"id": "ISO 9001:2008", "type": "ISO", "primary": True}],
+        "title": [{"content": "Quality management (old)"}],
+        "relation": [
+            {
+                "type": "obsoleted-by",
+                "bibitem": "ISO 9001:2015",  # string instead of dict
+            },
+        ],
+    }
+    record, _ = _yaml_to_record(doc)
+
+    assert record is not None
+    assert record["superseded_by"] is None
+
+
+def test_yaml_to_record_string_ident_in_bibitem_skipped() -> None:
+    """docid list inside relation.bibitem containing plain strings should not raise."""
+    from scholar_mcp._sync_relaton import _yaml_to_record
+
+    doc = {
+        "docid": [{"id": "ISO 9001:2008", "type": "ISO", "primary": True}],
+        "title": [{"content": "Quality management (old)"}],
+        "relation": [
+            {
+                "type": "obsoleted-by",
+                "bibitem": {
+                    "docid": ["ISO 9001:2015"],  # plain string in list
+                },
+            },
+        ],
+    }
+    record, _ = _yaml_to_record(doc)
+
+    assert record is not None
+    assert record["superseded_by"] is None
+
+
+def test_yaml_to_record_string_link_entries_skipped() -> None:
+    """link list containing plain strings should not raise."""
+    from scholar_mcp._sync_relaton import _yaml_to_record
+
+    doc = {
+        "docid": [{"id": "ISO 9001:2015", "type": "ISO", "primary": True}],
+        "title": [{"content": "Quality management"}],
+        "link": [
+            "https://www.iso.org/standard/62085.html",  # plain string — must be skipped
+            {"type": "src", "content": "https://www.iso.org/standard/62085.html"},
+        ],
+    }
+    record, _ = _yaml_to_record(doc)
+
+    assert record is not None
+    assert record["url"] == "https://www.iso.org/standard/62085.html"
+
+
+def test_yaml_to_record_string_date_entries_skipped() -> None:
+    """date list containing plain strings should not raise."""
+    from scholar_mcp._sync_relaton import _yaml_to_record
+
+    doc = {
+        "docid": [{"id": "ISO 9001:2015", "type": "ISO", "primary": True}],
+        "title": [{"content": "Quality management"}],
+        "date": [
+            "2015-09-15",  # plain string — must be skipped
+            {"type": "published", "value": "2015-09-15"},
+        ],
+    }
+    record, _ = _yaml_to_record(doc)
+
+    assert record is not None
+    assert record["published_date"] == "2015-09-15"
+
+
+def test_yaml_to_record_supersedes_string_entries_skipped() -> None:
+    """relation 'obsoletes' entries containing string idents should not raise."""
+    from scholar_mcp._sync_relaton import _yaml_to_record
+
+    doc = {
+        "docid": [{"id": "ISO 9001:2015", "type": "ISO", "primary": True}],
+        "title": [{"content": "Quality management"}],
+        "relation": [
+            {
+                "type": "obsoletes",
+                "bibitem": {
+                    "docid": ["ISO 9001:2008"],  # plain string in list
+                },
+            },
+            {
+                "type": "obsoletes",
+                "bibitem": {
+                    "docid": [{"id": "ISO 9001:2008", "type": "ISO"}],
+                },
+            },
+        ],
+    }
+    record, _ = _yaml_to_record(doc)
+
+    assert record is not None
+    assert record["supersedes"] == ["ISO 9001:2008"]


### PR DESCRIPTION
## Summary

- **Root cause**: ISO sync failed with `AttributeError: 'str' object has no attribute 'get'` because some ISO YAML files contain plain strings mixed into list fields (`docid`, `link`, `date`, `relation`) that are otherwise lists of dicts. Calling `.get()` on a string raises the error.
- **Fix**: Add `isinstance(x, dict)` guards at every site in `_sync_relaton.py` that calls `.get()` on list items: `_canonical_identifier_and_body`, `_first_link_of_type`, `_published_date`, `_superseded_by`, `_supersedes`, and the aliases loop in `_yaml_to_record`. Non-dict entries are silently skipped.
- IEC/IEEE/CC/CEN synced fine because their YAML files don't have this edge case at scale; ISO's ~24K records expose it.

## Test plan

- [ ] `uv run pytest -x -q` — all 1019 tests pass
- [ ] `uv run mypy src/` — clean
- [ ] `uv run ruff check . && uv run ruff format --check .` — clean
- [ ] 7 new regression tests, one per guard site — 93% coverage on `_sync_relaton.py`
- [ ] After merge, re-run `docker compose exec -u appuser scholar-mcp scholar-mcp sync-standards --body ISO` to confirm ISO completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)