### PR TITLE
chore(copier): update to v1.2.0

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by `copier update`.
-_commit: v1.1.9
+_commit: v1.2.0
 _src_path: https://github.com/pvliesdonk/fastmcp-server-template
 docker_registry: ghcr.io/pvliesdonk
 domain_description: FastMCP server for Semantic Scholar with OpenAlex enrichment and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         run: uv sync --all-extras
 
       - name: Run mypy
-        run: uv run mypy src/
+        run: uv run mypy src/ tests/
 
   test:
     name: Test (Python ${{ matrix.python-version }})

--- a/.github/workflows/copier-update.yml
+++ b/.github/workflows/copier-update.yml
@@ -45,10 +45,19 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Run copier update
+        id: copier
         env:
           VCS_REF: ${{ inputs.vcs_ref }}
         run: |
           set -euo pipefail
+          # Capture the pre-update `_commit` BEFORE copier rewrites
+          # `.copier-answers.yml` with the new ref — the PR body uses it to
+          # render the prev_ref→ref delta and a compare link.  `|| true` so
+          # a missing/corrupt answers file doesn't abort before the update
+          # (the post-update meta step re-parses and hard-fails if needed).
+          prev_ref=$(awk '/^_commit:[[:space:]]/ {print $2; exit}' .copier-answers.yml || true)
+          echo "prev_ref=${prev_ref}" >> "$GITHUB_OUTPUT"
+
           # `--conflict=inline` runs a real 3-way merge and writes standard
           # `<<<<<<< before updating / ||||||| last update / ======= / >>>>>>> after updating`
           # markers when local edits collide with template changes.  The
@@ -72,7 +81,7 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Read template ref + count conflicts
+      - name: Read template ref + collect conflict files
         if: steps.changes.outputs.changed == 'true'
         id: meta
         run: |
@@ -86,13 +95,42 @@ jobs:
             exit 1
           fi
           # `--conflict=inline` writes standard `<<<<<<< before updating`
-          # markers (not `.rej` sidecars).  Count files that contain at
+          # markers (not `.rej` sidecars).  Collect files that contain at
           # least one conflict marker; skip binary files with `git grep -I`.
           # `|| true` swallows git grep's exit code 1 on no-match so the
           # happy path (zero conflicts) doesn't trip `set -euo pipefail`.
-          conflict_count=$( { git grep -lI '^<<<<<<< before updating$' || true; } | wc -l | tr -d ' ')
+          # We emit the file *list* (not just the count) so the PR body can
+          # tell the reviewer exactly which files need manual resolution.
+          conflict_files=$( { git grep -lI '^<<<<<<< before updating$' || true; } )
+          if [ -n "${conflict_files}" ]; then
+            conflict_count=$(printf '%s\n' "${conflict_files}" | wc -l | tr -d ' ')
+          else
+            conflict_count=0
+          fi
+          # Derive the template source repo from `_src_path` in .copier-answers.yml
+          # rather than synthesising from `{{ github_org }}` — `github_org` is the
+          # *consumer's* org (for Docker paths, etc.), not the template source's.
+          # Normalize the common forms copier may have stored ({gh:,https://github.com/,
+          # git@github.com:}org/repo[.git]) down to `org/repo`; local paths or anything
+          # else unrecognised becomes empty and the PR step skips the release-notes
+          # and compare-link sections gracefully.
+          src_path=$(awk '/^_src_path:[[:space:]]/ {print $2; exit}' .copier-answers.yml || true)
+          template_repo=$(printf '%s' "${src_path}" \
+            | sed -E 's|^gh:||; s|^https?://github\.com/||; s|^git@github\.com:||; s|\.git$||; s|/+$||')
+          if ! printf '%s' "${template_repo}" | grep -qE '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$'; then
+            template_repo=""
+          fi
           echo "ref=${ref}" >> "$GITHUB_OUTPUT"
           echo "conflict_count=${conflict_count}" >> "$GITHUB_OUTPUT"
+          echo "template_repo=${template_repo}" >> "$GITHUB_OUTPUT"
+          # Multiline `conflict_files` needs the heredoc form of $GITHUB_OUTPUT.
+          # The `CONFLICT_FILES_EOF` delimiter is safe because git-tracked file paths
+          # can't contain newlines, let alone a line that matches that literal string.
+          {
+            echo "conflict_files<<CONFLICT_FILES_EOF"
+            printf '%s\n' "${conflict_files}"
+            echo "CONFLICT_FILES_EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Ensure PR labels exist
         if: steps.changes.outputs.changed == 'true'
@@ -131,26 +169,93 @@ jobs:
             -m "Automated \`copier update\` run — review the diff and merge if CI is green."
           git push --force-with-lease origin "${branch}"
 
+      - name: Compute diff summary
+        if: steps.changes.outputs.changed == 'true'
+        id: diff
+        run: |
+          set -euo pipefail
+          # `copier/update` is always `main + 1 commit` because the previous
+          # step does `git checkout -B` off the checked-out default branch
+          # before making a single commit, so HEAD~1..HEAD captures exactly
+          # this update's delta — no merge-base math needed.
+          diff_count=$(git diff --name-only HEAD~1 HEAD | wc -l | tr -d ' ')
+          echo "diff_count=${diff_count}" >> "$GITHUB_OUTPUT"
+          {
+            echo "diff_stat<<DIFF_STAT_EOF"
+            git diff --stat HEAD~1 HEAD
+            echo "DIFF_STAT_EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Open or update PR
         if: steps.changes.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           REF: ${{ steps.meta.outputs.ref }}
+          PREV_REF: ${{ steps.copier.outputs.prev_ref }}
+          TEMPLATE_REPO: ${{ steps.meta.outputs.template_repo }}
           CONFLICT_COUNT: ${{ steps.meta.outputs.conflict_count }}
+          CONFLICT_FILES: ${{ steps.meta.outputs.conflict_files }}
+          DIFF_COUNT: ${{ steps.diff.outputs.diff_count }}
+          DIFF_STAT: ${{ steps.diff.outputs.diff_stat }}
         run: |
           set -euo pipefail
           branch="copier/update"
           title="chore(copier): update to ${REF}"
 
+          # Fetch release notes for the target ref.  Empty when the release
+          # isn't cut yet (e.g. a manual `--vcs-ref` run targeting an unreleased
+          # sha) or when `_src_path` doesn't resolve to a GitHub repo (local
+          # template dev) — in which case the notes section is skipped.
+          release_notes=""
+          if [ -n "${TEMPLATE_REPO}" ]; then
+            release_notes=$(gh release view "${REF}" \
+              --repo "${TEMPLATE_REPO}" \
+              --json body --jq .body 2>/dev/null || true)
+          fi
+
           # Build the PR body piece-by-piece with $'\n' separators — a single
           # multi-line bash string would break the enclosing YAML block scalar
           # because the continuation lines would need to stay at column 11.
-          body="Automated \`copier update\` run against template ref \`${REF}\`."
-          body+=$'\n\n'"Review the diff, resolve any \`<<<<<<< before updating\` conflict markers, and merge if CI is green."
-          body+=$'\n\n'"> **Note:** \`--skip-answered\` was passed, so any **new** template variables introduced since the last update were silently filled with their copier defaults. Skim \`.copier-answers.yml\` for unexpected new keys."
-          if [ "${CONFLICT_COUNT}" -gt 0 ]; then
-            body+=$'\n\n'"⚠️ **${CONFLICT_COUNT} file(s) contain unresolved \`<<<<<<< before updating\` conflict markers — review and resolve manually before merging.**"
+
+          # Heading: render prev_ref→ref and a compare link when we have a
+          # previous ref that differs from the new one AND a resolvable
+          # template repo.  Otherwise fall back to a plain "update to REF".
+          if [ -n "${PREV_REF}" ] && [ "${PREV_REF}" != "${REF}" ]; then
+            body="## Template update: \`${PREV_REF}\` → \`${REF}\`"
+            if [ -n "${TEMPLATE_REPO}" ]; then
+              body+=$'\n\n'"[Compare on GitHub](https://github.com/${TEMPLATE_REPO}/compare/${PREV_REF}...${REF})"
+            fi
+          else
+            body="## Template update to \`${REF}\`"
           fi
+
+          # Release notes in a collapsed block so the PR body stays scannable.
+          if [ -n "${release_notes}" ]; then
+            body+=$'\n\n'"<details><summary>Release notes (${REF})</summary>"
+            body+=$'\n\n'"${release_notes}"
+            body+=$'\n\n'"</details>"
+          fi
+
+          # Diff stat — always collapsed; even a handful of files is noisy.
+          body+=$'\n\n'"<details><summary>Files changed (${DIFF_COUNT})</summary>"
+          body+=$'\n\n''```'
+          body+=$'\n'"${DIFF_STAT}"
+          body+=$'\n''```'
+          body+=$'\n\n'"</details>"
+
+          # Conflicts — list the files (not just a count), and call out that
+          # the markers are *committed to the branch*, not sidecar .rej files.
+          if [ "${CONFLICT_COUNT}" -gt 0 ]; then
+            body+=$'\n\n'"### ⚠️ ${CONFLICT_COUNT} file(s) with unresolved conflict markers"
+            body+=$'\n\n'"The \`<<<<<<< before updating\` markers **are committed to this branch** — resolve them before merging:"
+            body+=$'\n'
+            while IFS= read -r f; do
+              [ -n "${f}" ] && body+=$'\n'"- \`${f}\`"
+            done <<< "${CONFLICT_FILES}"
+          fi
+
+          body+=$'\n\n'"---"
+          body+=$'\n\n'"> **Note:** \`--skip-answered\` was passed, so any **new** template variables introduced since the last update were silently filled with their copier defaults. Skim \`.copier-answers.yml\` for unexpected new keys."
 
           if gh pr view "${branch}" --json state --jq '.state' 2>/dev/null | grep -q OPEN; then
             gh pr edit "${branch}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -347,11 +347,30 @@ jobs:
           VERSION: ${{ needs.release.outputs.version }}
         run: |
           cd catalog
-          jq --arg v "$VERSION" --arg ref "v$VERSION" '
-            .plugins |= map(
-              if .name == "scholar-mcp"
-              then .version = $v | .source.ref = $ref
-              else . end
+          NEW_ENTRY=$(jq -n \
+            --arg name    "scholar-mcp" \
+            --arg url     "https://github.com/pvliesdonk/scholar-mcp.git" \
+            --arg ref     "v$VERSION" \
+            --arg version "$VERSION" \
+            '{
+              name: $name,
+              source: {
+                source: "git-subdir",
+                url: $url,
+                path: ".claude-plugin/plugin",
+                ref: $ref
+              },
+              version: $version
+            }')
+          jq --arg name "scholar-mcp" \
+             --arg v    "$VERSION" \
+             --arg ref  "v$VERSION" \
+             --argjson new "$NEW_ENTRY" '
+            .plugins |= (
+              if any(.[]; .name == $name)
+              then map(if .name == $name then .version = $v | .source.ref = $ref else . end)
+              else . + [$new]
+              end
             )
           ' marketplace.json > marketplace.json.tmp
           mv marketplace.json.tmp marketplace.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,10 +43,26 @@ Every PR must pass **all** of the following before merge. Do not open or push a 
 
 1. **CI passes** — `uv run pytest -x -q` all tests pass
 2. **Lint passes** — run in this exact order: `uv run ruff check --fix .` then `uv run ruff format .` then verify with `uv run ruff format --check .`. Always run format *after* check --fix because check --fix can leave files needing reformatting.
-3. **Type-check passes** — `uv run mypy src/` reports no errors
+3. **Type-check passes** — `uv run mypy src/ tests/` reports no errors
 4. **Patch coverage ≥ 80%** — Codecov measures only lines added/changed in the PR diff. Run `uv run pytest --cov=<changed_module> --cov-report=term-missing` and verify new code is exercised. Add tests for every uncovered branch before pushing.
 5. **Docs updated** — `README.md` and `docs/**` reflect any user-facing changes in the same commit
 6. **Manifest version lockstep** — `server.json`, `.claude-plugin/plugin/.claude-plugin/plugin.json`, and `.claude-plugin/plugin/.mcp.json` must all carry the same version. The release workflow bumps them atomically via PSR; manual touches require updating all three.
+
+## Pre-commit Hooks
+
+This project ships a `.pre-commit-config.yaml` that runs ruff (check + format), mypy on `src/` and `tests/`, gitleaks secret scanning, and standard whitespace/YAML/JSON checks — aligned with the `ci.yml` lint/typecheck/secrets jobs so a clean pre-commit run implies a clean CI lane.
+
+- **Install once per clone:** `uv run pre-commit install`.
+- **Run on demand before pushing:** `uv run pre-commit run --all-files`. A green run is a precondition for gates #2 and #3 above.
+- **Never bypass with `--no-verify`.** A failing hook means the same check will fail in CI; fix the underlying issue rather than silencing it.
+
+The config is in `_skip_if_exists`, so domain-specific additions (shellcheck, yamllint, project-specific linters, additional file checks) on top of the shipped defaults survive `copier update`.
+
+## PR Discipline
+
+**Every PR must have at least one associated issue.** If the work doesn't have one yet — a bug found in the wild, an opportunistic cleanup, a small improvement — create the issue first, then open the PR with `Closes #N` (or `Refs #N`) in the body. A single PR may close multiple issues (`Closes #A, closes #B`) — bundling related fixes is fine; the rule is "no orphan PRs", not "one PR per issue". This keeps the changelog, release notes, and cross-repo history coherent.
+
+Trivial exceptions: pure typo fixes and automated dependency bumps (Dependabot / Renovate) may skip the issue.
 
 ## GitHub Review Types
 
@@ -111,6 +127,14 @@ Shared infrastructure (auth providers, middleware stack, logging bootstrap, even
 - [`fastmcp-server-template`](https://github.com/pvliesdonk/fastmcp-server-template) — the copier template this project was generated from. Ships the CI/release workflows, `Dockerfile`, `packaging/nfpm.yaml`, `packaging/mcpb/*`, `scripts/bump_manifests.py`, server.py skeleton, and this very section of CLAUDE.md.
 
 Fixes and improvements to shared code land in those repos and propagate here via `copier update` against the template's latest tag — run manually or via the weekly `.github/workflows/copier-update.yml` cron. Starter files listed in `_skip_if_exists` (e.g. `scripts/bump_manifests.py`, `packaging/mcpb/*`, the `tools.py` / `resources.py` / `prompts.py` / `domain.py` scaffolds, `README.md`, `CHANGELOG.md`, `LICENSE`, `.env.example`) are written once and require manual reconciliation on template updates — review `_skip_if_exists` in the template's `copier.yml` if you need to force-sync a file. Domain-specific code (tools, resources, prompts, and the fields and logic inside the `CONFIG-FIELDS-START` / `CONFIG-FIELDS-END` and `CONFIG-FROM-ENV-START` / `CONFIG-FROM-ENV-END` sentinels) stays in this repo.
+
+## Contributing fixes upstream
+
+- **Library-level fix** (anything you'd change in `fastmcp_pvl_core`): open a PR on `pvliesdonk/fastmcp-pvl-core`. After merge + release, bump `fastmcp-pvl-core` in this project's `pyproject.toml`. (Copier update alone won't pick it up unless the template's version constraint in `pyproject.toml.jinja` is also bumped.)
+- **Template-level fix** (anything template-owned — `Dockerfile`, workflows, `server.py` skeleton, `CLAUDE.md` sections): open a PR on `pvliesdonk/fastmcp-server-template`. After merge + release, this project gets the fix on the next weekly `copier update` cron (or dispatch the workflow manually).
+- **Domain-only fix** (anything inside `DOMAIN-START`/`DOMAIN-END` sentinels, `tools.py`, `resources.py`, `prompts.py`, `domain.py`, `tests/`): PR on this repo directly.
+
+If a conflict marker appears in a copier-update bot PR, the conflict itself often signals a template bug — investigate whether the template's version needs fixing before resolving locally.
 
 <!-- ===== TEMPLATE-OWNED SECTIONS END ===== -->
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,9 @@ RUN if [ "$APP_UID" -eq 0 ] || [ "$APP_GID" -eq 0 ]; then \
     fi \
     && groupadd -r --gid $APP_GID --non-unique appuser \
     && useradd -r --uid $APP_UID --gid $APP_GID --no-log-init -d /app appuser \
+    # DOCKERFILE-STATE-DIRS-START — domain state subdirs; kept across copier update
     && mkdir -p /data/service /data/state/fastmcp \
+    # DOCKERFILE-STATE-DIRS-END
     && chown -R appuser:appuser /app /data
 
 COPY --chmod=0755 docker-entrypoint.sh /usr/local/bin/
@@ -43,7 +45,9 @@ ENV PATH="/app/.venv/bin:$PATH" \
 
 EXPOSE 8000
 
+# DOCKERFILE-VOLUMES-START — mounted volume list; kept across copier update
 VOLUME ["/data/service", "/data/state"]
+# DOCKERFILE-VOLUMES-END
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["scholar-mcp", "serve", "--transport", "http", "--host", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -1,88 +1,255 @@
 # scholar-mcp
 
-<<<<<<< before updating
 <!-- mcp-name: io.github.pvliesdonk/scholar-mcp -->
 
-[![CI](https://github.com/pvliesdonk/scholar-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/pvliesdonk/scholar-mcp/actions/workflows/ci.yml)
-[![PyPI](https://img.shields.io/pypi/v/pvliesdonk-scholar-mcp)](https://pypi.org/project/pvliesdonk-scholar-mcp/)
-[![Python](https://img.shields.io/pypi/pyversions/pvliesdonk-scholar-mcp)](https://pypi.org/project/pvliesdonk-scholar-mcp/)
-[![License](https://img.shields.io/github/license/pvliesdonk/scholar-mcp)](https://github.com/pvliesdonk/scholar-mcp/blob/main/LICENSE)
-[![Docker](https://img.shields.io/badge/ghcr.io-scholar--mcp-blue)](https://ghcr.io/pvliesdonk/scholar-mcp)
-[![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://pvliesdonk.github.io/scholar-mcp/)
-[![llms.txt](https://img.shields.io/badge/llms.txt-available-green)](https://pvliesdonk.github.io/scholar-mcp/llms.txt)
+[![CI](https://github.com/pvliesdonk/scholar-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/pvliesdonk/scholar-mcp/actions/workflows/ci.yml) [![codecov](https://codecov.io/gh/pvliesdonk/scholar-mcp/graph/badge.svg)](https://codecov.io/gh/pvliesdonk/scholar-mcp) [![PyPI](https://img.shields.io/pypi/v/pvliesdonk-scholar-mcp)](https://pypi.org/project/pvliesdonk-scholar-mcp/) [![Python](https://img.shields.io/pypi/pyversions/pvliesdonk-scholar-mcp)](https://pypi.org/project/pvliesdonk-scholar-mcp/) [![License](https://img.shields.io/github/license/pvliesdonk/scholar-mcp)](LICENSE) [![Docker](https://img.shields.io/github/v/release/pvliesdonk/scholar-mcp?label=ghcr.io&logo=docker)](https://github.com/pvliesdonk/scholar-mcp/pkgs/container/scholar-mcp) [![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://pvliesdonk.github.io/scholar-mcp/) [![llms.txt](https://img.shields.io/badge/llms.txt-available-brightgreen)](https://pvliesdonk.github.io/scholar-mcp/llms.txt)
 
-A [FastMCP](https://github.com/jlowin/fastmcp) server for the scholarly citation landscape -- **papers**, **patents**, **books**, and **standards** -- giving LLMs a unified way to search, cross-reference, and retrieve prior art across all four source types via [Semantic Scholar](https://www.semanticscholar.org/), [EPO Open Patent Services](https://www.epo.org/en/searching-for-patents/data/web-services/ops), [Open Library](https://openlibrary.org/), and standards bodies (NIST, IETF, W3C, ETSI), with [OpenAlex](https://openalex.org/) enrichment and optional [docling-serve](https://github.com/DS4SD/docling-serve) PDF/full-text conversion.
+A [FastMCP](https://github.com/jlowin/fastmcp) server for the scholarly citation landscape — **papers**, **patents**, **books**, and **standards** — giving LLMs a unified way to search, cross-reference, and retrieve prior art across all four source types via [Semantic Scholar](https://www.semanticscholar.org/), [EPO Open Patent Services](https://www.epo.org/en/searching-for-patents/data/web-services/ops), [Open Library](https://openlibrary.org/), and standards bodies (NIST, IETF, W3C, ETSI), with [OpenAlex](https://openalex.org/) enrichment and optional [docling-serve](https://github.com/DS4SD/docling-serve) PDF/full-text conversion.
+
+**[Documentation](https://pvliesdonk.github.io/scholar-mcp/)** | **[PyPI](https://pypi.org/project/pvliesdonk-scholar-mcp/)** | **[Docker](https://github.com/pvliesdonk/scholar-mcp/pkgs/container/scholar-mcp)**
 
 ## Features
 
+<!-- DOMAIN-START -->
+
 ### Source domains
 
-- **Papers** -- full-text search with year/venue/field/citation filters; single-paper lookup by DOI, S2 ID, arXiv ID, ACM ID, or PubMed ID; author profile and name search; forward citations, backward references, BFS graph traversal, shortest-path bridge discovery; recommendations from positive/negative examples; BibTeX/CSL-JSON/RIS citation generation with OpenAlex venue enrichment.
-- **Patents** -- search across 100+ patent offices via EPO OPS with CPC/applicant/inventor/jurisdiction filters; bibliographic, claims, description, family, legal, and citations sections; NPL-to-paper resolution via Semantic Scholar and paper-to-patent citation discovery. EPO credentials are optional -- other domains work without them.
-- **Books** -- search by title/author/keywords via Open Library (no API key required); lookup by ISBN-10/13, Open Library work ID, or edition ID; subject-based recommendations sorted by popularity; Google Books excerpts and preview links; WorldCat permalinks for library discovery; cover image caching. Papers with an ISBN in `externalIds` are automatically enriched with publisher, edition, cover URL, and subject data from Open Library.
-- **Standards** -- identifier resolution, search, and metadata retrieval for NIST, IETF, W3C, and ETSI standards, with optional full-text fetch and Markdown conversion via docling. Tier 2 ISO, IEC, IEEE, Common Criteria (CC), and CEN/CENELEC metadata (including ISO/IEC/IEEE joint standards and the CC ↔ ISO/IEC 15408 cross-link) is synced locally via `sync-standards`. ISO, IEC, IEEE have a live-fetch fallback for unsynced identifiers; CC and CEN have no live API and require a sync first. Citations matching standards patterns (RFC, ISO, NIST SP, IEEE, EN, CC) are automatically enriched with structured `standard_metadata` including identifier, title, body, status, and full-text URL when available (see [docs/guides/standards.md](docs/guides/standards.md)).
+- **Papers** — full-text search with year/venue/field/citation filters; single-paper lookup by DOI, S2 ID, arXiv ID, ACM ID, or PubMed ID; author profile and name search; forward citations, backward references, BFS graph traversal, shortest-path bridge discovery; recommendations from positive/negative examples; BibTeX/CSL-JSON/RIS citation generation with OpenAlex venue enrichment.
+- **Patents** — search across 100+ patent offices via EPO OPS with CPC/applicant/inventor/jurisdiction filters; bibliographic, claims, description, family, legal, and citations sections; NPL-to-paper resolution via Semantic Scholar and paper-to-patent citation discovery. EPO credentials are optional — other domains work without them.
+- **Books** — search by title/author/keywords via Open Library (no API key required); lookup by ISBN-10/13, Open Library work ID, or edition ID; subject-based recommendations sorted by popularity; Google Books excerpts and preview links; WorldCat permalinks for library discovery; cover image caching. Papers with an ISBN in `externalIds` are automatically enriched with publisher, edition, cover URL, and subject data from Open Library.
+- **Standards** — identifier resolution, search, and metadata retrieval for NIST, IETF, W3C, and ETSI standards, with optional full-text fetch and Markdown conversion via docling. Tier 2 ISO, IEC, IEEE, Common Criteria (CC), and CEN/CENELEC metadata (including ISO/IEC/IEEE joint standards and the CC ↔ ISO/IEC 15408 cross-link) is synced locally via `sync-standards`. ISO, IEC, IEEE have a live-fetch fallback for unsynced identifiers; CC and CEN have no live API and require a sync first. Citations matching standards patterns (RFC, ISO, NIST SP, IEEE, EN, CC) are automatically enriched with structured `standard_metadata` including identifier, title, body, status, and full-text URL when available (see [docs/guides/standards.md](docs/guides/standards.md)).
 
 ### Cross-cutting
 
-- **Enrichment pipeline** -- phased enrichment from multiple sources: OpenAlex (OA status, affiliations, funders, concepts), CrossRef (publisher, page ranges, container titles), Google Books (preview links, excerpts), and Open Library (book metadata). Runs automatically on paper and book results.
-- **PDF conversion** -- download open-access PDFs and convert to Markdown via [docling-serve](https://github.com/DS4SD/docling-serve), with optional VLM enrichment for formulas and figures; automatic fallback to ArXiv, PubMed Central, and Unpaywall when Semantic Scholar has no OA link; direct URL download for PDFs found elsewhere.
-- **Intelligent caching** -- SQLite-backed cache with per-table TTLs (30 days for papers/authors, 7 days for citations/references) and identifier aliasing.
-- **Authentication** -- bearer token, OIDC (OAuth 2.1), or both simultaneously (multi-auth).
-- **Multi-transport** -- stdio (Claude Desktop), HTTP (streamable-http), and SSE transports.
-- **Linux packages** -- `.deb` and `.rpm` packages with systemd service and security hardening.
+- **Enrichment pipeline** — phased enrichment from multiple sources: OpenAlex (OA status, affiliations, funders, concepts), CrossRef (publisher, page ranges, container titles), Google Books (preview links, excerpts), and Open Library (book metadata). Runs automatically on paper and book results.
+- **PDF conversion** — download open-access PDFs and convert to Markdown via [docling-serve](https://github.com/DS4SD/docling-serve), with optional VLM enrichment for formulas and figures; automatic fallback to ArXiv, PubMed Central, and Unpaywall when Semantic Scholar has no OA link; direct URL download for PDFs found elsewhere.
+- **Intelligent caching** — SQLite-backed cache with per-table TTLs (30 days for papers/authors, 7 days for citations/references) and identifier aliasing.
+- **Authentication** — bearer token, OIDC (OAuth 2.1), or both simultaneously (multi-auth).
+- **Multi-transport** — stdio (Claude Desktop), HTTP (streamable-http), and SSE transports.
+- **Linux packages** — `.deb` and `.rpm` packages with systemd service and security hardening.
 
 ### Coverage by domain
 
 Per-domain depth is uneven. Papers currently have the richest tool surface (citation graph, recommendations, cross-referencing to all three other domains); standards are the leanest. That reflects public data availability, not a value hierarchy — writing a paper typically needs all four source types for citations and prior art. Parity work is tracked in [GitHub issues](https://github.com/pvliesdonk/scholar-mcp/issues) and [milestones](https://github.com/pvliesdonk/scholar-mcp/milestones); the roadmap shows intent, not a completeness commitment.
+<!-- DOMAIN-END -->
+
+## What you can do with it
+
+<!-- DOMAIN-START -->
+
+With this server mounted in an MCP client (Claude, etc.), you can:
+
+- **Survey a field** — "Find the 20 most-cited papers on graph neural networks from 2020–2024 and draft a literature review outline." Composes `search_papers` + `get_citations` + `enrich_paper`.
+- **Trace a citation path** — "What's the shortest citation path from 'Attention is All You Need' to 'RLHF for dialogue agents'?" Uses `find_bridge_papers` + `get_citation_graph`.
+- **Cross-reference prior art** — "For this patent family, list academic papers it cites and any books or standards that show up in the description." Composes `get_patent` + `batch_resolve` + standards/book enrichment.
+- **Generate a bibliography** — "Emit BibTeX for these 30 DOIs with OpenAlex venue data." Uses `generate_citations`.
+- **Look up a standard** — "What's the latest status of RFC 9000, and fetch the Markdown full text." Uses `resolve_standard_identifier` + `get_standard`.
+<!-- DOMAIN-END -->
+
+<!-- ===== TEMPLATE-OWNED SECTIONS BELOW — DO NOT EDIT; CHANGES WILL BE OVERWRITTEN ON COPIER UPDATE ===== -->
 
 ## Installation
 
-### Claude Code plugin
+### From PyPI
 
 ```bash
-/plugin marketplace add pvliesdonk/claude-plugins
-/plugin install scholar-mcp@pvliesdonk
+pip install pvliesdonk-scholar-mcp
 ```
 
-### Claude Desktop (.mcpb bundle)
+If you add optional extras via the `PROJECT-EXTRAS-START` / `PROJECT-EXTRAS-END` sentinels in `pyproject.toml`, document them below:
 
-Download `scholar-mcp-<VERSION>.mcpb` from the [latest release](https://github.com/pvliesdonk/scholar-mcp/releases/latest) and open it in Claude Desktop, or install via the Claude Desktop MCP gallery.
+<!-- DOMAIN-START -->
 
-### With `uvx` (recommended)
+Scholar-mcp ships two optional-dependency groups:
 
-```bash
-uvx --from pvliesdonk-scholar-mcp scholar-mcp serve
-```
+- **`[mcp]`** — installs FastMCP; required to run `scholar-mcp serve` and expose tools over stdio/HTTP.
+- **`[all]`** — currently identical to `[mcp]`; reserved for future optional backends.
 
-### With `pip`
+For MCP-server usage:
 
 ```bash
 pip install 'pvliesdonk-scholar-mcp[mcp]'
-scholar-mcp serve
+# or, without installing into the environment:
+uvx --from pvliesdonk-scholar-mcp scholar-mcp serve
 ```
 
-### With Docker
+Installing the bare `pvliesdonk-scholar-mcp` package is enough for library use (`from scholar_mcp import ...`) but the `scholar-mcp serve` CLI requires `[mcp]`.
+<!-- DOMAIN-END -->
+
+### From source
 
 ```bash
-docker run -v scholar-mcp-data:/data/scholar-mcp \
-           ghcr.io/pvliesdonk/scholar-mcp:latest
+git clone https://github.com/pvliesdonk/scholar-mcp.git
+cd scholar-mcp
+uv sync --all-extras --dev
 ```
 
-### Linux packages
-
-Download `.deb` or `.rpm` from the [latest release](https://github.com/pvliesdonk/scholar-mcp/releases/latest):
+### Docker
 
 ```bash
-# Debian/Ubuntu
-sudo dpkg -i scholar-mcp_*.deb
-
-# RHEL/Fedora
-sudo rpm -i scholar-mcp-*.rpm
+docker pull ghcr.io/pvliesdonk/scholar-mcp:latest
 ```
 
-> **Note:** The PyPI package is `pvliesdonk-scholar-mcp`. The CLI command installed is `scholar-mcp`.
+A `compose.yml` ships at the repo root as a starting point — copy `.env.example` to `.env`, edit, and `docker compose up -d`.
 
-## Quick Start
+### Linux packages (.deb / .rpm)
+
+Download `.deb` or `.rpm` packages from the [GitHub Releases](https://github.com/pvliesdonk/scholar-mcp/releases) page. Both install a hardened systemd unit; env configuration is sourced from `/etc/scholar-mcp/env` (copy from the shipped `/etc/scholar-mcp/env.example`).
+
+### Claude Desktop (.mcpb bundle)
+
+Download the `.mcpb` bundle from the [GitHub Releases](https://github.com/pvliesdonk/scholar-mcp/releases) page and double-click to install, or run:
+
+```bash
+mcpb install scholar-mcp-<version>.mcpb
+```
+
+Claude Desktop prompts for required env vars via a GUI wizard — no manual JSON editing needed.
+
+## Quick start
+
+```bash
+scholar-mcp serve                                # stdio transport
+scholar-mcp serve --transport http --port 8000   # streamable HTTP
+```
+
+For library usage (embedding the domain logic without the MCP transport), import from the `scholar_mcp` package directly — see `src/scholar_mcp/domain.py` for the entry point scaffold.
+
+## Configuration
+
+Core environment variables shared across all `fastmcp-pvl-core`-based services:
+
+| Variable | Default | Description |
+|---|---|---|
+| `FASTMCP_LOG_LEVEL` | `INFO` | Log level for FastMCP internals and app loggers (`DEBUG` / `INFO` / `WARNING` / `ERROR`). The `-v` CLI flag overrides to `DEBUG`. |
+| `FASTMCP_ENABLE_RICH_LOGGING` | `true` | Set to `false` for plain / structured JSON log output. |
+| `SCHOLAR_MCP_EVENT_STORE_URL` | `memory://` | Event store backend for HTTP session persistence — `memory://` (dev), `file:///path` (survives restarts). |
+
+Domain-specific variables go below under [Domain configuration](#domain-configuration).
+
+## GitHub secrets
+
+CI workflows reference three repository secrets. Configure them via **Settings → Secrets and variables → Actions** or with `gh secret set`:
+
+| Secret | Used by | How to generate |
+|---|---|---|
+| `RELEASE_TOKEN` | `release.yml`, `copier-update.yml` | Fine-grained PAT at <https://github.com/settings/personal-access-tokens/new> with `contents: write` and `pull_requests: write` (the `copier-update` cron opens PRs). Scoped to this repo. |
+| `CODECOV_TOKEN` | `ci.yml` | <https://codecov.io> — sign in with GitHub, add the repo, copy the upload token from the repo settings page. |
+| `CLAUDE_CODE_OAUTH_TOKEN` | `claude.yml`, `claude-code-review.yml` | Run `claude setup-token` locally and paste the result. |
+
+```bash
+gh secret set RELEASE_TOKEN
+gh secret set CODECOV_TOKEN
+gh secret set CLAUDE_CODE_OAUTH_TOKEN
+```
+
+`GITHUB_TOKEN` is auto-provided — no action needed.
+
+## Local development
+
+The PR gate (matches CI):
+
+```bash
+uv run pytest -x -q                                  # tests
+uv run ruff check --fix . && uv run ruff format .    # lint + format
+uv run mypy src/ tests/                              # type-check
+```
+
+Pre-commit runs a subset of the gate on each commit; see `.pre-commit-config.yaml` for details, or [`CLAUDE.md`](CLAUDE.md) for the full Hard PR Acceptance Gates.
+
+## Troubleshooting
+
+### Moving a scaffolded project
+
+`uv sync` creates `.venv/bin/*` scripts with absolute shebangs pointing at the venv Python. If you move the repo after scaffolding (`mv /old/path /new/path`), `uv run pytest` fails with `ModuleNotFoundError: No module named 'fastmcp'` because the stale shebang resolves to a different interpreter than the venv's site-packages.
+
+**Fix:**
+
+```bash
+rm -rf .venv
+uv sync --all-extras --dev
+```
+
+`uv run python -m pytest` also works as a one-shot workaround (bypasses the stale entry-script shim).
+
+### `uv.lock` refresh after `copier update`
+
+When `copier update` introduces new dependencies (e.g. a new extra added to `pyproject.toml.jinja`), CI runs `uv sync --frozen` which fails against a stale lockfile. Run `uv lock` locally and commit the refreshed `uv.lock` alongside accepting the copier-update PR.
+
+## License
+
+MIT — see [LICENSE](LICENSE).
+
+<!-- ===== TEMPLATE-OWNED SECTIONS END ===== -->
+
+## Domain configuration
+
+<!-- DOMAIN-START -->
+
+All settings are controlled via environment variables with the `SCHOLAR_MCP_` prefix.
+
+### Core
+
+| Variable | Default | Description |
+|---|---|---|
+| `SCHOLAR_MCP_S2_API_KEY` | — | Semantic Scholar API key ([request one](https://www.semanticscholar.org/product/api#api-key-form)); optional but recommended for higher rate limits |
+| `SCHOLAR_MCP_READ_ONLY` | `true` | If `true`, write-tagged tools (`fetch_paper_pdf`, `convert_pdf_to_markdown`, `fetch_and_convert`, `fetch_pdf_by_url`, `fetch_patent_pdf`) are hidden |
+| `SCHOLAR_MCP_CACHE_DIR` | `/data/scholar-mcp` | Directory for the SQLite cache database and downloaded PDFs |
+| `SCHOLAR_MCP_CONTACT_EMAIL` | — | Included in the OpenAlex User-Agent for [polite pool](https://docs.openalex.org/how-to-use-the-api/rate-limits-and-authentication#the-polite-pool) access (faster rate limits); also enables Unpaywall PDF lookups |
+
+### PDF Conversion (optional)
+
+| Variable | Default | Description |
+|---|---|---|
+| `SCHOLAR_MCP_DOCLING_URL` | — | Base URL of a running [docling-serve](https://github.com/DS4SD/docling-serve) instance (e.g. `http://localhost:5001`) |
+| `SCHOLAR_MCP_VLM_API_URL` | — | OpenAI-compatible VLM endpoint for formula/figure-enriched PDF conversion |
+| `SCHOLAR_MCP_VLM_API_KEY` | — | API key for the VLM endpoint |
+| `SCHOLAR_MCP_VLM_MODEL` | `gpt-4o` | Model name for VLM-enriched conversion |
+
+### Patent Search (optional)
+
+| Variable | Default | Description |
+|---|---|---|
+| `SCHOLAR_MCP_EPO_CONSUMER_KEY` | — | EPO OPS consumer key ([register at developers.epo.org](https://developers.epo.org/user/register)); both key and secret must be set for patent tools to appear |
+| `SCHOLAR_MCP_EPO_CONSUMER_SECRET` | — | EPO OPS consumer secret |
+
+### Google Books (optional)
+
+| Variable | Default | Description |
+|---|---|---|
+| `SCHOLAR_MCP_GOOGLE_BOOKS_API_KEY` | — | Google Books API key for higher rate limits (1000 req/day without key) |
+
+### Tier 2 standards sync (optional)
+
+| Variable | Default | Description |
+|---|---|---|
+| `SCHOLAR_GITHUB_TOKEN` | — | GitHub personal access token for Relaton sync; lifts unauthenticated GitHub rate limit from 60/hr to 5,000/hr (no scopes required for public-repo reads). Useful for repeated `--force` testing; daily cron is fine unauthenticated. |
+
+### Authentication (optional)
+
+| Variable | Default | Description |
+|---|---|---|
+| `SCHOLAR_MCP_BEARER_TOKEN` | — | Static bearer token for HTTP transport authentication |
+| `SCHOLAR_MCP_BASE_URL` | — | Public base URL, required for OIDC (e.g. `https://mcp.example.com`) |
+| `SCHOLAR_MCP_OIDC_CONFIG_URL` | — | OIDC discovery endpoint URL |
+| `SCHOLAR_MCP_OIDC_CLIENT_ID` | — | OIDC client ID |
+| `SCHOLAR_MCP_OIDC_CLIENT_SECRET` | — | OIDC client secret |
+| `SCHOLAR_MCP_OIDC_JWT_SIGNING_KEY` | — | JWT signing key; required on Linux/Docker to survive restarts (`openssl rand -hex 32`) |
+<!-- DOMAIN-END -->
+
+## Key design decisions
+
+<!-- DOMAIN-START -->
+
+- **Library-first, MCP-optional.** The core domain logic (S2/EPO/Open Library/standards clients, enrichment pipeline, cache) is importable without FastMCP; the MCP server is a thin async wrapper. Enables reuse in scripts, notebooks, and other servers.
+- **Sync domain code, async MCP layer.** Backend clients are synchronous; MCP tools call them via `asyncio.to_thread()`. Simpler client code, explicit offloading at the transport boundary.
+- **SQLite cache with per-table TTLs and identifier aliases.** Papers / authors last 30 days, citations / references 7 days. DOI ↔ S2 ID ↔ arXiv ID aliasing survives across cache clears so repeated enrichment hits the same row.
+- **Read-only by default.** Write-tagged tools (PDF download/convert, patent PDF) are hidden unless `SCHOLAR_MCP_READ_ONLY=false`. Safer default for first-run.
+- **Rate-limited try-once with background queueing.** S2/OpenAlex calls try once; on 429 they queue a retry-enabled background task and return `{"queued": true, "task_id": ...}`. PDF tools always queue unless the cache already has the conversion.
+- **Tier 2 standards sync out-of-band.** ISO/IEC/IEEE/CC/CEN catalogues come from community Relaton dumps via `scholar-mcp sync-standards`, not live at runtime — avoids paywalled-HTML scraping and keeps tool calls fast.
+<!-- DOMAIN-END -->
+
+## Quick Start details
 
 ### stdio transport (Claude Desktop / MCP clients)
 
@@ -114,11 +281,16 @@ Claude Desktop configuration (`claude_desktop_config.json`):
 uvx --from pvliesdonk-scholar-mcp scholar-mcp serve --transport http --port 8000
 ```
 
+### Claude Code plugin
+
+```bash
+/plugin marketplace add pvliesdonk/claude-plugins
+/plugin install scholar-mcp@pvliesdonk
+```
+
 ### Syncing Tier 2 standards catalogues
 
-Tier 2 bodies (ISO, IEC, IEEE, CC, CEN) are populated
-from community-curated bulk dumps rather than live-scraped at MCP-server
-runtime. Run the sync on first install and periodically thereafter:
+Tier 2 bodies (ISO, IEC, IEEE, CC, CEN) are populated from community-curated bulk dumps rather than live-scraped at MCP-server runtime. Run the sync on first install and periodically thereafter:
 
 ```bash
 scholar-mcp sync-standards            # all registered bodies
@@ -129,63 +301,7 @@ scholar-mcp sync-standards --body CEN # only CEN/CENELEC
 scholar-mcp sync-standards --force    # re-sync even if upstream SHA is unchanged
 ```
 
-Schedule via cron / launchd / systemd timer — weekly is sufficient;
-standards change slowly. First sync can take several minutes; subsequent
-runs that find no upstream changes exit within seconds.
-
-## Configuration
-
-All settings are controlled via environment variables with the `SCHOLAR_MCP_` prefix.
-
-### Core
-
-| Variable | Default | Description |
-|---|---|---|
-| `SCHOLAR_MCP_S2_API_KEY` | -- | Semantic Scholar API key ([request one](https://www.semanticscholar.org/product/api#api-key-form)); optional but recommended for higher rate limits |
-| `SCHOLAR_MCP_READ_ONLY` | `true` | If `true`, write-tagged tools (`fetch_paper_pdf`, `convert_pdf_to_markdown`, `fetch_and_convert`, `fetch_pdf_by_url`, `fetch_patent_pdf`) are hidden |
-| `SCHOLAR_MCP_CACHE_DIR` | `/data/scholar-mcp` | Directory for the SQLite cache database and downloaded PDFs |
-| `SCHOLAR_MCP_CONTACT_EMAIL` | -- | Included in the OpenAlex User-Agent for [polite pool](https://docs.openalex.org/how-to-use-the-api/rate-limits-and-authentication#the-polite-pool) access (faster rate limits); also enables Unpaywall PDF lookups |
-| `FASTMCP_LOG_LEVEL` | `INFO` | Logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`). Controls all output (app + middleware). The `-v` CLI flag sets this to `DEBUG`. |
-| `FASTMCP_ENABLE_RICH_LOGGING` | `true` | Set `false` for plain/JSON-structured log output (e.g. for log aggregators) |
-
-### PDF Conversion (optional)
-
-| Variable | Default | Description |
-|---|---|---|
-| `SCHOLAR_MCP_DOCLING_URL` | -- | Base URL of a running [docling-serve](https://github.com/DS4SD/docling-serve) instance (e.g. `http://localhost:5001`) |
-| `SCHOLAR_MCP_VLM_API_URL` | -- | OpenAI-compatible VLM endpoint for formula/figure-enriched PDF conversion |
-| `SCHOLAR_MCP_VLM_API_KEY` | -- | API key for the VLM endpoint |
-| `SCHOLAR_MCP_VLM_MODEL` | `gpt-4o` | Model name for VLM-enriched conversion |
-
-### Patent Search (optional)
-
-| Variable | Default | Description |
-|---|---|---|
-| `SCHOLAR_MCP_EPO_CONSUMER_KEY` | -- | EPO OPS consumer key ([register at developers.epo.org](https://developers.epo.org/user/register)); both key and secret must be set for patent tools to appear |
-| `SCHOLAR_MCP_EPO_CONSUMER_SECRET` | -- | EPO OPS consumer secret |
-
-### Google Books (optional)
-
-| Variable | Default | Description |
-|---|---|---|
-| `SCHOLAR_MCP_GOOGLE_BOOKS_API_KEY` | -- | Google Books API key for higher rate limits (1000 req/day without key) |
-
-### Tier 2 standards sync (optional)
-
-| Variable | Default | Description |
-|---|---|---|
-| `SCHOLAR_GITHUB_TOKEN` | -- | GitHub personal access token for Relaton sync; lifts unauthenticated GitHub rate limit from 60/hr to 5,000/hr (no scopes required for public-repo reads). Useful for repeated `--force` testing; daily cron is fine unauthenticated. |
-
-### Authentication (optional)
-
-| Variable | Default | Description |
-|---|---|---|
-| `SCHOLAR_MCP_BEARER_TOKEN` | -- | Static bearer token for HTTP transport authentication |
-| `SCHOLAR_MCP_BASE_URL` | -- | Public base URL, required for OIDC (e.g. `https://mcp.example.com`) |
-| `SCHOLAR_MCP_OIDC_CONFIG_URL` | -- | OIDC discovery endpoint URL |
-| `SCHOLAR_MCP_OIDC_CLIENT_ID` | -- | OIDC client ID |
-| `SCHOLAR_MCP_OIDC_CLIENT_SECRET` | -- | OIDC client secret |
-| `SCHOLAR_MCP_OIDC_JWT_SIGNING_KEY` | -- | JWT signing key; required on Linux/Docker to survive restarts (`openssl rand -hex 32`) |
+Schedule via cron / launchd / systemd timer — weekly is sufficient; standards change slowly. First sync can take several minutes; subsequent runs that find no upstream changes exit within seconds.
 
 ## MCP Tools
 
@@ -214,7 +330,7 @@ All settings are controlled via environment variables with the `SCHOLAR_MCP_` pr
 
 | Tool | Description |
 |---|---|
-| `recommend_papers` | Paper recommendations from 1--5 positive examples and optional negative examples. |
+| `recommend_papers` | Paper recommendations from 1–5 positive examples and optional negative examples. |
 | `generate_citations` | Generate BibTeX, CSL-JSON, or RIS citations for up to 100 papers, with automatic entry type inference and optional OpenAlex venue enrichment. |
 | `enrich_paper` | Augment Semantic Scholar metadata with OpenAlex fields (affiliations, funders, OA status, concepts). |
 
@@ -319,222 +435,3 @@ scholar-mcp cache clear --older-than 30
 # Override cache directory
 scholar-mcp cache stats --cache-dir /path/to/cache
 ```
-
-## Development
-
-```bash
-# Install with dev and MCP dependencies
-uv sync --extra dev --extra mcp
-
-# Run tests
-uv run pytest
-
-# Lint and format
-uv run ruff check src/ tests/
-uv run ruff format src/ tests/
-
-# Type check
-uv run mypy src/
-
-# Build docs locally
-uv sync --extra docs
-uv run mkdocs serve
-```
-=======
-[![CI](https://github.com/pvliesdonk/scholar-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/pvliesdonk/scholar-mcp/actions/workflows/ci.yml) [![codecov](https://codecov.io/gh/pvliesdonk/scholar-mcp/graph/badge.svg)](https://codecov.io/gh/pvliesdonk/scholar-mcp) [![PyPI](https://img.shields.io/pypi/v/pvliesdonk-scholar-mcp)](https://pypi.org/project/pvliesdonk-scholar-mcp/) [![Python](https://img.shields.io/pypi/pyversions/pvliesdonk-scholar-mcp)](https://pypi.org/project/pvliesdonk-scholar-mcp/) [![License](https://img.shields.io/github/license/pvliesdonk/scholar-mcp)](LICENSE) [![Docker](https://img.shields.io/github/v/release/pvliesdonk/scholar-mcp?label=ghcr.io&logo=docker)](https://github.com/pvliesdonk/scholar-mcp/pkgs/container/scholar-mcp) [![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://pvliesdonk.github.io/scholar-mcp/) [![llms.txt](https://img.shields.io/badge/llms.txt-available-brightgreen)](https://pvliesdonk.github.io/scholar-mcp/llms.txt)
-
-FastMCP server for Semantic Scholar with OpenAlex enrichment and docling PDF conversion
-
-**[Documentation](https://pvliesdonk.github.io/scholar-mcp/)** | **[PyPI](https://pypi.org/project/pvliesdonk-scholar-mcp/)** | **[Docker](https://github.com/pvliesdonk/scholar-mcp/pkgs/container/scholar-mcp)**
-
-## Features
-
-<!-- DOMAIN-START -->
-<!-- Replace with 3-7 bullets describing what this MCP server does. Kept across copier update. -->
-
-- **[Capability 1]** — one-sentence description of a user-visible feature.
-- **[Capability 2]** — one-sentence description of another capability.
-- **MCP tools** — N LLM-visible tools exposed; see `src/scholar_mcp/tools.py`.
-- **MCP resources** — M resources exposing domain state; see `src/scholar_mcp/resources.py`.
-- **MCP prompts** — K prompt templates; see `src/scholar_mcp/prompts.py`.
-<!-- DOMAIN-END -->
-
-## What you can do with it
-
-<!-- DOMAIN-START -->
-<!-- Replace with 3-5 concrete "you can ask Claude to X" examples. Kept across copier update. -->
-
-With this server mounted in an MCP client (Claude, etc.), you can:
-
-- **[Task 1]** — "[example user request]." Composes tools `[tool_a]` + `[tool_b]`.
-- **[Task 2]** — "[another example request]." Uses resource `[resource_x]`.
-- **[Task 3]** — "[third example]."
-
-Short, concrete prompts beat abstract feature lists — replace the
-`[Task N]` placeholders with prompts that actually work against your
-server's tool surface.
-<!-- DOMAIN-END -->
-
-<!-- ===== TEMPLATE-OWNED SECTIONS BELOW — DO NOT EDIT; CHANGES WILL BE OVERWRITTEN ON COPIER UPDATE ===== -->
-
-## Installation
-
-### From PyPI
-
-```bash
-pip install pvliesdonk-scholar-mcp
-```
-
-If you add optional extras via the `PROJECT-EXTRAS-START` / `PROJECT-EXTRAS-END` sentinels in `pyproject.toml`, document them below:
-
-<!-- DOMAIN-START -->
-<!-- List optional extras and their purpose here (e.g. `pip install pvliesdonk-scholar-mcp[embeddings]`). Kept across copier update. -->
-<!-- DOMAIN-END -->
-
-### From source
-
-```bash
-git clone https://github.com/pvliesdonk/scholar-mcp.git
-cd scholar-mcp
-uv sync --all-extras --dev
-```
-
-### Docker
-
-```bash
-docker pull ghcr.io/pvliesdonk/scholar-mcp:latest
-```
-
-A `compose.yml` ships at the repo root as a starting point — copy `.env.example` to `.env`, edit, and `docker compose up -d`.
-
-### Linux packages (.deb / .rpm)
-
-Download `.deb` or `.rpm` packages from the [GitHub Releases](https://github.com/pvliesdonk/scholar-mcp/releases) page. Both install a hardened systemd unit; env configuration is sourced from `/etc/scholar-mcp/env` (copy from the shipped `/etc/scholar-mcp/env.example`).
-
-### Claude Desktop (.mcpb bundle)
-
-Download the `.mcpb` bundle from the [GitHub Releases](https://github.com/pvliesdonk/scholar-mcp/releases) page and double-click to install, or run:
-
-```bash
-mcpb install scholar-mcp-<version>.mcpb
-```
-
-Claude Desktop prompts for required env vars via a GUI wizard — no manual JSON editing needed.
-
-## Quick start
-
-```bash
-scholar-mcp serve                                # stdio transport
-scholar-mcp serve --transport http --port 8000   # streamable HTTP
-```
-
-For library usage (embedding the domain logic without the MCP transport), import from the `scholar_mcp` package directly — see `src/scholar_mcp/domain.py` for the entry point scaffold.
-
-## Configuration
-
-Core environment variables shared across all `fastmcp-pvl-core`-based services:
-
-| Variable | Default | Description |
-|---|---|---|
-| `FASTMCP_LOG_LEVEL` | `INFO` | Log level for FastMCP internals and app loggers (`DEBUG` / `INFO` / `WARNING` / `ERROR`). The `-v` CLI flag overrides to `DEBUG`. |
-| `FASTMCP_ENABLE_RICH_LOGGING` | `true` | Set to `false` for plain / structured JSON log output. |
-| `SCHOLAR_MCP_EVENT_STORE_URL` | `memory://` | Event store backend for HTTP session persistence — `memory://` (dev), `file:///path` (survives restarts). |
-
-Domain-specific variables go below under [Domain configuration](#domain-configuration).
-
-## Post-scaffold checklist
-
-After `copier copy` and `gh repo create --push`:
-
-1. **Fill in the DOMAIN blocks** in this README (Features, What you can do with it, Domain configuration, Key design decisions) and in `CLAUDE.md`.
-2. Configure GitHub secrets — see below.
-3. Install dev dependencies: `uv sync --all-extras --dev`.
-4. Install pre-commit hooks: `uv run pre-commit install`.
-5. Run the gate locally: `uv run pytest -x -q && uv run ruff check --fix . && uv run ruff format . && uv run mypy src/ tests/`.
-6. Push the first commit — CI should be green.
-
-## GitHub secrets
-
-CI workflows reference three repository secrets. Configure them via **Settings → Secrets and variables → Actions** or with `gh secret set`:
-
-| Secret | Used by | How to generate |
-|---|---|---|
-| `RELEASE_TOKEN` | `release.yml`, `copier-update.yml` | Fine-grained PAT at <https://github.com/settings/personal-access-tokens/new> with `contents: write` and `pull_requests: write` (the `copier-update` cron opens PRs). Scoped to this repo. |
-| `CODECOV_TOKEN` | `ci.yml` | <https://codecov.io> — sign in with GitHub, add the repo, copy the upload token from the repo settings page. |
-| `CLAUDE_CODE_OAUTH_TOKEN` | `claude.yml`, `claude-code-review.yml` | Run `claude setup-token` locally and paste the result. |
-
-```bash
-gh secret set RELEASE_TOKEN
-gh secret set CODECOV_TOKEN
-gh secret set CLAUDE_CODE_OAUTH_TOKEN
-```
-
-`GITHUB_TOKEN` is auto-provided — no action needed.
-
-## Local development
-
-The PR gate (matches CI):
-
-```bash
-uv run pytest -x -q                                  # tests
-uv run ruff check --fix . && uv run ruff format .    # lint + format
-uv run mypy src/ tests/                              # type-check
-```
-
-Pre-commit runs a subset of the gate on each commit; see `.pre-commit-config.yaml` for details, or [`CLAUDE.md`](CLAUDE.md) for the full Hard PR Acceptance Gates.
-
-## Troubleshooting
-
-### Moving a scaffolded project
-
-`uv sync` creates `.venv/bin/*` scripts with absolute shebangs pointing at the venv Python. If you move the repo after scaffolding (`mv /old/path /new/path`), `uv run pytest` fails with `ModuleNotFoundError: No module named 'fastmcp'` because the stale shebang resolves to a different interpreter than the venv's site-packages.
-
-**Fix:**
-
-```bash
-rm -rf .venv
-uv sync --all-extras --dev
-```
-
-`uv run python -m pytest` also works as a one-shot workaround (bypasses the stale entry-script shim).
-
-### `uv.lock` refresh after `copier update`
-
-When `copier update` introduces new dependencies (e.g. a new extra added to `pyproject.toml.jinja`), CI runs `uv sync --frozen` which fails against a stale lockfile. Run `uv lock` locally and commit the refreshed `uv.lock` alongside accepting the copier-update PR.
->>>>>>> after updating
-
-## License
-
-<<<<<<< before updating
-MIT
-=======
-- [Documentation](https://pvliesdonk.github.io/scholar-mcp/)
-- [llms.txt](https://pvliesdonk.github.io/scholar-mcp/llms.txt)
-- [FastMCP](https://gofastmcp.com)
-- [fastmcp-pvl-core](https://pypi.org/project/fastmcp-pvl-core/)
-
-<!-- ===== TEMPLATE-OWNED SECTIONS END ===== -->
-
-## Domain configuration
-
-<!-- DOMAIN-START -->
-<!-- Replace with a table of domain-specific env vars. Kept across copier update. -->
-
-Domain environment variables use the `SCHOLAR_MCP_` prefix:
-
-| Variable | Default | Required | Description |
-|---|---|---|---|
-| `SCHOLAR_MCP_EXAMPLE_VAR` | — | **Yes** | Replace this row with your first required setting. |
-| `SCHOLAR_MCP_ANOTHER_VAR` | `default` | No | Replace with an optional setting. |
-
-Domain-config fields are composed inside `src/scholar_mcp/config.py` between the `CONFIG-FIELDS-START` / `CONFIG-FIELDS-END` sentinels; env reads go through `fastmcp_pvl_core.env(_ENV_PREFIX, "SUFFIX", default)` so naming stays consistent.
-<!-- DOMAIN-END -->
-
-## Key design decisions
-
-<!-- DOMAIN-START -->
-<!-- Replace with 3-6 bullets describing non-obvious architectural decisions. Kept across copier update. -->
-
-_Replace this placeholder with a short list of the non-obvious design calls this service makes — e.g. "writes are append-only", "embeddings cached in SQLite", "auth uses OIDC bearer tokens". Three to six bullets is typically enough; link out to longer ADRs under `docs/decisions/` if you maintain any._
-<!-- DOMAIN-END -->
->>>>>>> after updating

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ scholar-mcp serve                                # stdio transport
 scholar-mcp serve --transport http --port 8000   # streamable HTTP
 ```
 
-For library usage (embedding the domain logic without the MCP transport), import from the `scholar_mcp` package directly — see `src/scholar_mcp/domain.py` for the entry point scaffold.
+For library usage (embedding the domain logic without the MCP transport), import from the `scholar_mcp` package directly — backend clients live under `src/scholar_mcp/_s2_client.py`, `_epo_client.py`, `_openlibrary_client.py`, and `_standards_client.py`.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # scholar-mcp
 
+<<<<<<< before updating
 <!-- mcp-name: io.github.pvliesdonk/scholar-mcp -->
 
 [![CI](https://github.com/pvliesdonk/scholar-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/pvliesdonk/scholar-mcp/actions/workflows/ci.yml)
@@ -339,7 +340,201 @@ uv run mypy src/
 uv sync --extra docs
 uv run mkdocs serve
 ```
+=======
+[![CI](https://github.com/pvliesdonk/scholar-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/pvliesdonk/scholar-mcp/actions/workflows/ci.yml) [![codecov](https://codecov.io/gh/pvliesdonk/scholar-mcp/graph/badge.svg)](https://codecov.io/gh/pvliesdonk/scholar-mcp) [![PyPI](https://img.shields.io/pypi/v/pvliesdonk-scholar-mcp)](https://pypi.org/project/pvliesdonk-scholar-mcp/) [![Python](https://img.shields.io/pypi/pyversions/pvliesdonk-scholar-mcp)](https://pypi.org/project/pvliesdonk-scholar-mcp/) [![License](https://img.shields.io/github/license/pvliesdonk/scholar-mcp)](LICENSE) [![Docker](https://img.shields.io/github/v/release/pvliesdonk/scholar-mcp?label=ghcr.io&logo=docker)](https://github.com/pvliesdonk/scholar-mcp/pkgs/container/scholar-mcp) [![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://pvliesdonk.github.io/scholar-mcp/) [![llms.txt](https://img.shields.io/badge/llms.txt-available-brightgreen)](https://pvliesdonk.github.io/scholar-mcp/llms.txt)
+
+FastMCP server for Semantic Scholar with OpenAlex enrichment and docling PDF conversion
+
+**[Documentation](https://pvliesdonk.github.io/scholar-mcp/)** | **[PyPI](https://pypi.org/project/pvliesdonk-scholar-mcp/)** | **[Docker](https://github.com/pvliesdonk/scholar-mcp/pkgs/container/scholar-mcp)**
+
+## Features
+
+<!-- DOMAIN-START -->
+<!-- Replace with 3-7 bullets describing what this MCP server does. Kept across copier update. -->
+
+- **[Capability 1]** — one-sentence description of a user-visible feature.
+- **[Capability 2]** — one-sentence description of another capability.
+- **MCP tools** — N LLM-visible tools exposed; see `src/scholar_mcp/tools.py`.
+- **MCP resources** — M resources exposing domain state; see `src/scholar_mcp/resources.py`.
+- **MCP prompts** — K prompt templates; see `src/scholar_mcp/prompts.py`.
+<!-- DOMAIN-END -->
+
+## What you can do with it
+
+<!-- DOMAIN-START -->
+<!-- Replace with 3-5 concrete "you can ask Claude to X" examples. Kept across copier update. -->
+
+With this server mounted in an MCP client (Claude, etc.), you can:
+
+- **[Task 1]** — "[example user request]." Composes tools `[tool_a]` + `[tool_b]`.
+- **[Task 2]** — "[another example request]." Uses resource `[resource_x]`.
+- **[Task 3]** — "[third example]."
+
+Short, concrete prompts beat abstract feature lists — replace the
+`[Task N]` placeholders with prompts that actually work against your
+server's tool surface.
+<!-- DOMAIN-END -->
+
+<!-- ===== TEMPLATE-OWNED SECTIONS BELOW — DO NOT EDIT; CHANGES WILL BE OVERWRITTEN ON COPIER UPDATE ===== -->
+
+## Installation
+
+### From PyPI
+
+```bash
+pip install pvliesdonk-scholar-mcp
+```
+
+If you add optional extras via the `PROJECT-EXTRAS-START` / `PROJECT-EXTRAS-END` sentinels in `pyproject.toml`, document them below:
+
+<!-- DOMAIN-START -->
+<!-- List optional extras and their purpose here (e.g. `pip install pvliesdonk-scholar-mcp[embeddings]`). Kept across copier update. -->
+<!-- DOMAIN-END -->
+
+### From source
+
+```bash
+git clone https://github.com/pvliesdonk/scholar-mcp.git
+cd scholar-mcp
+uv sync --all-extras --dev
+```
+
+### Docker
+
+```bash
+docker pull ghcr.io/pvliesdonk/scholar-mcp:latest
+```
+
+A `compose.yml` ships at the repo root as a starting point — copy `.env.example` to `.env`, edit, and `docker compose up -d`.
+
+### Linux packages (.deb / .rpm)
+
+Download `.deb` or `.rpm` packages from the [GitHub Releases](https://github.com/pvliesdonk/scholar-mcp/releases) page. Both install a hardened systemd unit; env configuration is sourced from `/etc/scholar-mcp/env` (copy from the shipped `/etc/scholar-mcp/env.example`).
+
+### Claude Desktop (.mcpb bundle)
+
+Download the `.mcpb` bundle from the [GitHub Releases](https://github.com/pvliesdonk/scholar-mcp/releases) page and double-click to install, or run:
+
+```bash
+mcpb install scholar-mcp-<version>.mcpb
+```
+
+Claude Desktop prompts for required env vars via a GUI wizard — no manual JSON editing needed.
+
+## Quick start
+
+```bash
+scholar-mcp serve                                # stdio transport
+scholar-mcp serve --transport http --port 8000   # streamable HTTP
+```
+
+For library usage (embedding the domain logic without the MCP transport), import from the `scholar_mcp` package directly — see `src/scholar_mcp/domain.py` for the entry point scaffold.
+
+## Configuration
+
+Core environment variables shared across all `fastmcp-pvl-core`-based services:
+
+| Variable | Default | Description |
+|---|---|---|
+| `FASTMCP_LOG_LEVEL` | `INFO` | Log level for FastMCP internals and app loggers (`DEBUG` / `INFO` / `WARNING` / `ERROR`). The `-v` CLI flag overrides to `DEBUG`. |
+| `FASTMCP_ENABLE_RICH_LOGGING` | `true` | Set to `false` for plain / structured JSON log output. |
+| `SCHOLAR_MCP_EVENT_STORE_URL` | `memory://` | Event store backend for HTTP session persistence — `memory://` (dev), `file:///path` (survives restarts). |
+
+Domain-specific variables go below under [Domain configuration](#domain-configuration).
+
+## Post-scaffold checklist
+
+After `copier copy` and `gh repo create --push`:
+
+1. **Fill in the DOMAIN blocks** in this README (Features, What you can do with it, Domain configuration, Key design decisions) and in `CLAUDE.md`.
+2. Configure GitHub secrets — see below.
+3. Install dev dependencies: `uv sync --all-extras --dev`.
+4. Install pre-commit hooks: `uv run pre-commit install`.
+5. Run the gate locally: `uv run pytest -x -q && uv run ruff check --fix . && uv run ruff format . && uv run mypy src/ tests/`.
+6. Push the first commit — CI should be green.
+
+## GitHub secrets
+
+CI workflows reference three repository secrets. Configure them via **Settings → Secrets and variables → Actions** or with `gh secret set`:
+
+| Secret | Used by | How to generate |
+|---|---|---|
+| `RELEASE_TOKEN` | `release.yml`, `copier-update.yml` | Fine-grained PAT at <https://github.com/settings/personal-access-tokens/new> with `contents: write` and `pull_requests: write` (the `copier-update` cron opens PRs). Scoped to this repo. |
+| `CODECOV_TOKEN` | `ci.yml` | <https://codecov.io> — sign in with GitHub, add the repo, copy the upload token from the repo settings page. |
+| `CLAUDE_CODE_OAUTH_TOKEN` | `claude.yml`, `claude-code-review.yml` | Run `claude setup-token` locally and paste the result. |
+
+```bash
+gh secret set RELEASE_TOKEN
+gh secret set CODECOV_TOKEN
+gh secret set CLAUDE_CODE_OAUTH_TOKEN
+```
+
+`GITHUB_TOKEN` is auto-provided — no action needed.
+
+## Local development
+
+The PR gate (matches CI):
+
+```bash
+uv run pytest -x -q                                  # tests
+uv run ruff check --fix . && uv run ruff format .    # lint + format
+uv run mypy src/ tests/                              # type-check
+```
+
+Pre-commit runs a subset of the gate on each commit; see `.pre-commit-config.yaml` for details, or [`CLAUDE.md`](CLAUDE.md) for the full Hard PR Acceptance Gates.
+
+## Troubleshooting
+
+### Moving a scaffolded project
+
+`uv sync` creates `.venv/bin/*` scripts with absolute shebangs pointing at the venv Python. If you move the repo after scaffolding (`mv /old/path /new/path`), `uv run pytest` fails with `ModuleNotFoundError: No module named 'fastmcp'` because the stale shebang resolves to a different interpreter than the venv's site-packages.
+
+**Fix:**
+
+```bash
+rm -rf .venv
+uv sync --all-extras --dev
+```
+
+`uv run python -m pytest` also works as a one-shot workaround (bypasses the stale entry-script shim).
+
+### `uv.lock` refresh after `copier update`
+
+When `copier update` introduces new dependencies (e.g. a new extra added to `pyproject.toml.jinja`), CI runs `uv sync --frozen` which fails against a stale lockfile. Run `uv lock` locally and commit the refreshed `uv.lock` alongside accepting the copier-update PR.
+>>>>>>> after updating
 
 ## License
 
+<<<<<<< before updating
 MIT
+=======
+- [Documentation](https://pvliesdonk.github.io/scholar-mcp/)
+- [llms.txt](https://pvliesdonk.github.io/scholar-mcp/llms.txt)
+- [FastMCP](https://gofastmcp.com)
+- [fastmcp-pvl-core](https://pypi.org/project/fastmcp-pvl-core/)
+
+<!-- ===== TEMPLATE-OWNED SECTIONS END ===== -->
+
+## Domain configuration
+
+<!-- DOMAIN-START -->
+<!-- Replace with a table of domain-specific env vars. Kept across copier update. -->
+
+Domain environment variables use the `SCHOLAR_MCP_` prefix:
+
+| Variable | Default | Required | Description |
+|---|---|---|---|
+| `SCHOLAR_MCP_EXAMPLE_VAR` | — | **Yes** | Replace this row with your first required setting. |
+| `SCHOLAR_MCP_ANOTHER_VAR` | `default` | No | Replace with an optional setting. |
+
+Domain-config fields are composed inside `src/scholar_mcp/config.py` between the `CONFIG-FIELDS-START` / `CONFIG-FIELDS-END` sentinels; env reads go through `fastmcp_pvl_core.env(_ENV_PREFIX, "SUFFIX", default)` so naming stays consistent.
+<!-- DOMAIN-END -->
+
+## Key design decisions
+
+<!-- DOMAIN-START -->
+<!-- Replace with 3-6 bullets describing non-obvious architectural decisions. Kept across copier update. -->
+
+_Replace this placeholder with a short list of the non-obvious design calls this service makes — e.g. "writes are append-only", "embeddings cached in SQLite", "auth uses OIDC bearer tokens". Three to six bullets is typically enough; link out to longer ADRs under `docs/decisions/` if you maintain any._
+<!-- DOMAIN-END -->
+>>>>>>> after updating

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -1,0 +1,23 @@
+# Prompts
+
+MCP prompts are reusable prompt templates exposed to clients. The scaffold
+ships a minimal set defined in `src/scholar_mcp/prompts.py`; add
+domain-specific prompts there and document them in this page.
+
+## Built-in prompts
+
+_None in the scaffold._ Define prompts with `@mcp.prompt(...)` decorators in
+`src/scholar_mcp/prompts.py` and list them here with their arguments,
+usage, and example output.
+
+## Example
+
+```python
+@mcp.prompt()
+def summarize(topic: str) -> str:
+    """Summarize the given topic in three sentences."""
+    return f"Write a three-sentence summary of: {topic}"
+```
+
+See the [FastMCP prompts documentation](https://gofastmcp.com/servers/prompts)
+for the full prompt API.

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -1,13 +1,13 @@
 # Prompts
 
 MCP prompts are reusable prompt templates exposed to clients. The scaffold
-ships a minimal set defined in `src/scholar_mcp/prompts.py`; add
+ships a minimal set defined in `src/scholar_mcp/_server_prompts.py`; add
 domain-specific prompts there and document them in this page.
 
 ## Built-in prompts
 
 _None in the scaffold._ Define prompts with `@mcp.prompt(...)` decorators in
-`src/scholar_mcp/prompts.py` and list them here with their arguments,
+`src/scholar_mcp/_server_prompts.py` and list them here with their arguments,
 usage, and example output.
 
 ## Example

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,15 @@ dependencies = [
 mcp = ["fastmcp[tasks]>=3.2.0,<4"]
 all = ["fastmcp[tasks]>=3.2.0,<4"]
 # PROJECT-EXTRAS-END
+<<<<<<< before updating
+=======
+
+docs = [
+    "mkdocs-material>=9",
+    "mkdocstrings[python]>=0.28",
+]
+
+>>>>>>> after updating
 dev = [
     "pytest>=7.0",
     "pytest-asyncio>=0.21",
@@ -80,6 +89,7 @@ ignore = ["E501"]
 [tool.ruff.lint.per-file-ignores]
 # Depends() and CurrentContext() calls in argument defaults are the standard
 # FastMCP dependency injection pattern — B008 is a false positive here.
+<<<<<<< before updating
 # Context/FastMCP imports must stay runtime (not TYPE_CHECKING) for DI.
 "src/scholar_mcp/server.py" = ["ARG001", "B008", "TCH002"]
 "src/scholar_mcp/cli.py" = ["B008", "TCH002", "TCH003"]
@@ -109,6 +119,20 @@ ignore = ["E501"]
 "src/scholar_mcp/_server_prompts.py" = ["B008", "TCH002"]
 # pytest fixtures need runtime imports; Path used in signatures needs to be importable at runtime.
 "tests/*.py" = ["ARG001", "ARG002", "TCH001", "TCH002", "TCH003"]
+=======
+# Context/FastMCP/Service imports must stay runtime (not TYPE_CHECKING) for
+# DI resolution — TC001/TC002/TC003.
+"src/scholar_mcp/cli.py" = ["B008"]
+"src/scholar_mcp/_server_deps.py" = ["B008", "TC002", "TC003"]
+"src/scholar_mcp/_server_apps.py" = ["B008", "TC001", "TC002"]
+"src/scholar_mcp/tools.py" = ["B008", "TC001", "TC002"]
+"src/scholar_mcp/resources.py" = ["B008", "TC001", "TC002"]
+"src/scholar_mcp/prompts.py" = ["B008", "TC002"]
+"tests/conftest.py" = ["TC002", "TC003"]
+"tests/test_smoke.py" = ["TC002"]
+"tests/test_tools.py" = ["TC002"]
+# Add project-specific overrides below as needed.
+>>>>>>> after updating
 
 [tool.ruff.lint.isort]
 known-first-party = ["scholar_mcp"]
@@ -178,6 +202,9 @@ ignore_missing_imports = true
 venvPath = "."
 venv = ".venv"
 pythonVersion = "3.11"
+# src-layout editable installs use a .pth shim that Pyright does not execute;
+# point Pyright at src/ directly so IDE import resolution matches runtime.
+extraPaths = ["src"]
 
 [tool.semantic_release]
 version_toml = ["pyproject.toml:project.version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,15 +35,6 @@ dependencies = [
 mcp = ["fastmcp[tasks]>=3.2.0,<4"]
 all = ["fastmcp[tasks]>=3.2.0,<4"]
 # PROJECT-EXTRAS-END
-<<<<<<< before updating
-=======
-
-docs = [
-    "mkdocs-material>=9",
-    "mkdocstrings[python]>=0.28",
-]
-
->>>>>>> after updating
 dev = [
     "pytest>=7.0",
     "pytest-asyncio>=0.21",
@@ -82,57 +73,43 @@ src = ["src", "tests"]
 
 [tool.ruff.lint]
 select = [
-    "E", "W", "F", "I", "B", "C4", "UP", "ARG", "SIM", "TCH", "PTH", "RUF",
+    "E", "W", "F", "I", "B", "C4", "UP", "ARG", "SIM", "TC", "PTH", "RUF",
 ]
 ignore = ["E501"]
 
 [tool.ruff.lint.per-file-ignores]
 # Depends() and CurrentContext() calls in argument defaults are the standard
 # FastMCP dependency injection pattern — B008 is a false positive here.
-<<<<<<< before updating
-# Context/FastMCP imports must stay runtime (not TYPE_CHECKING) for DI.
-"src/scholar_mcp/server.py" = ["ARG001", "B008", "TCH002"]
-"src/scholar_mcp/cli.py" = ["B008", "TCH002", "TCH003"]
-"src/scholar_mcp/_server_apps.py" = ["TCH002"]
-"src/scholar_mcp/_server_deps.py" = ["ARG001", "B008", "TCH002", "TCH003"]
-"src/scholar_mcp/_cache.py" = ["TCH003"]
-"src/scholar_mcp/_docling_client.py" = ["TCH002"]
-"src/scholar_mcp/_rate_limiter.py" = ["TCH002", "TCH003"]
-"src/scholar_mcp/_server_tools.py" = ["ARG001", "B008", "TCH001", "TCH002"]
-"src/scholar_mcp/_tools_search.py" = ["ARG001", "B008", "TCH001", "TCH002"]
-"src/scholar_mcp/_tools_graph.py" = ["ARG001", "B008", "TCH001", "TCH002"]
-"src/scholar_mcp/_tools_recommendations.py" = ["ARG001", "B008", "TCH001", "TCH002"]
-"src/scholar_mcp/_tools_utility.py" = ["ARG001", "B008", "TCH001", "TCH002"]
-"src/scholar_mcp/_tools_pdf.py" = ["ARG001", "B008", "TCH001", "TCH002"]
-"src/scholar_mcp/_tools_tasks.py" = ["ARG001", "B008", "TCH001", "TCH002"]
-"src/scholar_mcp/_tools_citation.py" = ["ARG001", "B008", "TCH001", "TCH002"]
-"src/scholar_mcp/_tools_patent.py" = ["ARG001", "B008", "TCH001", "TCH002"]
-"src/scholar_mcp/_tools_books.py" = ["ARG001", "B008", "TCH001", "TCH002"]
-"src/scholar_mcp/_tools_standards.py" = ["ARG001", "B008", "TCH001", "TCH002"]
-"src/scholar_mcp/_book_enrichment.py" = ["TCH001"]
-"src/scholar_mcp/_task_queue.py" = ["TCH003"]
-"src/scholar_mcp/_openlibrary_client.py" = ["TCH001"]
-"src/scholar_mcp/_standards_client.py" = ["TCH001", "TCH002", "TCH003"]
-"src/scholar_mcp/_sync_relaton.py" = ["TCH001", "TCH002", "TCH003"]
-"src/scholar_mcp/_relaton_live.py" = ["TCH001", "TCH002", "TCH003"]
-"src/scholar_mcp/_server_resources.py" = ["B008", "TCH001", "TCH002"]
-"src/scholar_mcp/_server_prompts.py" = ["B008", "TCH002"]
-# pytest fixtures need runtime imports; Path used in signatures needs to be importable at runtime.
-"tests/*.py" = ["ARG001", "ARG002", "TCH001", "TCH002", "TCH003"]
-=======
 # Context/FastMCP/Service imports must stay runtime (not TYPE_CHECKING) for
 # DI resolution — TC001/TC002/TC003.
-"src/scholar_mcp/cli.py" = ["B008"]
-"src/scholar_mcp/_server_deps.py" = ["B008", "TC002", "TC003"]
-"src/scholar_mcp/_server_apps.py" = ["B008", "TC001", "TC002"]
-"src/scholar_mcp/tools.py" = ["B008", "TC001", "TC002"]
-"src/scholar_mcp/resources.py" = ["B008", "TC001", "TC002"]
-"src/scholar_mcp/prompts.py" = ["B008", "TC002"]
-"tests/conftest.py" = ["TC002", "TC003"]
-"tests/test_smoke.py" = ["TC002"]
-"tests/test_tools.py" = ["TC002"]
-# Add project-specific overrides below as needed.
->>>>>>> after updating
+"src/scholar_mcp/server.py" = ["ARG001", "B008", "TC002"]
+"src/scholar_mcp/cli.py" = ["B008", "TC002", "TC003"]
+"src/scholar_mcp/_server_apps.py" = ["TC002"]
+"src/scholar_mcp/_server_deps.py" = ["ARG001", "B008", "TC002", "TC003"]
+"src/scholar_mcp/_cache.py" = ["TC003"]
+"src/scholar_mcp/_docling_client.py" = ["TC002"]
+"src/scholar_mcp/_rate_limiter.py" = ["TC002", "TC003"]
+"src/scholar_mcp/_server_tools.py" = ["ARG001", "B008", "TC001", "TC002"]
+"src/scholar_mcp/_tools_search.py" = ["ARG001", "B008", "TC001", "TC002"]
+"src/scholar_mcp/_tools_graph.py" = ["ARG001", "B008", "TC001", "TC002"]
+"src/scholar_mcp/_tools_recommendations.py" = ["ARG001", "B008", "TC001", "TC002"]
+"src/scholar_mcp/_tools_utility.py" = ["ARG001", "B008", "TC001", "TC002"]
+"src/scholar_mcp/_tools_pdf.py" = ["ARG001", "B008", "TC001", "TC002"]
+"src/scholar_mcp/_tools_tasks.py" = ["ARG001", "B008", "TC001", "TC002"]
+"src/scholar_mcp/_tools_citation.py" = ["ARG001", "B008", "TC001", "TC002"]
+"src/scholar_mcp/_tools_patent.py" = ["ARG001", "B008", "TC001", "TC002"]
+"src/scholar_mcp/_tools_books.py" = ["ARG001", "B008", "TC001", "TC002"]
+"src/scholar_mcp/_tools_standards.py" = ["ARG001", "B008", "TC001", "TC002"]
+"src/scholar_mcp/_book_enrichment.py" = ["TC001"]
+"src/scholar_mcp/_task_queue.py" = ["TC003"]
+"src/scholar_mcp/_openlibrary_client.py" = ["TC001"]
+"src/scholar_mcp/_standards_client.py" = ["TC001", "TC002", "TC003"]
+"src/scholar_mcp/_sync_relaton.py" = ["TC001", "TC002", "TC003"]
+"src/scholar_mcp/_relaton_live.py" = ["TC001", "TC002", "TC003"]
+"src/scholar_mcp/_server_resources.py" = ["B008", "TC001", "TC002"]
+"src/scholar_mcp/_server_prompts.py" = ["B008", "TC002"]
+# pytest fixtures need runtime imports; Path used in signatures needs to be importable at runtime.
+"tests/*.py" = ["ARG001", "ARG002", "TC001", "TC002", "TC003"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["scholar_mcp"]
@@ -195,6 +172,31 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = ["yaml"]
 ignore_missing_imports = true
+
+# Tests use pytest idioms (untyped fixtures, monkey-patching, ad-hoc stubs,
+# TypedDict literals passed as dicts) that don't pay back when forced into
+# strict annotation. Keep mypy running over tests/ so import-time failures
+# still surface, but relax the checks that produce no signal in test code.
+# Incremental re-tightening tracked in #167.
+[[tool.mypy.overrides]]
+module = "tests.*"
+disallow_untyped_defs = false
+disallow_incomplete_defs = false
+warn_unused_ignores = false
+disable_error_code = [
+    "arg-type",
+    "attr-defined",
+    "comparison-overlap",
+    "func-returns-value",
+    "index",
+    "list-item",
+    "method-assign",
+    "misc",
+    "no-any-return",
+    "type-arg",
+    "union-attr",
+    "var-annotated",
+]
 
 [tool.pyright]
 # Point Pyright at the uv-managed venv so editor diagnostics resolve

--- a/uv.lock
+++ b/uv.lock
@@ -1881,7 +1881,7 @@ wheels = [
 
 [[package]]
 name = "pvliesdonk-scholar-mcp"
-version = "1.7.0"
+version = "1.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Automated `copier update` run against template ref `v1.2.0`.

Review the diff, resolve any `<<<<<<< before updating` conflict markers, and merge if CI is green.

> **Note:** `--skip-answered` was passed, so any **new** template variables introduced since the last update were silently filled with their copier defaults. Skim `.copier-answers.yml` for unexpected new keys.

⚠️ **2 file(s) contain unresolved `<<<<<<< before updating` conflict markers — review and resolve manually before merging.**