### PR TITLE
chore(copier): bootstrap copier-update workflow + align with template v1.1.4

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by `copier update`.
-_commit: v1.1.3
+_commit: v1.1.4
 _src_path: https://github.com/pvliesdonk/fastmcp-server-template
 docker_registry: ghcr.io/pvliesdonk
 domain_description: FastMCP server for Semantic Scholar with OpenAlex enrichment and

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by `copier update`.
-_commit: v1.0.4
+_commit: v1.1.3
 _src_path: https://github.com/pvliesdonk/fastmcp-server-template
 docker_registry: ghcr.io/pvliesdonk
 domain_description: FastMCP server for Semantic Scholar with OpenAlex enrichment and

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,11 +21,11 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: python
           queries: security-extended
           config-file: .github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/copier-update.yml
+++ b/.github/workflows/copier-update.yml
@@ -1,0 +1,160 @@
+name: Copier Update
+
+# Weekly automated `copier update` against this project's template source.
+# If the template has moved since `.copier-answers.yml:_commit`, opens (or
+# refreshes) a PR on branch `copier/update` so CI can validate the diff and
+# an operator can review/merge.
+#
+# Uses the RELEASE_TOKEN PAT (not GITHUB_TOKEN) so the opened PR triggers
+# downstream workflows — GITHUB_TOKEN-authored PRs are muted by design.
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"  # Monday 06:00 UTC
+  workflow_dispatch:
+    inputs:
+      vcs_ref:
+        description: "Template ref to update to (default: latest tag from .copier-answers.yml source)"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          version: "latest"
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Run copier update
+        env:
+          VCS_REF: ${{ inputs.vcs_ref }}
+        run: |
+          set -euo pipefail
+          # `--conflict=inline` runs a real 3-way merge and writes standard
+          # `<<<<<<< before updating / ||||||| last update / ======= / >>>>>>> after updating`
+          # markers when local edits collide with template changes.  The
+          # alternative `--conflict=rej` is dangerously misleading: it
+          # blindly renders the new template content into the working file
+          # and only writes a `.rej` sidecar describing what was lost — so
+          # divergent local lines (license overrides, version bumps, etc.)
+          # silently disappear.
+          args=(update --trust --defaults --skip-answered --conflict=inline)
+          if [ -n "${VCS_REF}" ]; then
+            args+=(--vcs-ref "${VCS_REF}")
+          fi
+          uvx copier "${args[@]}"
+
+      - name: Detect changes
+        id: changes
+        run: |
+          if git diff --quiet && git diff --cached --quiet && [ -z "$(git ls-files --others --exclude-standard)" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Read template ref + count conflicts
+        if: steps.changes.outputs.changed == 'true'
+        id: meta
+        run: |
+          set -euo pipefail
+          # Parse `_commit:` from .copier-answers.yml without depending on
+          # PyYAML being present in the runner's system Python.  copier's
+          # to_nice_yaml output puts the key on its own line in canonical form.
+          ref=$(awk '/^_commit:[[:space:]]/ {print $2; exit}' .copier-answers.yml)
+          if [ -z "${ref}" ]; then
+            echo "::error::could not read _commit from .copier-answers.yml"
+            exit 1
+          fi
+          # `--conflict=inline` writes standard `<<<<<<< before updating`
+          # markers (not `.rej` sidecars).  Count files that contain at
+          # least one conflict marker; skip binary files with `git grep -I`.
+          # `|| true` swallows git grep's exit code 1 on no-match so the
+          # happy path (zero conflicts) doesn't trip `set -euo pipefail`.
+          conflict_count=$( { git grep -lI '^<<<<<<< before updating$' || true; } | wc -l | tr -d ' ')
+          echo "ref=${ref}" >> "$GITHUB_OUTPUT"
+          echo "conflict_count=${conflict_count}" >> "$GITHUB_OUTPUT"
+
+      - name: Ensure PR labels exist
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          # `gh pr create --label foo` fails if the label doesn't exist,
+          # so ensure both labels are present first.  `|| true` keeps the
+          # step idempotent across repeat runs.
+          gh label create copier \
+            --color C5DEF5 \
+            --description "Automated copier template sync" \
+            2>/dev/null || true
+          gh label create dependencies \
+            --color 0075CA \
+            --description "Pull requests that update a dependency file" \
+            2>/dev/null || true
+
+      - name: Commit and push to copier/update branch
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          branch="copier/update"
+          git checkout -B "${branch}"
+          git add -A
+          git commit -m "chore(copier): update to ${{ steps.meta.outputs.ref }}" \
+            -m "Automated \`copier update\` run — review the diff and merge if CI is green."
+          git push --force-with-lease origin "${branch}"
+
+      - name: Open or update PR
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          REF: ${{ steps.meta.outputs.ref }}
+          CONFLICT_COUNT: ${{ steps.meta.outputs.conflict_count }}
+        run: |
+          set -euo pipefail
+          branch="copier/update"
+          title="chore(copier): update to ${REF}"
+
+          # Build the PR body piece-by-piece with $'\n' separators — a single
+          # multi-line bash string would break the enclosing YAML block scalar
+          # because the continuation lines would need to stay at column 11.
+          body="Automated \`copier update\` run against template ref \`${REF}\`."
+          body+=$'\n\n'"Review the diff, resolve any \`<<<<<<< before updating\` conflict markers, and merge if CI is green."
+          body+=$'\n\n'"> **Note:** \`--skip-answered\` was passed, so any **new** template variables introduced since the last update were silently filled with their copier defaults. Skim \`.copier-answers.yml\` for unexpected new keys."
+          if [ "${CONFLICT_COUNT}" -gt 0 ]; then
+            body+=$'\n\n'"⚠️ **${CONFLICT_COUNT} file(s) contain unresolved \`<<<<<<< before updating\` conflict markers — review and resolve manually before merging.**"
+          fi
+
+          if gh pr view "${branch}" --json state --jq '.state' 2>/dev/null | grep -q OPEN; then
+            gh pr edit "${branch}" \
+              --title "${title}" \
+              --body "${body}" \
+              --add-label copier \
+              --add-label dependencies
+          else
+            gh pr create \
+              --base main \
+              --head "${branch}" \
+              --title "${title}" \
+              --body "${body}" \
+              --label copier \
+              --label dependencies
+          fi

--- a/.github/workflows/copier-update.yml
+++ b/.github/workflows/copier-update.yml
@@ -113,12 +113,14 @@ jobs:
 
       - name: Commit and push to copier/update branch
         if: steps.changes.outputs.changed == 'true'
+        env:
+          REF: ${{ steps.meta.outputs.ref }}
         run: |
           set -euo pipefail
           branch="copier/update"
           git checkout -B "${branch}"
           git add -A
-          git commit -m "chore(copier): update to ${{ steps.meta.outputs.ref }}" \
+          git commit -m "chore(copier): update to ${REF}" \
             -m "Automated \`copier update\` run — review the diff and merge if CI is green."
           git push --force-with-lease origin "${branch}"
 

--- a/.github/workflows/coverage-status.yml
+++ b/.github/workflows/coverage-status.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Download patch coverage artifact
         id: download
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: patch-coverage
           run-id: ${{ github.event.workflow_run.id }}

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
+from scholar_mcp.server import make_server
+
 
 def test_make_server_constructs() -> None:
     """make_server() returns a FastMCP instance without raising."""
-    from scholar_mcp.server import make_server
-
     server = make_server()
     assert server is not None

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,11 @@
+"""Smoke tests for Scholar MCP."""
+
+from __future__ import annotations
+
+
+def test_make_server_constructs() -> None:
+    """make_server() returns a FastMCP instance without raising."""
+    from scholar_mcp.server import make_server
+
+    server = make_server()
+    assert server is not None

--- a/uv.lock
+++ b/uv.lock
@@ -1881,7 +1881,7 @@ wheels = [
 
 [[package]]
 name = "pvliesdonk-scholar-mcp"
-version = "1.8.0rc1"
+version = "1.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

First copier update since scholar's v1.0.4 retrofit, skipping directly to **v1.1.3** — the first stable version after the review iterations that fixed scaffold re-creation, `--conflict=inline`, and label guards.

Supersedes #156, which targeted the stale v1.1.1 and carried the `--conflict=rej` workflow bug that was fixed upstream.

## Diff carried by copier update

- **Add `.github/workflows/copier-update.yml`** — the weekly auto-sync workflow. This is what we're bootstrapping.
- `.github/workflows/codeql.yml`: `github/codeql-action` v3 → v4. Closes #153.
- `tests/test_smoke.py`: canonical template content (imports `scholar_mcp.server.make_server`, which exists post-#157).

## Manually brought in line (3-way merge couldn't carry)

- `.github/workflows/coverage-status.yml`: `actions/download-artifact` v4 → v8. Scholar's file diverged from template's v8 baseline during the original retrofit and copier has no patch between v1.0.4 and v1.1.3 to apply. Closes #152.

## `uv.lock` self-entry version: `1.8.0rc1` → `1.7.0` (not a regression)

Copier's fresh render re-syncs `uv.lock`'s `pvliesdonk-scholar-mcp` self-entry with the authoritative `pyproject.toml` (currently `1.7.0` — scholar's last stable release). The previous `1.8.0rc1` was a stale rc entry that never corresponded to a released build. No code or dependency change, just a lockfile correction.

## Close #156 after merge

This PR replaces #156's scope. #156 has the outdated v1.1.1 workflow content and the `--conflict=rej` bug; this PR lands the fixed v1.1.3 equivalent.

## Follow-ups (separate PRs)

- `pyproject.toml` sentinel backfill: add `PROJECT-DEPS-START/END` and `PROJECT-EXTRAS-START/END` zones so future template dep additions merge cleanly.
- `CLAUDE.md` sentinel alignment: `DOMAIN-START/END` + `TEMPLATE-OWNED SECTIONS` markers.
- Template: wrap the shell commit-message interpolation in `env:` so `steps.meta.outputs.ref` doesn't interpolate directly into a shell string. Low risk for tag refs, but belt-and-suspenders for non-tag refs. [Reviewer's informational note — template-level fix.]

## Test plan

- [x] `uv run ruff check .` → clean
- [x] `uv run ruff format --check .` → clean
- [x] `uv run mypy src/` → clean
- [x] `uv run pytest -x -q` → 1024 passed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)