### PR TITLE
chore(copier): update to v1.1.8

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by `copier update`.
-_commit: v1.1.4
+_commit: v1.1.8
 _src_path: https://github.com/pvliesdonk/fastmcp-server-template
 docker_registry: ghcr.io/pvliesdonk
 domain_description: FastMCP server for Semantic Scholar with OpenAlex enrichment and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,9 +99,18 @@ Every issue, PR, and code change must consider documentation impact. Before clos
 
 ## Config & Customization Contract
 
-Domain configuration composes :class:`fastmcp_pvl_core.ServerConfig` inside :class:`ProjectConfig` (see `src/scholar_mcp/config.py`).  Add domain fields between the `CONFIG-FIELDS-START` / `CONFIG-FIELDS-END` sentinels and populate them in `from_env` between the `CONFIG-FROM-ENV-START` / `CONFIG-FROM-ENV-END` sentinels.  Never inherit from `ServerConfig`; always compose.
+Domain configuration composes `fastmcp_pvl_core.ServerConfig` inside your domain config class (see `src/scholar_mcp/config.py`).  Add domain fields between the `CONFIG-FIELDS-START` / `CONFIG-FIELDS-END` sentinels and populate them in `from_env` between the `CONFIG-FROM-ENV-START` / `CONFIG-FROM-ENV-END` sentinels.  Never inherit from `ServerConfig`; always compose.
 
 Env var prefix is `SCHOLAR_MCP_` — all env reads go through `fastmcp_pvl_core.env(_ENV_PREFIX, "SUFFIX", default)` so naming stays consistent.
+
+## Shared Infrastructure
+
+Shared infrastructure (auth providers, middleware stack, logging bootstrap, event store factory, CLI scaffolding, release pipeline, Docker entrypoint, nfpm packaging, mcpb bundle) lives upstream in two places:
+
+- [`fastmcp-pvl-core`](https://github.com/pvliesdonk/fastmcp-pvl-core) — the Python library that provides `ServerConfig`, auth builders, middleware helpers, artifact store, and the `make_serve_parser` / `configure_logging_from_env` / `normalise_http_path` CLI helpers.
+- [`fastmcp-server-template`](https://github.com/pvliesdonk/fastmcp-server-template) — the copier template this project was generated from. Ships the CI/release workflows, `Dockerfile`, `packaging/nfpm.yaml`, `packaging/mcpb/*`, `scripts/bump_manifests.py`, server.py skeleton, and this very section of CLAUDE.md.
+
+Fixes and improvements to shared code land in those repos and propagate here via `copier update` against the template's latest tag — run manually or via the weekly `.github/workflows/copier-update.yml` cron. Starter files listed in `_skip_if_exists` (e.g. `scripts/bump_manifests.py`, `packaging/mcpb/*`, the `tools.py` / `resources.py` / `prompts.py` / `domain.py` scaffolds, `README.md`, `CHANGELOG.md`, `LICENSE`, `.env.example`) are written once and require manual reconciliation on template updates — review `_skip_if_exists` in the template's `copier.yml` if you need to force-sync a file. Domain-specific code (tools, resources, prompts, and the fields and logic inside the `CONFIG-FIELDS-START` / `CONFIG-FIELDS-END` and `CONFIG-FROM-ENV-START` / `CONFIG-FROM-ENV-END` sentinels) stays in this repo.
 
 <!-- ===== TEMPLATE-OWNED SECTIONS END ===== -->
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,14 @@
 FROM python:3.12-slim
 
 # DOCKERFILE-APT-DEPS-START — add domain apt packages below; kept across copier update
+<<<<<<< before updating
 RUN apt-get update && apt-get install -y --no-install-recommends git gosu \
     && rm -rf /var/lib/apt/lists/*
+=======
+RUN apt-get update && apt-get install -y --no-install-recommends git git-lfs gosu \
+    && rm -rf /var/lib/apt/lists/* \
+    && git lfs install --system
+>>>>>>> after updating
 # DOCKERFILE-APT-DEPS-END
 
 COPY --from=ghcr.io/astral-sh/uv:0.6 /uv /uvx /bin/
@@ -23,7 +29,11 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 COPY pyproject.toml README.md /app/
 COPY src/ /app/src/
 RUN --mount=type=cache,target=/root/.cache/uv \
+<<<<<<< before updating
     uv sync --frozen --no-dev --extra all
+=======
+    uv sync --frozen --no-dev
+>>>>>>> after updating
 # DOCKERFILE-UV-EXTRAS-END
 
 # Create non-root user with configurable UID/GID for bind-mount compatibility.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,8 @@
 FROM python:3.12-slim
 
 # DOCKERFILE-APT-DEPS-START — add domain apt packages below; kept across copier update
-<<<<<<< before updating
 RUN apt-get update && apt-get install -y --no-install-recommends git gosu \
     && rm -rf /var/lib/apt/lists/*
-=======
-RUN apt-get update && apt-get install -y --no-install-recommends git git-lfs gosu \
-    && rm -rf /var/lib/apt/lists/* \
-    && git lfs install --system
->>>>>>> after updating
 # DOCKERFILE-APT-DEPS-END
 
 COPY --from=ghcr.io/astral-sh/uv:0.6 /uv /uvx /bin/
@@ -29,11 +23,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 COPY pyproject.toml README.md /app/
 COPY src/ /app/src/
 RUN --mount=type=cache,target=/root/.cache/uv \
-<<<<<<< before updating
     uv sync --frozen --no-dev --extra all
-=======
-    uv sync --frozen --no-dev
->>>>>>> after updating
 # DOCKERFILE-UV-EXTRAS-END
 
 # Create non-root user with configurable UID/GID for bind-mount compatibility.


### PR DESCRIPTION
Automated `copier update` run against template ref `v1.1.8`.

Review the diff, resolve any `<<<<<<< before updating` conflict markers, and merge if CI is green.

> **Note:** `--skip-answered` was passed, so any **new** template variables introduced since the last update were silently filled with their copier defaults. Skim `.copier-answers.yml` for unexpected new keys.

⚠️ **1 file(s) contain unresolved `<<<<<<< before updating` conflict markers — review and resolve manually before merging.**