### PR TITLE
chore(copier): update to v1.1.1

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by `copier update`.
-_commit: v1.1.0
+_commit: v1.1.1
 _src_path: https://github.com/pvliesdonk/fastmcp-server-template
 docker_registry: ghcr.io/pvliesdonk
 domain_description: FastMCP server for Semantic Scholar with OpenAlex enrichment and

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by `copier update`.
-_commit: v1.0.4
+_commit: v1.1.0
 _src_path: https://github.com/pvliesdonk/fastmcp-server-template
 docker_registry: ghcr.io/pvliesdonk
 domain_description: FastMCP server for Semantic Scholar with OpenAlex enrichment and

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,11 +21,11 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: python
           queries: security-extended
           config-file: .github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/copier-update.yml
+++ b/.github/workflows/copier-update.yml
@@ -50,7 +50,15 @@ jobs:
           VCS_REF: ${{ inputs.vcs_ref }}
         run: |
           set -euo pipefail
-          args=(update --trust --defaults --skip-answered --conflict=rej)
+          # `--conflict=inline` runs a real 3-way merge and writes standard
+          # `<<<<<<< before updating / ||||||| last update / ======= / >>>>>>> after updating`
+          # markers when local edits collide with template changes.  The
+          # alternative `--conflict=rej` is dangerously misleading: it
+          # blindly renders the new template content into the working file
+          # and only writes a `.rej` sidecar describing what was lost — so
+          # divergent local lines (license overrides, version bumps, etc.)
+          # silently disappear.
+          args=(update --trust --defaults --skip-answered --conflict=inline)
           if [ -n "${VCS_REF}" ]; then
             args+=(--vcs-ref "${VCS_REF}")
           fi
@@ -78,9 +86,14 @@ jobs:
             echo "::error::could not read _commit from .copier-answers.yml"
             exit 1
           fi
-          rej_count=$(find . -name '*.rej' -not -path './.git/*' | wc -l | tr -d ' ')
+          # `--conflict=inline` writes standard `<<<<<<< before updating`
+          # markers (not `.rej` sidecars).  Count files that contain at
+          # least one conflict marker; skip binary files with `git grep -I`.
+          # `|| true` swallows git grep's exit code 1 on no-match so the
+          # happy path (zero conflicts) doesn't trip `set -euo pipefail`.
+          conflict_count=$( { git grep -lI '^<<<<<<< before updating$' || true; } | wc -l | tr -d ' ')
           echo "ref=${ref}" >> "$GITHUB_OUTPUT"
-          echo "rej_count=${rej_count}" >> "$GITHUB_OUTPUT"
+          echo "conflict_count=${conflict_count}" >> "$GITHUB_OUTPUT"
 
       - name: Ensure `copier` label exists
         if: steps.changes.outputs.changed == 'true'
@@ -108,7 +121,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           REF: ${{ steps.meta.outputs.ref }}
-          REJ_COUNT: ${{ steps.meta.outputs.rej_count }}
+          CONFLICT_COUNT: ${{ steps.meta.outputs.conflict_count }}
         run: |
           set -euo pipefail
           branch="copier/update"
@@ -118,10 +131,10 @@ jobs:
           # multi-line bash string would break the enclosing YAML block scalar
           # because the continuation lines would need to stay at column 11.
           body="Automated \`copier update\` run against template ref \`${REF}\`."
-          body+=$'\n\n'"Review the diff, fix any \`.rej\` conflict files, and merge if CI is green."
+          body+=$'\n\n'"Review the diff, resolve any \`<<<<<<< before updating\` conflict markers, and merge if CI is green."
           body+=$'\n\n'"> **Note:** \`--skip-answered\` was passed, so any **new** template variables introduced since the last update were silently filled with their copier defaults. Skim \`.copier-answers.yml\` for unexpected new keys."
-          if [ "${REJ_COUNT}" -gt 0 ]; then
-            body+=$'\n\n'"⚠️ **${REJ_COUNT} \`.rej\` conflict file(s) present — review and resolve manually before merging.**"
+          if [ "${CONFLICT_COUNT}" -gt 0 ]; then
+            body+=$'\n\n'"⚠️ **${CONFLICT_COUNT} file(s) contain unresolved \`<<<<<<< before updating\` conflict markers — review and resolve manually before merging.**"
           fi
 
           if gh pr view "${branch}" --json state --jq '.state' 2>/dev/null | grep -q OPEN; then

--- a/.github/workflows/copier-update.yml
+++ b/.github/workflows/copier-update.yml
@@ -1,0 +1,141 @@
+name: Copier Update
+
+# Weekly automated `copier update` against this project's template source.
+# If the template has moved since `.copier-answers.yml:_commit`, opens (or
+# refreshes) a PR on branch `copier/update` so CI can validate the diff and
+# an operator can review/merge.
+#
+# Uses the RELEASE_TOKEN PAT (not GITHUB_TOKEN) so the opened PR triggers
+# downstream workflows — GITHUB_TOKEN-authored PRs are muted by design.
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"  # Monday 06:00 UTC
+  workflow_dispatch:
+    inputs:
+      vcs_ref:
+        description: "Template ref to update to (default: latest tag from .copier-answers.yml source)"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          version: "latest"
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Run copier update
+        id: copier
+        env:
+          VCS_REF: ${{ inputs.vcs_ref }}
+        run: |
+          set -euo pipefail
+          args=(update --trust --defaults --skip-answered --conflict=rej)
+          if [ -n "${VCS_REF}" ]; then
+            args+=(--vcs-ref "${VCS_REF}")
+          fi
+          uvx copier "${args[@]}"
+
+      - name: Detect changes
+        id: changes
+        run: |
+          if git diff --quiet && git diff --cached --quiet && [ -z "$(git ls-files --others --exclude-standard)" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Read template ref + count conflicts
+        if: steps.changes.outputs.changed == 'true'
+        id: meta
+        run: |
+          set -euo pipefail
+          # Parse `_commit:` from .copier-answers.yml without depending on
+          # PyYAML being present in the runner's system Python.  copier's
+          # to_nice_yaml output puts the key on its own line in canonical form.
+          ref=$(awk '/^_commit:[[:space:]]/ {print $2; exit}' .copier-answers.yml)
+          if [ -z "${ref}" ]; then
+            echo "::error::could not read _commit from .copier-answers.yml"
+            exit 1
+          fi
+          rej_count=$(find . -name '*.rej' -not -path './.git/*' | wc -l | tr -d ' ')
+          echo "ref=${ref}" >> "$GITHUB_OUTPUT"
+          echo "rej_count=${rej_count}" >> "$GITHUB_OUTPUT"
+
+      - name: Ensure `copier` label exists
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          gh label create copier \
+            --color C5DEF5 \
+            --description "Automated copier template sync" \
+            2>/dev/null || true
+
+      - name: Commit and push to copier/update branch
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          branch="copier/update"
+          git checkout -B "${branch}"
+          git add -A
+          git commit -m "chore(copier): update to ${{ steps.meta.outputs.ref }}" \
+            -m "Automated \`copier update\` run — review the diff and merge if CI is green."
+          git push --force-with-lease origin "${branch}"
+
+      - name: Open or update PR
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          REF: ${{ steps.meta.outputs.ref }}
+          REJ_COUNT: ${{ steps.meta.outputs.rej_count }}
+        run: |
+          set -euo pipefail
+          branch="copier/update"
+          title="chore(copier): update to ${REF}"
+
+          # Build the PR body piece-by-piece with $'\n' separators — a single
+          # multi-line bash string would break the enclosing YAML block scalar
+          # because the continuation lines would need to stay at column 11.
+          body="Automated \`copier update\` run against template ref \`${REF}\`."
+          body+=$'\n\n'"Review the diff, fix any \`.rej\` conflict files, and merge if CI is green."
+          body+=$'\n\n'"> **Note:** \`--skip-answered\` was passed, so any **new** template variables introduced since the last update were silently filled with their copier defaults. Skim \`.copier-answers.yml\` for unexpected new keys."
+          if [ "${REJ_COUNT}" -gt 0 ]; then
+            body+=$'\n\n'"⚠️ **${REJ_COUNT} \`.rej\` conflict file(s) present — review and resolve manually before merging.**"
+          fi
+
+          if gh pr view "${branch}" --json state --jq '.state' 2>/dev/null | grep -q OPEN; then
+            gh pr edit "${branch}" \
+              --title "${title}" \
+              --body "${body}" \
+              --add-label copier \
+              --add-label dependencies
+          else
+            gh pr create \
+              --base main \
+              --head "${branch}" \
+              --title "${title}" \
+              --body "${body}" \
+              --label copier \
+              --label dependencies
+          fi

--- a/.github/workflows/coverage-status.yml
+++ b/.github/workflows/coverage-status.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Download patch coverage artifact
         id: download
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: patch-coverage
           run-id: ${{ github.event.workflow_run.id }}

--- a/uv.lock
+++ b/uv.lock
@@ -1881,7 +1881,7 @@ wheels = [
 
 [[package]]
 name = "pvliesdonk-scholar-mcp"
-version = "1.8.0rc1"
+version = "1.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

First copier update from \`v1.0.4\` → \`v1.1.0\`. Bootstraps the new \`copier-update.yml\` workflow into this repo so future updates run on the Monday cron.

## Changes

- ✨ **New** \`.github/workflows/copier-update.yml\` — weekly + manual \`copier update\` runs that open a PR on \`copier/update\` whenever the template moves.
- ⬆️ \`github/codeql-action\` v3 → v4 (closes #153)
- ⬆️ \`actions/download-artifact\` v4 → v8 in \`coverage-status.yml\` (closes #152) — local file diverged from template at retrofit time, the 3-way merge couldn't carry it; bumped manually here.

## Manual cleanup applied

Three \`.rej\` conflict files (\`ci.yml.rej\`, \`docs.yml.rej\`, \`release.yml.rej\`) were dropped — all hunks were \`setup-uv 8.0.0 → 8.1.0\` and \`deploy-pages v4 → v5\`, both already at target locally via merged dependabot PRs #150 and #151.

Template-scaffold tests \`tests/test_smoke.py\` + \`tests/test_tools.py\` were re-emitted by copier (they reference the template's \`server.py\` + \`ping\` tool, neither of which exist in scholar) and dropped.

## Test plan

- [x] \`uv run ruff check .\` → clean
- [x] \`uv run pytest -x -q\` → 1021 passed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)