### PR TITLE
refactor(pyproject): add PROJECT-DEPS + PROJECT-EXTRAS sentinel markers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,16 +21,20 @@ dependencies = [
     # only list deps scholar uses DIRECTLY here.
     "fastmcp-pvl-core>=1.0,<2",
     "typer>=0.12",
+    # PROJECT-DEPS-START — domain dependencies; kept across copier update
     "httpx",
     "aiosqlite",
     "python-epo-ops-client>=4.2",
     "lxml>=5.0",
     "beautifulsoup4>=4.14.3",
+    # PROJECT-DEPS-END
 ]
 
 [project.optional-dependencies]
+# PROJECT-EXTRAS-START — domain optional-dependency groups; kept across copier update
 mcp = ["fastmcp[tasks]>=3.2.0,<4"]
 all = ["fastmcp[tasks]>=3.2.0,<4"]
+# PROJECT-EXTRAS-END
 dev = [
     "pytest>=7.0",
     "pytest-asyncio>=0.21",


### PR DESCRIPTION
## Summary

Template convention wraps domain `dependencies` entries and `optional-dependencies` groups in sentinel markers so copier's 3-way merge has stable anchors when the template adds/removes universal deps (e.g. the `typer` entry was added at some point above the zone).

Scholar was retrofitted at template v1.0.4 before the sentinel convention stabilised. Backfilling now so future template dep additions merge cleanly.

## Changes

Pure comment additions — no code changed:

- `PROJECT-DEPS-START / PROJECT-DEPS-END` wraps `httpx`, `aiosqlite`, `python-epo-ops-client`, `lxml`, `beautifulsoup4` — the scholar-specific deps. Universal `fastmcp-pvl-core` and `typer` stay outside the zone since they're template-shipped.
- `PROJECT-EXTRAS-START / PROJECT-EXTRAS-END` wraps the `mcp` and `all` extras. The `dev` and `docs` extras stay outside the zone (template convention treats them as first-class template concerns).

## Test plan

- [x] `uv run ruff check .` → clean
- [x] `uv run ruff format --check .` → clean
- [x] `uv run mypy src/` → clean
- [x] `uv run pytest -x -q` → 1024 passed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)