### PR TITLE
refactor(claude-md): add DOMAIN + TEMPLATE-OWNED sentinel structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,13 @@
 
 FastMCP server scaffold. See [TEMPLATE.md](TEMPLATE.md) for customisation guide.
 
+## Design
+<!-- DOMAIN-START -->
+<!-- Add scholar-mcp design notes here. Kept across copier update. -->
+<!-- DOMAIN-END -->
+
 ## Project Structure
+<!-- DOMAIN-START -->
 
 ```
 src/scholar_mcp/
@@ -16,6 +22,9 @@ src/scholar_mcp/
   _task_queue.py       -- In-memory task queue for background async operations
   _rate_limiter.py     -- Rate limiter, retry, try-once + RateLimitedError
 ```
+<!-- DOMAIN-END -->
+
+<!-- ===== TEMPLATE-OWNED SECTIONS BELOW — DO NOT EDIT; CHANGES WILL BE OVERWRITTEN ON COPIER UPDATE ===== -->
 
 ## Conventions
 
@@ -24,13 +33,9 @@ src/scholar_mcp/
 - `hatchling` build backend
 - Conventional commits: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`
 - Google-style docstrings on all public functions
-- `logging.getLogger(__name__)` throughout, no `print()` — see **Logging Standard** below
+- `logging.getLogger(__name__)` throughout, no `print()`
 - Type hints everywhere
-
-## Documentation
-
-- `README.md` and `docs/**` must be kept up to date with any user-facing changes (new tools, config options, CLI flags, deployment changes, etc.)
-- Update docs in the same PR as the code change
+- Tests: `pytest` with fixtures in `tests/fixtures/`
 
 ## Hard PR Acceptance Gates
 
@@ -40,8 +45,8 @@ Every PR must pass **all** of the following before merge. Do not open or push a 
 2. **Lint passes** — run in this exact order: `uv run ruff check --fix .` then `uv run ruff format .` then verify with `uv run ruff format --check .`. Always run format *after* check --fix because check --fix can leave files needing reformatting.
 3. **Type-check passes** — `uv run mypy src/` reports no errors
 4. **Patch coverage ≥ 80%** — Codecov measures only lines added/changed in the PR diff. Run `uv run pytest --cov=<changed_module> --cov-report=term-missing` and verify new code is exercised. Add tests for every uncovered branch before pushing.
-5. **Docs updated** — `README.md` and `docs/**` reflect any user-facing changes in the same commit. Includes `.claude-plugin/plugin/README.md` and `docs/guides/claude-code-plugin.md` when plugin-related.
-6. **Manifest version lockstep** — `server.json`, `.claude-plugin/plugin/.claude-plugin/plugin.json`, and `.claude-plugin/plugin/.mcp.json` must carry the same version. The release workflow bumps all three atomically.
+5. **Docs updated** — `README.md` and `docs/**` reflect any user-facing changes in the same commit
+6. **Manifest version lockstep** — `server.json`, `.claude-plugin/plugin/.claude-plugin/plugin.json`, and `.claude-plugin/plugin/.mcp.json` must all carry the same version. The release workflow bumps them atomically via PSR; manual touches require updating all three.
 
 ## GitHub Review Types
 
@@ -52,15 +57,17 @@ GitHub has two distinct review mechanisms — **both must be read and addressed*
 
 Always fetch both before declaring a review round complete.
 
-## Key Patterns
+## Documentation Discipline
 
-- Library is sync; MCP layer uses `asyncio.to_thread()` for blocking calls
-- Write tools tagged `tags={"write"}`, hidden via `mcp.disable(tags={"write"})` in read-only mode
-- All tools have MCP annotations (`readOnlyHint`, `destructiveHint`, `openWorldHint`)
-- Auth: `_build_bearer_auth()` + `_build_oidc_auth()` called in `make_server()`; MultiAuth when both set
-- `_ENV_PREFIX` in `config.py` controls all env var names — change once, affects everything
-- **Async task queue**: S2 tools try once (`retry=False`); on 429 `RateLimitedError`, queue with retries for background execution. PDF tools always queue (unless cache hit). `TaskQueue` lives in `ServiceBundle.tasks`.
-- **Tool queueing pattern**: extract tool logic into `async def _execute(*, retry=True) -> str`, try with `retry=False`, catch `RateLimitedError` and `bundle.tasks.submit(_execute(retry=True))`
+Every issue, PR, and code change must consider documentation impact. Before closing any issue or creating any PR, check whether the following need updating:
+
+- **`docs/design.md`** — the authoritative spec. Any new feature, changed behavior, or architectural decision must be reflected here.
+- **`README.md`** — user-facing documentation. New env vars, tools, resources, prompts, CLI flags, or configuration options must be documented here.
+- **`docs/` site pages** — the published documentation site. New or changed MCP tools/resources/prompts, new env vars, new installation methods or deployment options.
+- **`CHANGELOG.md`** — managed by semantic-release from conventional commits.
+- **Inline docstrings** — new or changed public API methods need accurate Google-style docstrings.
+
+**Rule: code without matching docs is incomplete.**
 
 ## Logging Standard
 
@@ -73,15 +80,15 @@ Always fetch both before declaring a review round complete.
 ### Log Levels
 | Level | Use for |
 |-------|---------|
-| `DEBUG` | Detailed internals: cache hits, parameter values, enrichment attempts, rate-limit queueing |
+| `DEBUG` | Detailed internals: cache hits, parameter values, config resolution |
 | `INFO` | Significant operations: service startup, configuration decisions (tool calls logged by middleware) |
 | `WARNING` | Degraded but continuing: API errors with fallback, missing optional config, unexpected data |
 | `ERROR` | Failures affecting the primary result. Use `logger.error(..., exc_info=True)` when traceback is needed |
 
 ### Exception Handling
 - All exceptions must be caught and handled. No bare `except:`. Always specify the exception type.
-- Expected errors (HTTP 4xx, rate limits, missing data): catch, log, return user-facing error string.
-- Optional enrichment failures (OpenAlex, Unpaywall): catch, log at `DEBUG` with `exc_info=True`, continue.
+- Expected errors (HTTP 4xx, missing data): catch, log, return user-facing error string.
+- Optional enrichment failures: catch, log at `DEBUG` with `exc_info=True`, continue.
 - Primary result errors: catch, log at `WARNING` or `ERROR`, return error string.
 - `ErrorHandlingMiddleware` is a safety net. If it catches something, that's a bug to fix.
 
@@ -89,3 +96,23 @@ Always fetch both before declaring a review round complete.
 - Pseudo-structured: `logger.info("event_name key=%s", value)`
 - Event name as first token (snake_case), then key=value pairs via `%s` formatting.
 - Never use f-strings in log calls (defeats lazy evaluation).
+
+## Config & Customization Contract
+
+Domain configuration composes :class:`fastmcp_pvl_core.ServerConfig` inside :class:`ProjectConfig` (see `src/scholar_mcp/config.py`).  Add domain fields between the `CONFIG-FIELDS-START` / `CONFIG-FIELDS-END` sentinels and populate them in `from_env` between the `CONFIG-FROM-ENV-START` / `CONFIG-FROM-ENV-END` sentinels.  Never inherit from `ServerConfig`; always compose.
+
+Env var prefix is `SCHOLAR_MCP_` — all env reads go through `fastmcp_pvl_core.env(_ENV_PREFIX, "SUFFIX", default)` so naming stays consistent.
+
+<!-- ===== TEMPLATE-OWNED SECTIONS END ===== -->
+
+## Key Patterns
+<!-- DOMAIN-START -->
+
+- Library is sync; MCP layer uses `asyncio.to_thread()` for blocking calls
+- Write tools tagged `tags={"write"}`, hidden via `mcp.disable(tags={"write"})` in read-only mode
+- All tools have MCP annotations (`readOnlyHint`, `destructiveHint`, `openWorldHint`)
+- Auth: `_build_bearer_auth()` + `_build_oidc_auth()` called in `make_server()`; MultiAuth when both set
+- `_ENV_PREFIX` in `config.py` controls all env var names — change once, affects everything
+- **Async task queue**: S2 tools try once (`retry=False`); on 429 `RateLimitedError`, queue with retries for background execution. PDF tools always queue (unless cache hit). `TaskQueue` lives in `ServiceBundle.tasks`.
+- **Tool queueing pattern**: extract tool logic into `async def _execute(*, retry=True) -> str`, try with `retry=False`, catch `RateLimitedError` and `bundle.tasks.submit(_execute(retry=True))`
+<!-- DOMAIN-END -->


### PR DESCRIPTION
Structural move.  No functional changes.  Prepares for clean copier-update diffs from template v1.1.5.

See spec in fastmcp-server-template repo: `docs/superpowers/specs/2026-04-22-copier-sync-and-claude-md-parity-design.md` §3.2.