### PR TITLE
chore(copier): converge drifted template-owned files to v1.1.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,34 +1,46 @@
+# Python bytecode
 __pycache__/
 *.py[cod]
 *$py.class
+*.so
+
+# Distribution / packaging
 *.egg-info/
+*.egg
 dist/
 build/
 .eggs/
-*.egg
+
+# Virtualenvs
 .venv/
 venv/
-.env
-*.so
+
+# Tooling caches
 .mypy_cache/
 .pytest_cache/
 .ruff_cache/
+
+# Test / coverage artifacts
 .coverage
 coverage.xml
+coverage.json
 htmlcov/
-*.npy
-*.npz
+
+# MkDocs build output
 site/
 
-# Local artifacts (scholar-specific)
-coverage.json
-.playwright-mcp/
+# Local environment
+.env
+.env.local
 
-# Shared dev-ecosystem ignores (align with template convention)
+# --- Development / ecosystem ignores (don't ship)
 .mcpregistry_*
 .worktrees/
-# Claude Code local overrides (scope narrowly so project-shared assets
-# under .claude/ — hooks, custom commands, agents — stay committable)
 .claude/worktrees/
 .claude/settings.local.json
 docs/superpowers/
+
+# --- Scholar-specific local artifacts
+*.npy
+*.npz
+.playwright-mcp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,32 @@
 FROM python:3.12-slim
 
+# DOCKERFILE-APT-DEPS-START — add domain apt packages below; kept across copier update
 RUN apt-get update && apt-get install -y --no-install-recommends git gosu \
     && rm -rf /var/lib/apt/lists/*
+# DOCKERFILE-APT-DEPS-END
 
 COPY --from=ghcr.io/astral-sh/uv:0.6 /uv /uvx /bin/
 
 ENV UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy
 
-# Create non-root user early so COPY --chown works without recursive chown.
+WORKDIR /app
+
+# DOCKERFILE-UV-EXTRAS-START — append `--extra <name>` flags below to pull domain-specific extras; kept across copier update
+# Install dependencies first (cache layer).
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    uv sync --frozen --no-install-project --no-dev --extra all
+
+# Copy source and install project.
+COPY pyproject.toml README.md /app/
+COPY src/ /app/src/
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev --extra all
+# DOCKERFILE-UV-EXTRAS-END
+
+# Create non-root user with configurable UID/GID for bind-mount compatibility.
 ARG APP_UID=1000
 ARG APP_GID=1000
 RUN if [ "$APP_UID" -eq 0 ] || [ "$APP_GID" -eq 0 ]; then \
@@ -17,24 +35,7 @@ RUN if [ "$APP_UID" -eq 0 ] || [ "$APP_GID" -eq 0 ]; then \
     && groupadd -r --gid $APP_GID --non-unique appuser \
     && useradd -r --uid $APP_UID --gid $APP_GID --no-log-init -d /app appuser \
     && mkdir -p /data/service /data/state/fastmcp \
-    && chown appuser:appuser /data /data/service /data/state /data/state/fastmcp
-
-WORKDIR /app
-RUN chown appuser:appuser /app
-
-# Install dependencies first as appuser (cache layer).
-RUN --mount=type=cache,target=/home/appuser/.cache/uv,uid=$APP_UID,gid=$APP_GID \
-    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    --mount=type=bind,source=uv.lock,target=uv.lock \
-    chown appuser:appuser . \
-    && su appuser -s /bin/sh -c "uv sync --frozen --no-install-project --no-dev --extra all"
-
-# Copy source and install project as appuser.
-COPY --chown=appuser:appuser . .
-USER appuser
-RUN --mount=type=cache,target=/home/appuser/.cache/uv,uid=$APP_UID,gid=$APP_GID \
-    uv sync --frozen --no-dev --extra all
-USER root
+    && chown -R appuser:appuser /app /data
 
 COPY --chmod=0755 docker-entrypoint.sh /usr/local/bin/
 ENV PATH="/app/.venv/bin:$PATH" \
@@ -45,4 +46,4 @@ EXPOSE 8000
 VOLUME ["/data/service", "/data/state"]
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
-CMD ["scholar-mcp", "serve", "--transport", "http"]
+CMD ["scholar-mcp", "serve", "--transport", "http", "--host", "0.0.0.0"]

--- a/scripts/bump_manifests.py
+++ b/scripts/bump_manifests.py
@@ -59,12 +59,37 @@ def main() -> int:
         )
         return 1
     server = _load(server_path)
+    if not isinstance(server, dict):
+        print(
+            f"{server_path} must contain a JSON object (top-level), "
+            f"got {type(server).__name__}",
+            file=sys.stderr,
+        )
+        return 1
     server["version"] = version
-    for pkg in server.get("packages", []):
+    packages = server.get("packages", [])
+    if not isinstance(packages, list):
+        print(
+            f"{server_path}: 'packages' must be a JSON array, got "
+            f"{type(packages).__name__}",
+            file=sys.stderr,
+        )
+        return 1
+    for i, pkg in enumerate(packages):
+        if not isinstance(pkg, dict):
+            print(
+                f"WARNING: packages[{i}] is not a JSON object "
+                f"(got {type(pkg).__name__}) — skipped",
+                file=sys.stderr,
+            )
+            continue
         if pkg.get("registryType") == "pypi":
             pkg["version"] = version
         elif pkg.get("registryType") == "oci":
-            identifier = pkg.get("identifier", "")
+            # ``or ""`` covers both the absent-key and the JSON-null cases;
+            # ``dict.get(key, default)`` only returns default when the key
+            # is absent, not when the value is None.
+            identifier = pkg.get("identifier") or ""
             new_id, n = re.subn(r":v[^:]+$", f":v{version}", identifier)
             if n == 0:
                 print(


### PR DESCRIPTION
Pre-emptive alignment before the Phase 4 copier-update bot PR lands.  See spec in fastmcp-server-template repo: `docs/superpowers/specs/2026-04-22-copier-sync-and-claude-md-parity-design.md` §2.4 + §3.3 Phase 1.5.

## Files converged

- **`.gitignore`** — adopt template's commented-section layout; scholar-specific entries (`*.npy`, `*.npz`, `.playwright-mcp/`) moved to a dedicated trailing block so future template bumps touch only the shared portion.
- **`scripts/bump_manifests.py`** — adopt template v1.1.5's defensive isinstance checks. Scholar had no custom logic, so convergence is loss-free.
- **`Dockerfile`** — adopt v1.1.5 sentinel blocks (`DOCKERFILE-APT-DEPS-*`, `DOCKERFILE-UV-EXTRAS-*`) with scholar's `--extra all` migrated into the UV-EXTRAS block. Also adopt the simplified root-build + single recursive chown pattern and `--host 0.0.0.0` in CMD.

## Files preserved (domain content, not pure drift)

- **`docker-entrypoint.sh`** — scholar `mkdir -p`s `/data/state/embeddings` and `/data/state/fastembed` for its embeddings pipeline.
- **`docs/deployment/docker.md`** — ~138 lines of domain-specific docs (S2 API key, docling-serve compose stack, traefik labels with scholar-mcp image).
- **`docs/deployment/oidc.md`** — uses the correct `SCHOLAR_MCP_` env prefix; the template ships hardcoded `MCP_SERVER_` placeholders (tracked as a separate template bug).
- **`docs/guides/authentication.md`** — scholar documents 5 auth modes (multi-auth, remote, oidc-proxy, bearer, none) with the correct prefix; template renders only a 4-mode version.

## Files skipped (no drift)

- `compose.yml`, `codecov.yml` — already match template.

## Local gate

- `uv sync --all-extras --dev` OK
- `uv run ruff check .` — All checks passed
- `uv run ruff format --check .` — 107 files already formatted
- `uv run mypy src/` — no issues in 50 source files
- `uv run pytest -x -q` — 1024 passed, 4 deselected

## Do not merge yet

Blocked on Phase 4 / bot PR sequencing.