### PR TITLE
chore(copier): update to v1.6.1

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by `copier update`.
-_commit: v1.2.0
+_commit: v1.6.1
 _src_path: https://github.com/pvliesdonk/fastmcp-server-template
 docker_registry: ghcr.io/pvliesdonk
 domain_description: FastMCP server for Semantic Scholar with OpenAlex enrichment and

--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,18 @@
+# Gemini Code Assist — repo review config
+# Reference: https://developers.google.com/gemini-code-assist/docs/customize-repo-review
+#
+# gemini-code-assist is a merge gate, not a pair reviewer. Local review (two
+# subagent code-reviewers with different prompt templates) runs before any
+# push; by the time the PR opens we expect the hosted bot to have nothing to
+# flag. These settings narrow the bot's scope so it fires on flip-to-ready
+# (not on every draft push) and only surfaces real issues.
+
+code_review:
+  disable: false
+  comment_severity_threshold: HIGH
+  max_review_comments: 20
+  pull_request_opened:
+    help: false
+    summary: false
+    code_review: true
+    include_drafts: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         run: uv python install 3.12
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --all-extras --all-groups
 
       - name: Run ruff check
         run: uv run ruff check src/ tests/
@@ -46,7 +46,7 @@ jobs:
         run: uv python install 3.12
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --all-extras --all-groups
 
       - name: Run mypy
         run: uv run mypy src/ tests/
@@ -82,7 +82,7 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --all-extras --all-groups
 
       - name: Run tests with coverage
         run: uv run pytest --cov --cov-report=xml
@@ -193,7 +193,13 @@ jobs:
         run: uv python install 3.12
 
       - name: Export dependency list (excluding local project)
-        run: uv export --all-extras --frozen --no-emit-project --no-hashes -o ${{ runner.temp }}/requirements.txt
+        # `dev` is uv's only auto-activated default group, so --no-default-groups
+        # excludes it; `docs` is non-default and never exported unless explicitly
+        # requested via --group/--all-groups (neither passed here). Net effect:
+        # only runtime + user-defined extras land in the audit input — avoids
+        # spurious CVE reports against tooling (pip-audit's own `pip` dep, etc.)
+        # that does not run in production.
+        run: uv export --all-extras --no-default-groups --frozen --no-emit-project --no-hashes -o ${{ runner.temp }}/requirements.txt
 
       - name: Run pip-audit
         run: uvx pip-audit --strict --progress-spinner off -r ${{ runner.temp }}/requirements.txt

--- a/.github/workflows/copier-update.yml
+++ b/.github/workflows/copier-update.yml
@@ -27,6 +27,11 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      # Required by anthropics/claude-code-action@v1: setupGitHubToken() mints
+      # a Claude-app GitHub token via OIDC token exchange, which needs
+      # id-token: write at the job level. Without it the agent steps retry
+      # 3x then abort on "Could not fetch an OIDC token".
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -84,6 +89,9 @@ jobs:
       - name: Read template ref + collect conflict files
         if: steps.changes.outputs.changed == 'true'
         id: meta
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          PREVIOUS_COMMIT: ${{ steps.copier.outputs.prev_ref }}
         run: |
           set -euo pipefail
           # Parse `_commit:` from .copier-answers.yml without depending on
@@ -94,6 +102,25 @@ jobs:
             echo "::error::could not read _commit from .copier-answers.yml"
             exit 1
           fi
+          # Detect whether the template ref actually changed (agent jobs B/C
+          # should fire even when no conflicts but the template advanced).
+          if [ -n "${PREVIOUS_COMMIT}" ] && [ "${PREVIOUS_COMMIT}" != "${ref}" ]; then
+            template_advanced=true
+          else
+            template_advanced=false
+          fi
+          echo "template_advanced=${template_advanced}" >> "$GITHUB_OUTPUT"
+          # Surface previous_commit / new_ref under stable names so the
+          # downstream agent + aggregator steps can reference them via
+          # `steps.meta.outputs.*` regardless of which earlier step produced
+          # the value.  `previous_commit` may be empty on first-ever update.
+          echo "previous_commit=${PREVIOUS_COMMIT}" >> "$GITHUB_OUTPUT"
+          echo "new_ref=${ref}" >> "$GITHUB_OUTPUT"
+          # Pre-detect any existing PR on the copier/update branch so the
+          # aggregator's overflow-comment step has a PR number to post to
+          # (set to 0 when no PR exists yet — overflow posting is best-effort).
+          pr_number=$(gh pr view copier/update --json number --jq .number 2>/dev/null || echo 0)
+          echo "pr_number=${pr_number}" >> "$GITHUB_OUTPUT"
           # `--conflict=inline` writes standard `<<<<<<< before updating`
           # markers (not `.rej` sidecars).  Collect files that contain at
           # least one conflict marker; skip binary files with `git grep -I`.
@@ -131,6 +158,192 @@ jobs:
             printf '%s\n' "${conflict_files}"
             echo "CONFLICT_FILES_EOF"
           } >> "$GITHUB_OUTPUT"
+
+      - name: Clone template at both refs (for agent context)
+        id: clone-template
+        # Provides /tmp/template at both old (downstream's previous _commit)
+        # and new (just-applied) refs so the three claude-code agent steps can
+        # read template-side history (CHANGELOG, conflict files at the old
+        # ref, excluded-file evolution diffs).
+        # Failure-tolerant: if clone fails, agent steps see the missing dir
+        # and write error placeholders; PR still opens.
+        if: steps.changes.outputs.changed == 'true' && (steps.meta.outputs.conflict_count > 0 || steps.meta.outputs.template_advanced == 'true')
+        continue-on-error: true
+        env:
+          PREVIOUS_COMMIT: ${{ steps.meta.outputs.previous_commit }}
+          TEMPLATE_REPO: ${{ steps.meta.outputs.template_repo }}
+        run: |
+          set -euo pipefail
+          rm -rf /tmp/template
+          if [ -z "${TEMPLATE_REPO}" ]; then
+            echo "::notice::template_repo unresolved; skipping clone (agent steps will skip)"
+            exit 0
+          fi
+          git clone --filter=blob:none \
+            "https://github.com/${TEMPLATE_REPO}.git" \
+            /tmp/template
+          # Verify both refs are reachable
+          git -C /tmp/template fetch --tags
+          if [ -n "${PREVIOUS_COMMIT}" ]; then
+            git -C /tmp/template rev-parse "${PREVIOUS_COMMIT}^{commit}" >/dev/null
+          fi
+          echo "template_clone_ok=true" >> "$GITHUB_OUTPUT"
+
+      - name: Check claude-code token availability
+        id: agent-prereq
+        if: steps.changes.outputs.changed == 'true'
+        # Detect whether the downstream repo has CLAUDE_CODE_OAUTH_TOKEN
+        # configured. Without it, the three agent steps skip and the
+        # aggregator renders "agent disabled" placeholders.
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          if [ -n "${CLAUDE_CODE_OAUTH_TOKEN}" ]; then
+            echo "agent_enabled=true"  >> "$GITHUB_OUTPUT"
+          else
+            echo "agent_enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::CLAUDE_CODE_OAUTH_TOKEN not set; skipping agent analysis. Set in repo secrets to enable."
+          fi
+
+      # Jobs A, B, C are independent — they share no data dependency, only
+      # the cloned `/tmp/template` workspace and the per-job env vars.
+      # Currently sequential for simplicity (single workflow job, fewer
+      # `needs:` edges); could be parallelized into separate jobs if wall-
+      # clock latency becomes an issue. Don't make A→B→C serial for
+      # ordering reasons — there is no ordering reason. Agent JSON outputs
+      # land in distinct `/tmp/agent-job-{a,b,c}.json` files; the
+      # aggregator step reads each independently.
+      #
+      # Each agent step has TWO sub-steps:
+      #   1. Pre-render its prompt via `envsubst` and capture into a step
+      #      output (heredoc form for multi-line content).
+      #   2. Invoke claude-code-action with `prompt:` set to the rendered
+      #      content. claude-code-action@v1 only accepts `prompt:` (a
+      #      string) as a public input — there is NO `prompt_file:` input
+      #      on the user-facing wrapper (the action internally writes the
+      #      resolved prompt to `${RUNNER_TEMP}/claude-prompts/claude-prompt.txt`
+      #      from the `prompt:` value).
+      #
+      # envsubst's restricted-form `'${VAR1} ${VAR2}'` only substitutes
+      # those listed; any other `$VAR` references in the prompt body
+      # (e.g. shell-pattern examples) stay literal.
+      #
+      # Multi-line `CONFLICT_FILES_LIST` is safe via envsubst's file-to-file
+      # I/O — no argv quoting. Same pattern is used in release.yml.jinja's
+      # mcpb manifest rendering.
+      #
+      # Each agent step constrains tool access via `claude_args
+      # --allowed-tools` to enforce the spec's per-job tool boundaries
+      # (Job A: file read/write + git commit on the working tree; Jobs B/C:
+      # read everywhere, plus a bare Write — narrowed to the single output
+      # JSON at /tmp/agent-job-{b,c}.json by prose in each job's prompt).
+      # The path-scoped Write(//tmp/agent-job-b.json) form documented at
+      # code.claude.com/docs/en/permissions empirically doesn't match the
+      # agent's single-slash invocations under the SDK shipped with
+      # claude-code-action@v1, so the prose constraint is what's narrow.
+
+      - name: Pre-render Job A prompt
+        id: prepare-prompt-a
+        if: |
+          steps.changes.outputs.changed == 'true' &&
+          steps.agent-prereq.outputs.agent_enabled == 'true' &&
+          steps.meta.outputs.conflict_count > 0 &&
+          steps.clone-template.outputs.template_clone_ok == 'true'
+        env:
+          PREVIOUS_COMMIT: ${{ steps.meta.outputs.previous_commit }}
+          NEW_REF: ${{ steps.meta.outputs.new_ref }}
+          CONFLICT_FILES_LIST: ${{ steps.meta.outputs.conflict_files }}
+        run: |
+          envsubst '${PREVIOUS_COMMIT} ${NEW_REF} ${CONFLICT_FILES_LIST}' \
+            < scripts/copier_update_prompts/job_a.md \
+            > /tmp/agent-prompt-a.md
+          {
+            echo "prompt<<PROMPT_EOF"
+            cat /tmp/agent-prompt-a.md
+            echo "PROMPT_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Agent Job A — Conflict resolution
+        if: |
+          steps.changes.outputs.changed == 'true' &&
+          steps.agent-prereq.outputs.agent_enabled == 'true' &&
+          steps.meta.outputs.conflict_count > 0 &&
+          steps.clone-template.outputs.template_clone_ok == 'true'
+        continue-on-error: true
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: ${{ steps.prepare-prompt-a.outputs.prompt }}
+          claude_args: |
+            --allowed-tools "Read,Edit,Write,Bash(git status:*),Bash(git diff:*),Bash(git add:*),Bash(git commit:*),Bash(git rev-parse:*),Bash(git -C /tmp/template:*)"
+
+      - name: Pre-render Job B prompt
+        id: prepare-prompt-b
+        if: |
+          steps.changes.outputs.changed == 'true' &&
+          steps.agent-prereq.outputs.agent_enabled == 'true' &&
+          steps.meta.outputs.template_advanced == 'true' &&
+          steps.clone-template.outputs.template_clone_ok == 'true'
+        env:
+          PREVIOUS_COMMIT: ${{ steps.meta.outputs.previous_commit }}
+          NEW_REF: ${{ steps.meta.outputs.new_ref }}
+        run: |
+          envsubst '${PREVIOUS_COMMIT} ${NEW_REF}' \
+            < scripts/copier_update_prompts/job_b.md \
+            > /tmp/agent-prompt-b.md
+          {
+            echo "prompt<<PROMPT_EOF"
+            cat /tmp/agent-prompt-b.md
+            echo "PROMPT_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Agent Job B — Changelog triage
+        if: |
+          steps.changes.outputs.changed == 'true' &&
+          steps.agent-prereq.outputs.agent_enabled == 'true' &&
+          steps.meta.outputs.template_advanced == 'true' &&
+          steps.clone-template.outputs.template_clone_ok == 'true'
+        continue-on-error: true
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: ${{ steps.prepare-prompt-b.outputs.prompt }}
+          claude_args: |
+            --allowed-tools "Read,Write,Bash(cat:*),Bash(git -C /tmp/template:*)"
+
+      - name: Pre-render Job C prompt
+        id: prepare-prompt-c
+        if: |
+          steps.changes.outputs.changed == 'true' &&
+          steps.agent-prereq.outputs.agent_enabled == 'true' &&
+          steps.meta.outputs.template_advanced == 'true' &&
+          steps.clone-template.outputs.template_clone_ok == 'true'
+        env:
+          PREVIOUS_COMMIT: ${{ steps.meta.outputs.previous_commit }}
+          NEW_REF: ${{ steps.meta.outputs.new_ref }}
+        run: |
+          envsubst '${PREVIOUS_COMMIT} ${NEW_REF}' \
+            < scripts/copier_update_prompts/job_c.md \
+            > /tmp/agent-prompt-c.md
+          {
+            echo "prompt<<PROMPT_EOF"
+            cat /tmp/agent-prompt-c.md
+            echo "PROMPT_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Agent Job C — Excluded-file evolution
+        if: |
+          steps.changes.outputs.changed == 'true' &&
+          steps.agent-prereq.outputs.agent_enabled == 'true' &&
+          steps.meta.outputs.template_advanced == 'true' &&
+          steps.clone-template.outputs.template_clone_ok == 'true'
+        continue-on-error: true
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: ${{ steps.prepare-prompt-c.outputs.prompt }}
+          claude_args: |
+            --allowed-tools "Read,Write,Bash(cat:*),Bash(git -C /tmp/template:*)"
 
       - name: Ensure PR labels exist
         if: steps.changes.outputs.changed == 'true'
@@ -174,19 +387,27 @@ jobs:
         id: diff
         run: |
           set -euo pipefail
-          # `copier/update` is always `main + 1 commit` because the previous
-          # step does `git checkout -B` off the checked-out default branch
-          # before making a single commit, so HEAD~1..HEAD captures exactly
-          # this update's delta — no merge-base math needed.
-          diff_count=$(git diff --name-only HEAD~1 HEAD | wc -l | tr -d ' ')
+          # `copier/update` may have 1 or 2 commits ahead of main:
+          #   1 commit  — the chore(copier) commit only (no Job A auto-commit
+          #               because no conflicts arose, or Job A didn't run).
+          #   2 commits — Job A's "auto-resolve N trivial conflicts" commit
+          #               (made on default branch, carried forward into
+          #               copier/update via `git checkout -B`) PLUS the chore
+          #               commit on top.
+          # Always diff against main rather than HEAD~1 so Job A's
+          # auto-resolved files are reflected in the diff stat regardless
+          # of how many commits are stacked.
+          git fetch origin main --depth=50
+          diff_count=$(git diff --name-only origin/main HEAD | wc -l | tr -d ' ')
           echo "diff_count=${diff_count}" >> "$GITHUB_OUTPUT"
           {
             echo "diff_stat<<DIFF_STAT_EOF"
-            git diff --stat HEAD~1 HEAD
+            git diff --stat origin/main HEAD
             echo "DIFF_STAT_EOF"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Open or update PR
+      - name: Build #49 body content
+        id: build-body
         if: steps.changes.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
@@ -199,8 +420,7 @@ jobs:
           DIFF_STAT: ${{ steps.diff.outputs.diff_stat }}
         run: |
           set -euo pipefail
-          branch="copier/update"
-          title="chore(copier): update to ${REF}"
+          mkdir -p /tmp/aggregator
 
           # Fetch release notes for the target ref.  Empty when the release
           # isn't cut yet (e.g. a manual `--vcs-ref` run targeting an unreleased
@@ -257,10 +477,70 @@ jobs:
           body+=$'\n\n'"---"
           body+=$'\n\n'"> **Note:** \`--skip-answered\` was passed, so any **new** template variables introduced since the last update were silently filled with their copier defaults. Skim \`.copier-answers.yml\` for unexpected new keys."
 
+          # Persist for the aggregator (Compose PR body) and as the fallback
+          # body when the aggregator step fails.
+          printf '%s' "${body}" > /tmp/aggregator/existing-body.md
+
+      - name: Compose PR body via aggregator
+        id: compose
+        # Reads the existing #49-shaped body data + three /tmp/agent-job-*.json
+        # files (any may be missing/errored) and writes the composed PR body.
+        # Failure-tolerant: if aggregator crashes, PR still opens with the
+        # existing #49 body (no agent sections).
+        if: steps.changes.outputs.changed == 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          AGENT_ENABLED: ${{ steps.agent-prereq.outputs.agent_enabled }}
+          CONFLICT_COUNT: ${{ steps.meta.outputs.conflict_count }}
+          TEMPLATE_ADVANCED: ${{ steps.meta.outputs.template_advanced }}
+          PR_NUMBER: ${{ steps.meta.outputs.pr_number || '0' }}
+        run: |
+          set -euo pipefail
+
+          python3 scripts/copier_update_aggregator.py \
+            --existing-body /tmp/aggregator/existing-body.md \
+            --agent-enabled "${AGENT_ENABLED}" \
+            $( [ -f /tmp/agent-job-a.json ] && echo "--job-a /tmp/agent-job-a.json" ) \
+            $( [ -f /tmp/agent-job-b.json ] && echo "--job-b /tmp/agent-job-b.json" ) \
+            $( [ -f /tmp/agent-job-c.json ] && echo "--job-c /tmp/agent-job-c.json" ) \
+            --conflict-count "${CONFLICT_COUNT}" \
+            --template-advanced "${TEMPLATE_ADVANCED}" \
+            --output-body /tmp/aggregator/composed-body.md \
+            --overflow-dir /tmp/aggregator/overflow
+
+          echo "composed_body_path=/tmp/aggregator/composed-body.md" >> "$GITHUB_OUTPUT"
+
+          # Post overflow comments if any (best-effort: requires PR_NUMBER>0).
+          if [ "${PR_NUMBER}" != "0" ] && [ -d /tmp/aggregator/overflow ]; then
+            for overflow_file in /tmp/aggregator/overflow/overflow-*.md; do
+              [ -f "$overflow_file" ] || continue
+              gh pr comment "${PR_NUMBER}" --body-file "$overflow_file" || true
+            done
+          fi
+
+      - name: Open or update PR
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          REF: ${{ steps.meta.outputs.ref }}
+        run: |
+          set -euo pipefail
+          branch="copier/update"
+          title="chore(copier): update to ${REF}"
+
+          # Prefer the aggregator's composed body; fall back to the plain
+          # #49 body if the aggregator step failed (continue-on-error: true).
+          if [ -f /tmp/aggregator/composed-body.md ]; then
+            body_file=/tmp/aggregator/composed-body.md
+          else
+            body_file=/tmp/aggregator/existing-body.md
+          fi
+
           if gh pr view "${branch}" --json state --jq '.state' 2>/dev/null | grep -q OPEN; then
             gh pr edit "${branch}" \
               --title "${title}" \
-              --body "${body}" \
+              --body-file "${body_file}" \
               --add-label copier \
               --add-label dependencies
           else
@@ -268,7 +548,7 @@ jobs:
               --base main \
               --head "${branch}" \
               --title "${title}" \
-              --body "${body}" \
+              --body-file "${body_file}" \
               --label copier \
               --label dependencies
           fi

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,7 +48,7 @@ jobs:
         run: uv python install 3.12
 
       - name: Install dependencies
-        run: uv sync --extra docs --frozen
+        run: uv sync --no-default-groups --group docs --frozen
 
       - name: Build documentation
         run: uv run mkdocs build --strict

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/p/scholar-mcp
+      url: https://pypi.org/p/pvliesdonk-scholar-mcp
 
     permissions:
       id-token: write
@@ -221,7 +221,7 @@ jobs:
 
   publish-linux-packages:
     needs: release
-    if: needs.release.outputs.released == 'true'
+    if: needs.release.outputs.released == 'true' && !inputs.prerelease
     runs-on: ubuntu-latest
 
     permissions:
@@ -405,8 +405,13 @@ jobs:
 
       - name: Install mcp-publisher
         env:
-          MCP_PUBLISHER_VERSION: v1.5.0
-          MCP_PUBLISHER_SHA256: 79bbb73ba048c5906034f73ef6286d7763bd53cf368ea0b358fc593ed360cbd5
+          # v1.7.x is the first that requests the per-deployment OIDC audience
+          # the registry now requires (PR modelcontextprotocol/registry#1229,
+          # merged 2026-04-30 — production registry expects audience
+          # `https://registry.modelcontextprotocol.io`; v1.5.0 still requests
+          # `mcp-registry` and fails token exchange with HTTP 401).
+          MCP_PUBLISHER_VERSION: v1.7.6
+          MCP_PUBLISHER_SHA256: bcc96ca630cae4cf503b4550bd4a17462d42ad4819273bee56f4385bb059ddee
         run: |
           curl -sL "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz" -o mcp-publisher.tar.gz
           echo "${MCP_PUBLISHER_SHA256}  mcp-publisher.tar.gz" | sha256sum -c

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,8 @@ The config is in `_skip_if_exists`, so domain-specific additions (shellcheck, ya
 
 Trivial exceptions: pure typo fixes and automated dependency bumps (Dependabot / Renovate) may skip the issue.
 
+**Bot reviewers (claude-review, gemini-code-assist) are merge gates, not pair reviewers.** Local review must be complete before the PR opens. If a bot finds anything on first run, the local review was incomplete — that is a discipline failure to investigate, not "address-and-move-on." Run a local code-review pass on the cumulative diff before `gh pr create`; the bots are not a substitute.
+
 ## GitHub Review Types
 
 GitHub has two distinct review mechanisms — **both must be read and addressed**:
@@ -119,12 +121,45 @@ Domain configuration composes `fastmcp_pvl_core.ServerConfig` inside your domain
 
 Env var prefix is `SCHOLAR_MCP_` — all env reads go through `fastmcp_pvl_core.env(_ENV_PREFIX, "SUFFIX", default)` so naming stays consistent.
 
+### Tool icons
+
+Drop SVG / PNG / ICO / JPEG files into `src/scholar_mcp/static/icons/` and bulk-attach them to registered tools via `fastmcp_pvl_core.register_tool_icons(mcp, {"tool_name": "filename.svg"}, static_dir=...)` at the end of `register_tools()` — or attach at decoration time with `@mcp.tool(icons=[make_icon(STATIC / "x.svg")])` (where `STATIC = Path(__file__).parent / "static" / "icons"` is a shorthand you define at module level). The scaffold ships an empty `static/icons/` directory; commented-out wiring lives in `tools.py`.
+
+### Dockerfile extension points
+
+These sentinel blocks in `Dockerfile` are preserved across `copier update`. Add domain-specific apt packages, uv extras, state subdirs, and volume mounts inside them:
+
+- `# DOCKERFILE-APT-DEPS-START` / `-END` — extra apt packages installed into the runtime image
+- `# DOCKERFILE-UV-EXTRAS-START` / `-END` — `--extra <name>` flags added to both `uv sync` invocations (deps cache layer + project install — adding only to one breaks the cache layer)
+- `# DOCKERFILE-STATE-DIRS-START` / `-END` — state subdirectories created under `/data` (chowned to the runtime user)
+- `# DOCKERFILE-VOLUMES-START` / `-END` — `VOLUME` declarations on the final image
+
+## Server Info Tool (`get_server_info`)
+
+`make_server()` registers `get_server_info` (via `fastmcp_pvl_core.register_server_info_tool`) so operators can answer "is the latest fix actually deployed?" with a single MCP call. The default response carries `server_name`, `server_version`, and `core_version`.
+
+For services that talk to a remote upstream (e.g. paperless, an HTTP API), wire the upstream version inside the `DOMAIN-UPSTREAM-START` / `DOMAIN-UPSTREAM-END` sentinel in `src/scholar_mcp/server.py`. Pass `upstream_version=` (a zero-arg callable returning a dict / str / None) and optionally `upstream_label="<service>"` (default `"upstream"`). The simplest pattern is a module-level upstream client (typically constructed from env vars at import time) whose version method is referenced from the callable — `CurrentContext()` is a FastMCP DI marker that only resolves inside parameter defaults, so it cannot be called directly from a zero-arg provider. The block is preserved across `copier update`.
+
+## File Exchange (`register_file_exchange` + opt-in upload)
+
+`make_server()` calls `register_file_exchange(...)` inside the
+`DOMAIN-FILE-EXCHANGE-START` / `DOMAIN-FILE-EXCHANGE-END` sentinel in
+`src/scholar_mcp/server.py`. The block is preserved across
+`copier update`, so opt-in customisations (`produces=`, `consumer_sink=`,
+or uncommenting the `register_file_exchange_upload(...)` block for the
+inbound direction) survive subsequent template updates. Download direction
+is wired unconditionally; upload direction is opt-in by uncommenting
+the fully commented `register_file_exchange_upload(...)` call and
+fleshing out `_upload_receiver` / `_validate_upload_target`. See
+[`docs/guides/file-exchange.md`](docs/guides/file-exchange.md) for the
+full pattern.
+
 ## Shared Infrastructure
 
 Shared infrastructure (auth providers, middleware stack, logging bootstrap, event store factory, CLI scaffolding, release pipeline, Docker entrypoint, nfpm packaging, mcpb bundle) lives upstream in two places:
 
-- [`fastmcp-pvl-core`](https://github.com/pvliesdonk/fastmcp-pvl-core) — the Python library that provides `ServerConfig`, auth builders, middleware helpers, artifact store, and the `make_serve_parser` / `configure_logging_from_env` / `normalise_http_path` CLI helpers.
-- [`fastmcp-server-template`](https://github.com/pvliesdonk/fastmcp-server-template) — the copier template this project was generated from. Ships the CI/release workflows, `Dockerfile`, `packaging/nfpm.yaml`, `packaging/mcpb/*`, `scripts/bump_manifests.py`, server.py skeleton, and this very section of CLAUDE.md.
+- [`fastmcp-pvl-core`](https://github.com/pvliesdonk/fastmcp-pvl-core) — the Python library that provides `ServerConfig`, auth builders, middleware helpers, MCP File Exchange (`register_file_exchange` + `register_file_exchange_upload`), and the `make_serve_parser` / `configure_logging_from_env` / `normalise_http_path` CLI helpers.
+- [`fastmcp-server-template`](https://github.com/pvliesdonk/fastmcp-server-template) — the copier template this project was generated from. Ships the CI/release workflows, `Dockerfile`, `packaging/nfpm.yaml`, `packaging/mcpb/*`, `scripts/bump_manifests.py`, server.py skeleton, `.gemini/config.yaml` (gemini-code-assist scope control), and this very section of CLAUDE.md.
 
 Fixes and improvements to shared code land in those repos and propagate here via `copier update` against the template's latest tag — run manually or via the weekly `.github/workflows/copier-update.yml` cron. Starter files listed in `_skip_if_exists` (e.g. `scripts/bump_manifests.py`, `packaging/mcpb/*`, the `tools.py` / `resources.py` / `prompts.py` / `domain.py` scaffolds, `README.md`, `CHANGELOG.md`, `LICENSE`, `.env.example`) are written once and require manual reconciliation on template updates — review `_skip_if_exists` in the template's `copier.yml` if you need to force-sync a file. Domain-specific code (tools, resources, prompts, and the fields and logic inside the `CONFIG-FIELDS-START` / `CONFIG-FIELDS-END` and `CONFIG-FROM-ENV-START` / `CONFIG-FROM-ENV-END` sentinels) stays in this repo.
 
@@ -132,7 +167,7 @@ Fixes and improvements to shared code land in those repos and propagate here via
 
 - **Library-level fix** (anything you'd change in `fastmcp_pvl_core`): open a PR on `pvliesdonk/fastmcp-pvl-core`. After merge + release, bump `fastmcp-pvl-core` in this project's `pyproject.toml`. (Copier update alone won't pick it up unless the template's version constraint in `pyproject.toml.jinja` is also bumped.)
 - **Template-level fix** (anything template-owned — `Dockerfile`, workflows, `server.py` skeleton, `CLAUDE.md` sections): open a PR on `pvliesdonk/fastmcp-server-template`. After merge + release, this project gets the fix on the next weekly `copier update` cron (or dispatch the workflow manually).
-- **Domain-only fix** (anything inside `DOMAIN-START`/`DOMAIN-END` sentinels, `tools.py`, `resources.py`, `prompts.py`, `domain.py`, `tests/`): PR on this repo directly.
+- **Domain-only fix** (anything inside a `DOMAIN-*`, `CONFIG-*`, or `PROJECT-*` sentinel block, `tools.py`, `resources.py`, `prompts.py`, `domain.py`, `tests/`): PR on this repo directly.
 
 If a conflict marker appears in a copier-update bot PR, the conflict itself often signals a template bug — investigate whether the template's version needs fixing before resolving locally.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,18 +12,38 @@ ENV UV_COMPILE_BYTECODE=1 \
 
 WORKDIR /app
 
+# Optional remote-debugger listener.  Default off so production images stay
+# lean; pass ``--build-arg DEBUG=true`` to install the ``[debug]`` extra
+# (debugpy) and bake the listener into the image.  Accepts the same boolean
+# vocabulary as runtime ``parse_bool`` (``true``/``1``/``yes``/``on``,
+# case-insensitive); anything else is treated as off.  See
+# ``docs/deployment/docker.md`` for the full attach workflow.
+ARG DEBUG=false
+
 # DOCKERFILE-UV-EXTRAS-START — append `--extra <name>` flags below to pull domain-specific extras; kept across copier update
-# Install dependencies first (cache layer).
+# Install dependencies first (cache layer).  The ``$( ... )`` shell
+# expansion appends ``--extra debug`` only when ``--build-arg DEBUG=true``;
+# default builds get the lean install.
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     --mount=type=bind,source=uv.lock,target=uv.lock \
+<<<<<<< before updating
     uv sync --frozen --no-install-project --no-dev --extra all
+=======
+    uv sync --frozen --no-install-project --no-dev \
+        $( case "$DEBUG" in [Tt][Rr][Uu][Ee]|1|[Yy][Ee][Ss]|[Oo][Nn]) echo "--extra debug" ;; esac )
+>>>>>>> after updating
 
 # Copy source and install project.
 COPY pyproject.toml uv.lock README.md /app/
 COPY src/ /app/src/
 RUN --mount=type=cache,target=/root/.cache/uv \
+<<<<<<< before updating
     uv sync --frozen --no-dev --extra all
+=======
+    uv sync --frozen --no-dev \
+        $( case "$DEBUG" in [Tt][Rr][Uu][Ee]|1|[Yy][Ee][Ss]|[Oo][Nn]) echo "--extra debug" ;; esac )
+>>>>>>> after updating
 # DOCKERFILE-UV-EXTRAS-END
 
 # Create non-root user with configurable UID/GID for bind-mount compatibility.
@@ -44,6 +64,12 @@ ENV PATH="/app/.venv/bin:$PATH" \
     FASTMCP_HOME=/data/state/fastmcp
 
 EXPOSE 8000
+# Remote debugger: ``EXPOSE`` is metadata — nothing actually listens unless
+# the image was built with ``--build-arg DEBUG=true`` (which installs
+# debugpy) AND ``SCHOLAR_MCP_DEBUG_PORT`` is set at runtime.  Always
+# declared so the toggled ``[debug]`` extra has a stable port surface
+# to reach with ``-p 127.0.0.1:5678:5678``.
+EXPOSE 5678
 
 # DOCKERFILE-VOLUMES-START — mounted volume list; kept across copier update
 VOLUME ["/data/service", "/data/state"]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <!-- mcp-name: io.github.pvliesdonk/scholar-mcp -->
 
-[![CI](https://github.com/pvliesdonk/scholar-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/pvliesdonk/scholar-mcp/actions/workflows/ci.yml) [![codecov](https://codecov.io/gh/pvliesdonk/scholar-mcp/graph/badge.svg)](https://codecov.io/gh/pvliesdonk/scholar-mcp) [![PyPI](https://img.shields.io/pypi/v/pvliesdonk-scholar-mcp)](https://pypi.org/project/pvliesdonk-scholar-mcp/) [![Python](https://img.shields.io/pypi/pyversions/pvliesdonk-scholar-mcp)](https://pypi.org/project/pvliesdonk-scholar-mcp/) [![License](https://img.shields.io/github/license/pvliesdonk/scholar-mcp)](LICENSE) [![Docker](https://img.shields.io/github/v/release/pvliesdonk/scholar-mcp?label=ghcr.io&logo=docker)](https://github.com/pvliesdonk/scholar-mcp/pkgs/container/scholar-mcp) [![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://pvliesdonk.github.io/scholar-mcp/) [![llms.txt](https://img.shields.io/badge/llms.txt-available-brightgreen)](https://pvliesdonk.github.io/scholar-mcp/llms.txt)
+[![CI](https://github.com/pvliesdonk/scholar-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/pvliesdonk/scholar-mcp/actions/workflows/ci.yml) [![codecov](https://codecov.io/gh/pvliesdonk/scholar-mcp/graph/badge.svg)](https://codecov.io/gh/pvliesdonk/scholar-mcp) [![PyPI](https://img.shields.io/pypi/v/pvliesdonk-scholar-mcp)](https://pypi.org/project/pvliesdonk-scholar-mcp/) [![Python](https://img.shields.io/pypi/pyversions/pvliesdonk-scholar-mcp)](https://pypi.org/project/pvliesdonk-scholar-mcp/) [![License](https://img.shields.io/github/license/pvliesdonk/scholar-mcp)](LICENSE) [![Docker](https://img.shields.io/github/v/release/pvliesdonk/scholar-mcp?label=ghcr.io&logo=docker)](https://github.com/pvliesdonk/scholar-mcp/pkgs/container/scholar-mcp) [![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://pvliesdonk.github.io/scholar-mcp/) [![llms.txt](https://img.shields.io/badge/llms.txt-available-brightgreen)](https://pvliesdonk.github.io/scholar-mcp/llms.txt) [![Template](https://img.shields.io/badge/dynamic/yaml?url=https://raw.githubusercontent.com/pvliesdonk/scholar-mcp/main/.copier-answers.yml&query=%24._commit&label=template)](https://github.com/pvliesdonk/fastmcp-server-template)
 
 A [FastMCP](https://github.com/jlowin/fastmcp) server for the scholarly citation landscape — **papers**, **patents**, **books**, and **standards** — giving LLMs a unified way to search, cross-reference, and retrieve prior art across all four source types via [Semantic Scholar](https://www.semanticscholar.org/), [EPO Open Patent Services](https://www.epo.org/en/searching-for-patents/data/web-services/ops), [Open Library](https://openlibrary.org/), and standards bodies (NIST, IETF, W3C, ETSI), with [OpenAlex](https://openalex.org/) enrichment and optional [docling-serve](https://github.com/DS4SD/docling-serve) PDF/full-text conversion.
 
@@ -81,7 +81,7 @@ Installing the bare `pvliesdonk-scholar-mcp` package is enough for library use (
 ```bash
 git clone https://github.com/pvliesdonk/scholar-mcp.git
 cd scholar-mcp
-uv sync --all-extras --dev
+uv sync --all-extras --all-groups
 ```
 
 ### Docker
@@ -91,6 +91,8 @@ docker pull ghcr.io/pvliesdonk/scholar-mcp:latest
 ```
 
 A `compose.yml` ships at the repo root as a starting point — copy `.env.example` to `.env`, edit, and `docker compose up -d`.
+
+To attach a remote Python debugger (development only — the protocol is unauthenticated), see [Remote debugging](docs/deployment/docker.md#remote-debugging).
 
 ### Linux packages (.deb / .rpm)
 
@@ -113,7 +115,25 @@ scholar-mcp serve                                # stdio transport
 scholar-mcp serve --transport http --port 8000   # streamable HTTP
 ```
 
+<<<<<<< before updating
 For library usage (embedding the domain logic without the MCP transport), import from the `scholar_mcp` package directly — backend clients live under `src/scholar_mcp/_s2_client.py`, `_epo_client.py`, `_openlibrary_client.py`, and `_standards_client.py`.
+=======
+For library usage (embedding the domain logic without the MCP transport), import from the `scholar_mcp` package directly — see the project's domain modules under `src/scholar_mcp/` for entry points.
+
+### Server info
+
+The server registers a built-in `get_server_info` tool (via `fastmcp_pvl_core.register_server_info_tool`) so operators can confirm the deployed version with a single MCP call. The default response carries `server_name`, `server_version`, and `core_version`. Servers that talk to a remote upstream wire upstream version reporting inside the `DOMAIN-UPSTREAM-START` / `DOMAIN-UPSTREAM-END` sentinel in `src/scholar_mcp/server.py` — see [`CLAUDE.md`](CLAUDE.md#server-info-tool-get_server_info) for the wiring pattern.
+
+### File exchange
+
+The server scaffolds [MCP File Exchange](docs/guides/file-exchange.md)
+wiring — download direction is registered by default (on for HTTP/SSE,
+off for stdio); an upload direction ships fully commented-out for
+opt-in via `register_file_exchange_upload(...)`. See the guide for
+producing / consuming / uploading patterns and the env-var matrix, or
+[`CLAUDE.md`](CLAUDE.md#file-exchange-register_file_exchange--opt-in-upload)
+for the wiring pattern.
+>>>>>>> after updating
 
 ## Configuration
 
@@ -127,6 +147,59 @@ Core environment variables shared across all `fastmcp-pvl-core`-based services:
 
 Domain-specific variables go below under [Domain configuration](#domain-configuration).
 
+<<<<<<< before updating
+=======
+## Authorization (opt-in)
+
+This server inherits opt-in per-subject authorization from `fastmcp-pvl-core`.  The default posture is **off** — every authenticated caller can use every tool, resource, and prompt.  Turn it on by pointing `SCHOLAR_MCP_ACL_PATH` at a TOML ACL file; the middleware is installed only when the path is set, and individual tools opt in by declaring `meta={"required_scope": "<scope>"}` at registration.  A tool without `required_scope` is unrestricted regardless of caller.
+
+Wire it in by uncommenting the `acl_path` field in `src/scholar_mcp/config.py` and the `AuthorizationMiddleware` stanza in `src/scholar_mcp/server.py` — both ship as commented stubs in the scaffold.
+
+### ACL TOML schema
+
+```toml
+[subjects]
+"user:alice@example.com" = ["read", "write"]
+"user:admin@example.com" = ["*"]              # wildcard — any required scope passes
+"service:ci-bot"         = ["read"]
+"local"                  = ["*"]              # stdio mode subject
+```
+
+- **Subject strings are opaque.** The `<kind>:<id>` convention is documentation only; the library treats each subject as a literal string.
+- **`*` is the only library-treated special scope** — it grants every required scope.  Subject-side wildcards (`*` as an ACL key) are rejected at load time.
+- **Scope vocabulary is domain-defined.** Per-project or per-folder gating is encoded into the scope string itself (e.g. `read:project-foo`, `write:vault/personal`); `fastmcp-pvl-core` treats every scope except `*` as opaque.
+
+### Subject ↔ bearer-token alignment
+
+The subject string used as a *value* in the bearer-tokens TOML (`SCHOLAR_MCP_BEARER_TOKENS_FILE`) is the same string used as a *key* in the ACL TOML.  Same string, opposite roles — keep the two files consistent when adding or removing a principal.  See [Mapped bearer tokens](docs/guides/authentication.md#mapped-bearer-tokens-multi-subject) in the authentication guide for the bearer-tokens TOML schema.
+
+In single-token mode (`SCHOLAR_MCP_BEARER_TOKEN`) every authenticated caller shares one subject — the library's default (currently `"bearer-anon"`), override with `SCHOLAR_MCP_BEARER_DEFAULT_SUBJECT`; reference *that* string as the ACL key.  In stdio mode the subject is the literal `"local"`.
+
+### Load semantics
+
+The ACL file is loaded **once at server startup**.  Restart the server to pick up changes; live reload is not part of the initial implementation.  `load_acl` fails fast with `ConfigurationError` on every malformed condition, so a typo in the ACL file aborts startup rather than silently denying requests.
+
+### Privacy default
+
+Denied requests are logged at WARNING with the subject string for audit attribution.  The wire-side error payload **omits** the subject by default to limit cross-user information disclosure.  For internal-only servers where the subject is safe to surface to clients, construct the middleware with `AuthorizationMiddleware(..., expose_subject_in_error=True)`.
+
+### See also
+
+- [fastmcp-pvl-core README — Authorization](https://github.com/pvliesdonk/fastmcp-pvl-core#authorization-opt-in--authorizationmiddleware) — full design, the `check_authorization` per-call helper, and per-token subject mapping.
+- [Authorization submodule spec](https://github.com/pvliesdonk/fastmcp-pvl-core/blob/main/docs/specs/authorization-submodule.md) — design rationale and deviations table.
+
+## Post-scaffold checklist
+
+After `copier copy` and `gh repo create --push`:
+
+1. **Fill in the DOMAIN blocks** in this README (Features, What you can do with it, Domain configuration, Key design decisions) and in `CLAUDE.md`.
+2. Configure GitHub secrets — see below.
+3. Install dev + docs tooling: `uv sync --all-extras --all-groups`.
+4. Install pre-commit hooks: `uv run pre-commit install`.
+5. Run the gate locally: `uv run pytest -x -q && uv run ruff check --fix . && uv run ruff format . && uv run mypy src/ tests/`.
+6. Push the first commit — CI should be green.
+
+>>>>>>> after updating
 ## GitHub secrets
 
 CI workflows reference three repository secrets. Configure them via **Settings → Secrets and variables → Actions** or with `gh secret set`:
@@ -167,7 +240,7 @@ Pre-commit runs a subset of the gate on each commit; see `.pre-commit-config.yam
 
 ```bash
 rm -rf .venv
-uv sync --all-extras --dev
+uv sync --all-extras --all-groups
 ```
 
 `uv run python -m pytest` also works as a one-shot workaround (bypasses the stale entry-script shim).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,6 +13,7 @@ All settings are controlled via environment variables with the `SCHOLAR_MCP_` pr
 | `FASTMCP_LOG_LEVEL` | `INFO` | Logging level: `DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL`. Controls all output (application and middleware). The `-v` CLI flag sets this to `DEBUG`. |
 | `FASTMCP_ENABLE_RICH_LOGGING` | `true` | Set to `false` for plain/JSON-structured output suitable for log aggregation tools (Loki, Datadog, Splunk). When `true`, output uses Rich formatting (colors, timestamps). |
 
+<<<<<<< before updating
 ## PDF Conversion
 
 These settings are only needed if you want to use the PDF conversion tools. They require a running [docling-serve](https://github.com/DS4SD/docling-serve) instance.
@@ -157,3 +158,43 @@ Rate limiting is automatic and not configurable:
 - **With API key**: ~0.1s between Semantic Scholar requests
 - **Without API key**: ~1.1s between requests
 - **Retry**: automatic exponential backoff on HTTP 429 (up to 3 retries)
+=======
+## MCP File Exchange
+
+These variables control [MCP File Exchange](guides/file-exchange.md)
+participation — pass-by-reference file transfer between co-deployed
+servers (and HTTP fallback for remote clients). All are optional; the
+defaults are sensible for both stdio and HTTP deployments.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SCHOLAR_MCP_FILE_EXCHANGE_ENABLED` | `true` on HTTP/SSE, `false` on stdio | Master switch. Set `false` to opt out entirely. |
+| `SCHOLAR_MCP_FILE_EXCHANGE_PRODUCE` | `true` | Allow this server to mint `FileRef` objects via `handle.publish(...)`. |
+| `SCHOLAR_MCP_FILE_EXCHANGE_CONSUME` | `true` | Master toggle for the consumer side. **Only effective when `consumer_sink=` is wired in `server.py`** — without that argument, `fetch_file` is never registered no matter how this var is set. See [the guide](guides/file-exchange.md#consuming-files-consumer_sink). |
+| `SCHOLAR_MCP_FILE_EXCHANGE_TTL` | `3600` | Lifetime in seconds for download links and exchange-volume records. |
+| `SCHOLAR_MCP_UPLOAD_ENABLED` | `true` on HTTP/SSE, `false` on stdio | Master switch for the upload direction. **Only effective when `register_file_exchange_upload(...)` is uncommented in `server.py`** — without that call, no upload route is mounted regardless of this var. Also requires `SCHOLAR_MCP_BASE_URL` to be set so `create_upload_link` can mint usable URLs. See [the guide](guides/file-exchange.md#uploading-files-receiver). |
+| `SCHOLAR_MCP_UPLOAD_MAX_BYTES` | `10485760` (10 MiB) | Maximum POST body size for the upload route. Bodies exceeding this return HTTP 413. |
+| `SCHOLAR_MCP_UPLOAD_TTL` | `300` | Default lifetime in seconds for upload links. Caller-requested TTL is clamped to `SCHOLAR_MCP_UPLOAD_TTL_MAX`. |
+| `SCHOLAR_MCP_UPLOAD_TTL_MAX` | `3600` | Operator ceiling for caller-requested upload-link TTL. |
+| `SCHOLAR_MCP_BASE_URL` | unset | Public base URL of this server. Required for the `http` transfer method — the `create_download_link` tool and (when upload is wired) the `create_upload_link` tool both build URLs against it. Also referenced by the OIDC guide and the universal-variables list above — set it once and every consumer picks it up. |
+
+Note the upload-direction variables are namespaced under `_UPLOAD_*`,
+not `_FILE_EXCHANGE_UPLOAD_*` — this matches the upstream
+`fastmcp-pvl-core` 2.1.0 contract. The download-direction variables
+keep the historical `_FILE_EXCHANGE_*` namespace.
+
+The deployer also controls three **unprefixed** environment variables
+shared by every co-deployed server:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MCP_EXCHANGE_DIR` | unset | Path to a directory shared between co-deployed MCP servers. When set, the `exchange://` transfer method activates; when unset, only the HTTP method is available. |
+| `MCP_EXCHANGE_ID` | persisted in `.exchange-id` | Optional explicit exchange-group identifier; first server to start writes a UUID into `${MCP_EXCHANGE_DIR}/.exchange-id`, subsequent starts must agree. |
+| `MCP_EXCHANGE_NAMESPACE` | the server's `namespace=` argument | Override the namespace used in `exchange://` URIs for this process. |
+
+<!-- DOMAIN-CONFIG-VARS-START -->
+## Domain variables
+
+Document your project-specific variables here.
+<!-- DOMAIN-CONFIG-VARS-END -->
+>>>>>>> after updating

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -89,6 +89,7 @@ networks:
 See [Configuration](../configuration.md) for the full reference. Key variables for Docker:
 
 | Variable | Default | Description |
+<<<<<<< before updating
 |---|---|---|
 | `SCHOLAR_MCP_S2_API_KEY` | -- | Semantic Scholar API key (optional; ~1 req/s without, ~10 req/s with) |
 | `SCHOLAR_MCP_CACHE_DIR` | `/data/scholar-mcp` | Cache and PDF storage directory |
@@ -97,6 +98,15 @@ See [Configuration](../configuration.md) for the full reference. Key variables f
 | `SCHOLAR_MCP_BEARER_TOKEN` | -- | Bearer token for HTTP auth |
 | `FASTMCP_LOG_LEVEL` | `INFO` | Logging level (use `-v` or set to `DEBUG` for verbose output) |
 | `FASTMCP_ENABLE_RICH_LOGGING` | `true` | Set `false` for structured JSON logging with aggregators |
+=======
+|----------|---------|-------------|
+| `SCHOLAR_MCP_READ_ONLY` | `true` | Disable write tools |
+| `SCHOLAR_MCP_BEARER_TOKEN` | — | Enable bearer token auth |
+| `SCHOLAR_MCP_LOG_LEVEL` | `INFO` | Log level |
+| `SCHOLAR_MCP_INSTRUCTIONS` | (dynamic) | System instructions for LLM context |
+| `SCHOLAR_MCP_DEBUG_PORT` | — | Remote-debugger TCP port (see [Remote debugging](#remote-debugging); requires `--build-arg DEBUG=true` image) |
+| `SCHOLAR_MCP_DEBUG_WAIT` | `false` | Block startup until IDE attaches (see [Remote debugging](#remote-debugging)) |
+>>>>>>> after updating
 
 For OIDC authentication, see [OIDC deployment](oidc.md).
 
@@ -116,6 +126,7 @@ volumes:
 
 ## UID/GID
 
+<<<<<<< before updating
 The image runs as a non-root user with UID/GID 1000 by default. To match your host user for bind mounts, set build args:
 
 ```yaml
@@ -138,3 +149,65 @@ services:
 | `v1` | Latest minor in 1.x |
 
 Multi-arch: `linux/amd64` and `linux/arm64`.
+=======
+Set `PUID` and `PGID` in your `.env` file to match the owner of bind-mounted
+directories (default 1000/1000).
+
+## Remote debugging
+
+Production images ship without `debugpy` to keep the image lean.  To attach a remote Python debugger from VS Code or PyCharm:
+
+1. **Build with the debug extra:**
+
+    ```bash
+    docker build --build-arg DEBUG=true -t scholar-mcp:debug .
+    ```
+
+    This installs the `[debug]` optional-dependency group (which pulls `debugpy` transitively from `fastmcp-pvl-core`).  Default builds (`DEBUG=false`) skip it.
+
+2. **Run with the debug env vars set and the port mapped:**
+
+    ```bash
+    docker run --rm \
+      -e SCHOLAR_MCP_DEBUG_PORT=5678 \
+      -e SCHOLAR_MCP_DEBUG_WAIT=true \
+      -p 127.0.0.1:5678:5678 \
+      -p 8000:8000 \
+      scholar-mcp:debug
+    ```
+
+    | Env var | Effect |
+    |---------|--------|
+    | `SCHOLAR_MCP_DEBUG_PORT` | TCP port the debugger listens on (any value parsing to ``0`` disables; non-numeric or out-of-range values log a WARNING and the listener stays off) |
+    | `SCHOLAR_MCP_DEBUG_WAIT` | When truthy (``1``/``true``/``yes``/``on``), block startup until the IDE attaches.  Default is non-blocking. |
+
+3. **Attach from VS Code** — add a launch config:
+
+    ```json
+    {
+      "name": "Attach to scholar-mcp",
+      "type": "debugpy",
+      "request": "attach",
+      "connect": { "host": "localhost", "port": 5678 }
+    }
+    ```
+
+    PyCharm uses *Run → Edit Configurations → Python Debug Server* with the same host/port.
+
+!!! danger "Never publish the debug port on a public network"
+    The debug listener binds `0.0.0.0` inside the container so the IDE can reach it from the host, but **debugpy's DAP protocol is unauthenticated** — any peer that can reach the port has arbitrary code execution as the server process.  Always bind the port mapping to localhost (`-p 127.0.0.1:5678:5678`) or tunnel via `kubectl port-forward` / SSH.  Production images should be built with default `DEBUG=false`.
+
+When the helper is invoked but `debugpy` isn't installed (e.g. someone sets `DEBUG_PORT` on a non-debug image), it logs a WARNING and continues — safe failure mode.
+
+
+<!-- DOMAIN-DOCKER-EXTRA-START -->
+<!-- Project-specific notes for Docker deployment; kept across copier update. -->
+
+## Project-specific notes
+
+<!-- Add domain-specific caveats here (e.g. "the /data/uploads volume must
+     be writable by UID Y", "container needs cap_add: SYS_PTRACE for
+     debugging tools"). Use sub-headings to organize if needed. -->
+
+<!-- DOMAIN-DOCKER-EXTRA-END -->
+>>>>>>> after updating

--- a/docs/deployment/oidc.md
+++ b/docs/deployment/oidc.md
@@ -200,3 +200,15 @@ labels:
 
 - **Dedicated hostname** (preferred): give the MCP server its own hostname (e.g., `myservice.example.com`) so discovery routes do not collide.
 - **External auth gateway**: use `mcp-auth-proxy` as a sidecar instead of native OIDC. The MCP server runs unauthenticated behind the proxy, and the proxy handles OAuth discovery at its own routes.
+
+
+<!-- DOMAIN-OIDC-EXTRA-START -->
+<!-- Project-specific notes for OIDC deployment; kept across copier update. -->
+
+## Project-specific notes
+
+<!-- Add domain-specific caveats here (e.g. "Keycloak requires X claim",
+     "Authelia token-cache quirk for /admin paths", "this server's audience
+     claim must include 'mcp'"). Use sub-headings to organize if needed. -->
+
+<!-- DOMAIN-OIDC-EXTRA-END -->

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -62,6 +62,21 @@ Authorization: Bearer your-generated-token
 - Development and testing environments
 - Any scenario where full OIDC is overkill
 
+### Mapped bearer tokens (multi-subject)
+
+The bearer-token mode above shares one subject across every authenticated caller — by default the library's `bearer-anon`, override with `SCHOLAR_MCP_BEARER_DEFAULT_SUBJECT`.  For audit logs and authorization that distinguish callers, switch to mapped-token mode by pointing `SCHOLAR_MCP_BEARER_TOKENS_FILE` at a TOML file:
+
+```toml
+# tokens.toml
+[tokens]
+"ghp_alice_xxxxxxxx" = "user:alice@example.com"
+"sk_ci_yyyyyyyy"     = "service:ci-bot"
+```
+
+Each token resolves to a distinct subject string for downstream attribution.  Subject strings are opaque — the `<kind>:<id>` convention (`user:`, `service:`, `token:`) is documentation only.  When `BEARER_TOKENS_FILE` is set it overrides `BEARER_TOKEN` (a `WARNING` is logged if both are present).  A missing or malformed file aborts startup with `ConfigurationError` rather than silently denying every request.
+
+For the per-tool authorization that consumes these subjects, see [Authorization (opt-in)](https://github.com/pvliesdonk/scholar-mcp/blob/main/README.md#authorization-opt-in) in the project README.
+
 ---
 
 ## Remote auth
@@ -254,3 +269,16 @@ These upstream issues are actively tracked:
 - [modelcontextprotocol/python-sdk#1326](https://github.com/modelcontextprotocol/python-sdk/issues/1326) — SSE refresh deadlock
 
 When these are resolved, OIDC sessions should persist indefinitely via automatic token refresh with no changes needed server-side.
+
+
+<!-- DOMAIN-AUTH-EXTRA-START -->
+<!-- Project-specific notes for authentication; kept across copier update. -->
+
+## Project-specific notes
+
+<!-- Add domain-specific caveats here (e.g. "paperless-mcp tokens expire
+     every 60 min", "this server requires the 'admin' scope for write tools",
+     "bearer-token middleware skips /health for liveness probes"). Use
+     sub-headings to organize if needed. -->
+
+<!-- DOMAIN-AUTH-EXTRA-END -->

--- a/docs/guides/file-exchange.md
+++ b/docs/guides/file-exchange.md
@@ -1,0 +1,288 @@
+# MCP File Exchange
+
+Scholar MCP participates in the **MCP File Exchange** convention
+— a lightweight, spec-defined way for co-deployed MCP servers to pass
+files to each other by reference instead of by base64-in-context.
+
+The full specification lives in `fastmcp-pvl-core`'s docs:
+[`docs/specs/file-exchange.md`](https://github.com/pvliesdonk/fastmcp-pvl-core/blob/main/docs/specs/file-exchange.md).
+This page is the project-side guide: **what's wired by default, which
+env vars to set, and how to publish, consume, or accept agent-uploaded
+`FileRef` objects from your tool bodies.**
+
+## What's wired by default
+
+`make_server()` calls `register_file_exchange()` once during startup.
+That single call:
+
+1. Mounts an `/artifacts/{token}` HTTP route (HTTP transport only).
+2. Advertises the `experimental.file_exchange` capability on the MCP
+   `initialize` response.
+3. Registers two MCP tools when the surrounding env permits:
+    - `create_download_link` — producer-side; mints time-limited HTTP
+      URLs for `FileRef`s this server has published.
+    - `fetch_file` — consumer-side; resolves a `FileRef` (via
+      `exchange://` or `https://`) and hands the bytes to your sink.
+
+By default the feature is **on** for HTTP/SSE deployments and **off**
+for stdio. See [Configuration → MCP File Exchange](../configuration.md#mcp-file-exchange)
+for the env-var matrix.
+
+The **upload direction** is opt-in and not wired by default — see
+[Uploading files](#uploading-files-receiver) below for the
+`register_file_exchange_upload(...)` pattern.
+
+## The two patterns
+
+### Augmented response (recommended)
+
+The tool returns its normal output plus a `file_ref` field. Existing
+clients ignore the field and keep working; file-exchange-aware
+clients can use it.
+
+```python
+from fastmcp_pvl_core import FileRefPreview
+
+result = await handle.publish(
+    source=image_bytes,
+    mime_type="image/png",
+    preview=FileRefPreview(description=prompt, dimensions=(width, height)),
+)
+return {
+    "image_id": image_id,
+    "prompt": prompt,
+    "dimensions": {"width": width, "height": height},
+    "file_ref": result.to_dict(),
+}
+```
+
+### Reference-only
+
+The tool returns just the `FileRef` — appropriate when the file is
+large and you do not want to spend tokens on inline data:
+
+```python
+file_ref = await handle.publish(source=pdf_path, mime_type="application/pdf")
+return file_ref.to_dict()
+```
+
+## Producing files (`handle.publish`)
+
+`register_file_exchange` returns a `FileExchangeHandle`. Capture it
+in `make_server()` and stash it where your tool bodies can reach it.
+The simplest pattern is a module-level singleton in `server.py` —
+this stays well-typed under `mypy --strict` (the alternative,
+attaching to the `FastMCP` instance, fails `attr-defined` because
+`FastMCP` does not declare a `file_exchange` field):
+
+```python
+# server.py
+from fastmcp_pvl_core import FileExchangeHandle, register_file_exchange
+
+_file_exchange: FileExchangeHandle | None = None
+
+
+def get_file_exchange() -> FileExchangeHandle:
+    """Return the registered handle. Raises if make_server has not run."""
+    if _file_exchange is None:
+        raise RuntimeError("file exchange is not initialised — call make_server first")
+    return _file_exchange
+
+
+def make_server(*, transport: str = "stdio", ...) -> FastMCP:
+    global _file_exchange
+    ...
+    _file_exchange = register_file_exchange(
+        mcp,
+        namespace="scholar-mcp",
+        env_prefix=_ENV_PREFIX,
+        transport="auto",
+        produces=("image/png", "image/webp"),
+    )
+    return mcp
+```
+
+Then in a tool body:
+
+```python
+from fastmcp_pvl_core import FileRefPreview
+
+from scholar_mcp.server import get_file_exchange
+
+
+@mcp.tool
+async def render(prompt: str) -> dict[str, Any]:
+    image_bytes = await _render(prompt)
+    file_ref = await get_file_exchange().publish(
+        source=image_bytes,
+        mime_type="image/png",
+        preview=FileRefPreview(description=prompt),
+    )
+    return {"prompt": prompt, "file_ref": file_ref.to_dict()}
+```
+
+`publish()` returns a `FileRef`. Call `.to_dict()` (or let your
+return type adapter serialise it) before sending it back through MCP.
+
+## Consuming files (`consumer_sink`)
+
+Pass a `consumer_sink` to enable the `fetch_file` tool. The sink
+receives the resolved bytes and a `FetchContext`, and returns a
+`FetchResult`:
+
+```python
+from fastmcp_pvl_core import FetchContext, FetchResult
+
+async def _store_in_vault(data: bytes, ctx: FetchContext) -> FetchResult:
+    path = await _vault.write(data, mime_type=ctx.mime_type, name=ctx.suggested_filename)
+    return FetchResult(stored_at=str(path), bytes_written=len(data))
+
+# Consume-only servers do not need to capture the handle — the facade
+# wires `fetch_file` itself; the handle is only required to call
+# `.publish()` from a tool body (see "Producing files" above).
+register_file_exchange(
+    mcp,
+    namespace="scholar-mcp",
+    env_prefix=_ENV_PREFIX,
+    transport="auto",
+    consumes=("image/*", "application/pdf"),
+    consumer_sink=_store_in_vault,
+)
+```
+
+`consumes=` is advertised in the capability declaration; the LLM and
+peer servers use it to pick a destination for `fetch_file` calls.
+
+## Uploading files (`receiver=`)
+
+The download direction is producer-driven: this server `publish()`es
+a file, and a peer (or LLM tool) fetches it. The **upload direction**
+is the inverse — an agent or peer pushes bytes into this server, and
+a **receiver** in your code commits them.
+
+Wire it by uncommenting the `register_file_exchange_upload(...)`
+block in `src/scholar_mcp/server.py` (inside the
+`DOMAIN-FILE-EXCHANGE-START / END` sentinel) and supplying a
+`receiver`:
+
+```python
+from typing import Any
+
+from fastmcp_pvl_core import UploadRecord, register_file_exchange_upload
+
+
+# _vault is illustrative — replace with your domain's storage helper.
+def _upload_receiver(record: UploadRecord, body: bytes) -> dict[str, Any]:
+    # record.target_id, record.extra, record.max_bytes available.
+    path = _vault.write(record.target_id, body)
+    return {"path": str(path), "size_bytes": len(body)}
+
+register_file_exchange_upload(
+    mcp,
+    namespace="scholar-mcp",
+    env_prefix=_ENV_PREFIX,
+    receiver=_upload_receiver,
+)
+```
+
+Once registered, an LLM-visible `create_upload_link` tool appears.
+The agent calls it with a `target_id` (and optional `extra`,
+`ttl_seconds`, `max_bytes`); the helper mints a one-time HTTPS
+`POST /<namespace>/uploads/{token}` URL and returns it. The agent
+POSTs the bytes; the route hands them to your receiver.
+
+### Pre-link validation
+
+To reject bad `target_id`s **before** the token is minted — so an LLM
+sees a clean tool error rather than wastes a round-trip — supply
+`pre_link_validator`:
+
+```python
+def _validate_upload_target(target_id: str, extra: dict[str, Any] | None) -> None:
+    if not target_id.startswith("inbox/"):
+        raise ValueError(f"target_id must begin with 'inbox/': {target_id}")
+
+register_file_exchange_upload(
+    mcp,
+    namespace="scholar-mcp",
+    env_prefix=_ENV_PREFIX,
+    receiver=_upload_receiver,
+    pre_link_validator=_validate_upload_target,
+)
+```
+
+Raising `ValueError` surfaces the message verbatim to the caller.
+Other exceptions also propagate but are logged at ERROR with a
+`non-ValueError` marker so operators distinguish bugs from
+caller-input errors. Sync validators run in `asyncio.to_thread`
+automatically; `async def` validators run on the loop.
+
+### Receiver error contract
+
+The receiver runs **after** route-level checks pass. Oversized bodies
+(over `UPLOAD_MAX_BYTES`) return `413` and expired or already-consumed
+tokens return `404` before the receiver is invoked. Once the receiver
+runs, exceptions translate to status codes as follows:
+
+| Exception | Response | When to use |
+|-----------|----------|-------------|
+| `ValueError` | `400` Bad Request | Request body fails domain validation. |
+| `FileExistsError` | `409` Conflict | `target_id` collides with existing data. |
+| Anything else | `500` Internal Server Error | Server-side bug. Traceback is logged. |
+
+For `400` and `409`, the exception's `str(exc)` becomes the response
+body — frame those messages as caller-facing diagnostics. The `500`
+path returns a generic body and logs the traceback server-side. A
+returned `dict[str, Any]` produces `200` and is JSON-encoded into the
+response; non-dict returns are treated as receiver bugs (`500` with a
+WARNING log). Sync receivers run in `asyncio.to_thread` (blocking I/O
+does not stall the loop); `async def` receivers run on the loop.
+
+Tokens are **one-time** — every non-2xx response burns the link;
+retries call `create_upload_link` again. For uploads too large to
+buffer, use `stream_receiver=` (`AsyncIterator[bytes]` shape; **`async
+def` only** — sync stream receivers cannot iterate the body).
+Documented in the upstream `fastmcp-pvl-core` README — the template
+scaffolds the buffered shape only.
+
+See [Configuration → MCP File Exchange](../configuration.md#mcp-file-exchange)
+for the env-var matrix.
+
+## Co-deploying two servers (docker-compose)
+
+The `exchange://` transfer method requires both servers to share a
+volume mounted at `MCP_EXCHANGE_DIR`. Example:
+
+```yaml
+services:
+  image-mcp:
+    image: ghcr.io/example/image-mcp:latest
+    environment:
+      IMAGE_MCP_TRANSPORT: http
+      IMAGE_MCP_BASE_URL: https://mcp.example.com/image
+      MCP_EXCHANGE_DIR: /var/lib/mcp-exchange
+    volumes:
+      - mcp-exchange:/var/lib/mcp-exchange
+
+  vault-mcp:
+    image: ghcr.io/example/vault-mcp:latest
+    environment:
+      VAULT_MCP_TRANSPORT: http
+      VAULT_MCP_BASE_URL: https://mcp.example.com/vault
+      MCP_EXCHANGE_DIR: /var/lib/mcp-exchange
+    volumes:
+      - mcp-exchange:/var/lib/mcp-exchange
+
+volumes:
+  mcp-exchange:
+```
+
+Both containers see the same `.exchange-id` file, so they agree on
+the exchange group automatically. When `image-mcp` publishes a file,
+`vault-mcp` can fetch it via the `exchange://` URI without an HTTP
+round-trip — the bytes never leave the shared volume.
+
+When the servers are deployed apart (no shared volume), the spec's
+`http` transfer method handles it: peers call `create_download_link`
+on the producer, get a time-limited HTTPS URL, and pull the bytes
+across the network.

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,7 @@ A [FastMCP](https://github.com/jlowin/fastmcp) server for the scholarly citation
 
 ## What it does
 
+<<<<<<< before updating
 Scholar MCP exposes 27 tools that let LLM-powered applications search, cross-reference, and retrieve scholarly sources across four peer domains:
 
 - **Papers** -- full-text search (year, venue, field, citation filters); single-paper lookup by DOI / S2 ID / arXiv / ACM / PubMed; author profile and name search; forward citations, backward references, BFS citation graph, shortest-path bridge discovery; recommendations from positive/negative examples; BibTeX/CSL-JSON/RIS citation generation; OpenAlex enrichment (affiliations, funders, OA status, and concepts).
@@ -92,3 +93,20 @@ See [Installation](installation.md) for all methods including Linux packages.
 - [Claude Code plugin](guides/claude-code-plugin.md) -- install as a Claude Code plugin
 - [Claude Desktop setup](guides/claude-desktop.md) -- get started with Claude Desktop
 - [Docker deployment](deployment/docker.md) -- production Docker Compose setup
+=======
+- [Installation](installation.md)
+- [Configuration](configuration.md)
+- [Tools](tools/index.md)
+
+<!-- DOMAIN-INDEX-FEATURES-START -->
+## Features
+
+- _Add features specific to your server here._
+<!-- DOMAIN-INDEX-FEATURES-END -->
+
+<!-- DOMAIN-INDEX-USE-CASES-START -->
+## What you can do
+
+- _Add usage examples here._
+<!-- DOMAIN-INDEX-USE-CASES-END -->
+>>>>>>> after updating

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -78,6 +78,19 @@ See [systemd deployment](deployment/systemd.md) for configuration details.
 ```bash
 git clone https://github.com/pvliesdonk/scholar-mcp.git
 cd scholar-mcp
+<<<<<<< before updating
 uv sync --extra dev --extra mcp
 uv run scholar-mcp serve
+=======
+uv sync --all-extras --all-groups
+>>>>>>> after updating
 ```
+
+<!-- DOMAIN-INSTALL-EXTRA-START -->
+
+## Project-specific notes
+
+_Add domain-specific install notes here, e.g. system dependencies, optional
+extras, or custom configuration steps._
+
+<!-- DOMAIN-INSTALL-EXTRA-END -->

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -4,12 +4,15 @@ MCP prompts are reusable prompt templates exposed to clients. The scaffold
 ships a minimal set defined in `src/scholar_mcp/_server_prompts.py`; add
 domain-specific prompts there and document them in this page.
 
+<<<<<<< before updating
 ## Built-in prompts
 
 _None in the scaffold._ Define prompts with `@mcp.prompt(...)` decorators in
 `src/scholar_mcp/_server_prompts.py` and list them here with their arguments,
 usage, and example output.
 
+=======
+>>>>>>> after updating
 ## Example
 
 ```python
@@ -21,3 +24,11 @@ def summarize(topic: str) -> str:
 
 See the [FastMCP prompts documentation](https://gofastmcp.com/servers/prompts)
 for the full prompt API.
+
+<!-- DOMAIN-PROMPTS-LIST-START -->
+## Built-in prompts
+
+_None in the scaffold._ Define prompts with `@mcp.prompt(...)` decorators in
+`src/scholar_mcp/prompts.py` and list them here with their arguments,
+usage, and example output.
+<!-- DOMAIN-PROMPTS-LIST-END -->

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -1,5 +1,6 @@
 # Tools
 
+<<<<<<< before updating
 Scholar MCP provides 28 tools organised by scholarly source type: **Papers**, **Patents**, **Books**, and **Standards** are peer source domains; the remaining sections (Cross-source Utility, PDF Conversion, Task Polling) are cross-cutting. All tools return JSON.
 
 !!! info "Coverage by domain"
@@ -752,3 +753,16 @@ The `hint` field gives expected duration — keep polling until the task complet
 List all active (non-expired) background tasks.
 
 **Returns:** JSON list of `{"task_id": "...", "status": "..."}` dicts.
+=======
+The tools registered in this server are listed below. See the
+[FastMCP tools documentation](https://gofastmcp.com/servers/tools)
+for the full tool API.
+
+<!-- DOMAIN-TOOLS-LIST-START -->
+## ping
+
+Health-check tool — returns `"pong"` if the service is alive.
+Replace with real tools per the scaffold in
+`src/scholar_mcp/tools.py`.
+<!-- DOMAIN-TOOLS-LIST-END -->
+>>>>>>> after updating

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ theme:
 
 plugins:
   - search
+<<<<<<< before updating
   - llmstxt:
       full_output: llms-full.txt
       markdown_description: >
@@ -60,6 +61,30 @@ plugins:
           - deployment/docker.md: Docker Compose with docling-serve, Traefik, volumes, UID/GID
           - deployment/systemd.md: systemd service — package install, security hardening
           - deployment/oidc.md: OIDC authentication setup with Authelia
+=======
+  # Generates llms.txt + llms-full.txt for the README badge.
+  # Sections mirror `nav:` below — keep them aligned when customising
+  # (both blocks are sentinel-protected so customise both as a unit).
+  # `guides/*.md` and `deployment/*.md` use globs deliberately so new pages
+  # in those directories are auto-indexed without a sections-list update.
+  - llmstxt:
+      full_output: llms-full.txt
+      sections:
+        # PROJECT-LLMSTXT-SECTIONS-START — keep aligned with `nav:` below;
+        # kept across copier update.
+        Getting Started:
+          - index.md
+          - installation.md
+          - configuration.md
+        Guides:
+          - guides/*.md
+        MCP Interface:
+          - tools/index.md
+          - prompts.md
+        Deployment:
+          - deployment/*.md
+        # PROJECT-LLMSTXT-SECTIONS-END
+>>>>>>> after updating
   - mkdocstrings:
       handlers:
         python:
@@ -98,6 +123,9 @@ exclude_docs: |
   design.md
 
 nav:
+  # PROJECT-NAV-START — replace with your real navigation; kept across copier
+  # update. Keep aligned with the `llmstxt` plugin's sentinel-protected
+  # `sections:` block above.
   - Home: index.md
   - Installation: installation.md
   - Configuration: configuration.md
@@ -108,9 +136,17 @@ nav:
       - Claude Code Plugin: guides/claude-code-plugin.md
       - Claude Desktop: guides/claude-desktop.md
       - Authentication: guides/authentication.md
+<<<<<<< before updating
       - PDF Conversion: guides/pdf-conversion.md
       - Citation Graphs: guides/citation-graphs.md
+=======
+      - File Exchange: guides/file-exchange.md
+  - MCP Interface:
+      - Tools: tools/index.md
+      - Prompts: prompts.md
+>>>>>>> after updating
   - Deployment:
       - Docker: deployment/docker.md
       - systemd: deployment/systemd.md
       - OIDC Authentication: deployment/oidc.md
+  # PROJECT-NAV-END

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,9 +17,13 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
 ]
 dependencies = [
+<<<<<<< before updating
     # fastmcp + httpx + uvicorn come transitively via fastmcp-pvl-core;
     # only list deps scholar uses DIRECTLY here.
     "fastmcp-pvl-core>=1.0,<2",
+=======
+    "fastmcp-pvl-core>=2.1.0,<3",
+>>>>>>> after updating
     "typer>=0.12",
     # PROJECT-DEPS-START — domain dependencies; kept across copier update
     "httpx",
@@ -31,10 +35,23 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+<<<<<<< before updating
 # PROJECT-EXTRAS-START — domain optional-dependency groups; kept across copier update
 mcp = ["fastmcp[tasks]>=3.2.0,<4"]
 all = ["fastmcp[tasks]>=3.2.0,<4"]
 # PROJECT-EXTRAS-END
+=======
+# PROJECT-EXTRAS-START — add domain-specific optional-dependency groups below; kept across copier update
+# Pulls debugpy transitively via fastmcp-pvl-core's [debug] extra.  The
+# version range is inherited from the [project] dependency on
+# fastmcp-pvl-core above; pip resolves a single, consistent version.
+debug = ["fastmcp-pvl-core[debug]"]
+# PROJECT-EXTRAS-END
+
+# Tooling lives under PEP 735 [dependency-groups] (not [project.optional-dependencies])
+# so it never ships to PyPI consumers and never lands in the security-audit input.
+[dependency-groups]
+>>>>>>> after updating
 dev = [
     "pytest>=7.0",
     "pytest-asyncio>=0.21",
@@ -49,6 +66,12 @@ docs = [
     "mkdocs-material>=9.5",
     "mkdocstrings[python]>=0.24",
     "mkdocs-llmstxt>=0.2",
+]
+
+docs = [
+    "mkdocs-material>=9.7.6",
+    "mkdocstrings[python]>=0.28",
+    "mkdocs-llmstxt>=0.5",
 ]
 
 [project.scripts]
@@ -82,6 +105,7 @@ ignore = ["E501"]
 # FastMCP dependency injection pattern — B008 is a false positive here.
 # Context/FastMCP/Service imports must stay runtime (not TYPE_CHECKING) for
 # DI resolution — TC001/TC002/TC003.
+<<<<<<< before updating
 "src/scholar_mcp/server.py" = ["ARG001", "B008", "TC002"]
 "src/scholar_mcp/cli.py" = ["B008", "TC002", "TC003"]
 "src/scholar_mcp/_server_apps.py" = ["TC002"]
@@ -110,6 +134,22 @@ ignore = ["E501"]
 "src/scholar_mcp/_server_prompts.py" = ["B008", "TC002"]
 # pytest fixtures need runtime imports; Path used in signatures needs to be importable at runtime.
 "tests/*.py" = ["ARG001", "ARG002", "TC001", "TC002", "TC003"]
+=======
+# PROJECT-RUFF-IGNORES-START — replace, extend, or override the entries below
+# for your project's real source/test paths (split _server_apps.py into
+# per-domain modules, rename tests, add per-file overrides as needed); kept
+# across copier update.
+"src/scholar_mcp/cli.py" = ["B008"]
+"src/scholar_mcp/_server_deps.py" = ["B008", "TC002", "TC003"]
+"src/scholar_mcp/_server_apps.py" = ["B008", "TC001", "TC002"]
+"src/scholar_mcp/tools.py" = ["B008", "TC001", "TC002"]
+"src/scholar_mcp/resources.py" = ["B008", "TC001", "TC002"]
+"src/scholar_mcp/prompts.py" = ["B008", "TC002"]
+"tests/conftest.py" = ["TC002", "TC003"]
+"tests/test_smoke.py" = ["TC002", "TC003"]
+"tests/test_tools.py" = ["TC002"]
+# PROJECT-RUFF-IGNORES-END
+>>>>>>> after updating
 
 [tool.ruff.lint.isort]
 known-first-party = ["scholar_mcp"]

--- a/scripts/copier_update_aggregator.py
+++ b/scripts/copier_update_aggregator.py
@@ -1,0 +1,547 @@
+"""Compose the copier-update PR body from three claude-code agent JSON outputs.
+
+Reads /tmp/agent-job-{a,b,c}.json (or paths passed via CLI), validates each
+against an inline schema, and composes a markdown PR body that extends the
+existing #49-shaped body (delta/notes/diff/conflicts) with three new sections
+(conflict resolutions, changelog triage, excluded-file evolution).
+
+Failure-tolerant: missing/skipped/rate-limited/errored agent outputs render
+as state-specific placeholders without affecting other sections. The existing
+#49 sections always render regardless of agent state.
+
+Exit codes:
+- 0: composed body written successfully (even if some sections are placeholders)
+- 1: catastrophic failure (e.g. existing body file missing, output path unwritable)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+@dataclass
+class AggregatorInputs:
+    existing_body: str
+    agent_enabled: bool
+    job_a_path: Path | None
+    job_b_path: Path | None
+    job_c_path: Path | None
+    conflict_count: int
+    template_advanced: bool = True
+    """Whether the template ref actually changed.
+
+    Jobs B and C only fire when `template_advanced=True`. When False (e.g. a
+    `workflow_dispatch` re-run with the same vcs-ref), Jobs B/C section
+    rendering is suppressed entirely rather than rendered as 'Agent failed'.
+    Defaults to True for backward compatibility with callers that don't pass
+    the flag (Job A's `conflict_count` already gates its own section).
+    """
+
+
+def _read_job_json(path: Path | None) -> dict | None:
+    """Read and JSON-parse an agent output file. Returns None if missing or unreadable."""
+    if path is None or not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def _validate_job_a(data: dict | None) -> dict | None:
+    """Return data if it has the expected schema, else None (treated as errored).
+
+    Validates ONLY the top-level shape (`status` is a str; `auto_resolved` /
+    `needs_review` are lists). Item-level shape (each entry's `file`,
+    `commit_sha`, `articulation` keys) is intentionally NOT validated here —
+    a malformed item raises KeyError at render time and `_safe_render` catches
+    it, degrading to that section's error placeholder. This matches the spec's
+    section-level isolation contract; do not extend item-level validation here
+    expecting it to change failure granularity (it won't).
+    """
+    if data is None:
+        return None
+    if not isinstance(data.get("status"), str):
+        return None
+    if data["status"] == "ok" and not isinstance(data.get("auto_resolved", []), list):
+        return None
+    if data["status"] == "ok" and not isinstance(data.get("needs_review", []), list):
+        return None
+    return data
+
+
+def _validate_job_b(data: dict | None) -> dict | None:
+    """Return data if it has the expected schema, else None (treated as errored)."""
+    if data is None:
+        return None
+    if not isinstance(data.get("status"), str):
+        return None
+    if data["status"] == "ok" and not isinstance(data.get("entries", []), list):
+        return None
+    return data
+
+
+def _validate_job_c(data: dict | None) -> dict | None:
+    """Return data if it has the expected schema, else None (treated as errored)."""
+    if data is None:
+        return None
+    if not isinstance(data.get("status"), str):
+        return None
+    if data["status"] == "ok" and not isinstance(data.get("files", []), list):
+        return None
+    return data
+
+
+def _placeholder(section_title: str, status: str) -> str:
+    """Render a state-specific placeholder for a section."""
+    if status == "rate_limited":
+        msg = "⏳ Agent rate-limited — full analysis will retry on next cron."
+    else:  # generic error or missing-but-expected
+        msg = "⚠️ Agent failed — see workflow log."
+    return f"### {section_title}\n\n{msg}\n"
+
+
+def _pr_label(entry: dict) -> str:
+    """Render an entry's pr_number as ``#N``, or ``#?`` when null/missing.
+
+    LLM-emitted entries without a PR reference would otherwise render as
+    the literal ``#None`` in the body via Python's ``None.__str__`` inside
+    an f-string.  Used by Job B's three render strata.
+    """
+    pr = entry.get("pr_number")
+    return f"#{pr}" if pr is not None else "#?"
+
+
+def _file_label(entry: dict) -> str:
+    """Render an entry's file as ``\\`name\\```, or ``\\`(unnamed)\\``` when null/missing.
+
+    Same null-safety rationale as :func:`_pr_label` but for Job C's file
+    field; without coercion a null ``file`` renders as the literal
+    backticked ``\\`None\\```.
+    """
+    name = entry.get("file")
+    return f"`{name}`" if name is not None else "`(unnamed)`"
+
+
+def _render_job_a(data: dict | None, conflict_count: int) -> str:
+    """Render the 🔧 Conflict resolutions section."""
+    if conflict_count == 0:
+        return ""  # Job A is gated; no section if no conflicts
+    data = _validate_job_a(data)
+    if data is None:
+        return _placeholder("🔧 Conflict resolutions", "error")
+    status = data.get("status", "error")
+    if status == "rate_limited":
+        return _placeholder("🔧 Conflict resolutions", "rate_limited")
+    if status != "ok":
+        return _placeholder("🔧 Conflict resolutions", "error")
+
+    content: list[str] = []
+    auto = data.get("auto_resolved", [])
+    if auto:
+        content.append("**Auto-committed by claude-code** — VERIFY before merging:")
+        content.append("")
+        for item in auto:
+            content.append(
+                f"- `{item['file']}` (commit {item['commit_sha']}): "
+                f"_{item['articulation']}_"
+            )
+        content.append("")
+    review = data.get("needs_review", [])
+    if review:
+        content.append(
+            "**Needs review** — conflict markers remain, operator must resolve:"
+        )
+        content.append("")
+        for item in review:
+            content.append(f"- `{item['file']}`: {item['reasoning']}")
+            content.append(f"  Recommended approach: {item['recommended_resolution']}")
+        content.append("")
+    if not content:
+        # Status was "ok" but the LLM reported neither auto-resolved nor
+        # needs-review entries.  Suppress the section entirely rather than
+        # emitting an orphaned `### 🔧` header above empty content.
+        return ""
+    return "\n".join(["### 🔧 Conflict resolutions", "", *content])
+
+
+def _render_job_b(data: dict | None, template_advanced: bool = True) -> str:
+    """Render the ✨ New features in this update section."""
+    if not template_advanced:
+        return ""  # Job B is gated; no section if refs didn't differ
+    data = _validate_job_b(data)
+    if data is None:
+        return _placeholder("✨ New features in this update", "error")
+    status = data.get("status", "error")
+    if status == "rate_limited":
+        return _placeholder("✨ New features in this update", "rate_limited")
+    if status != "ok":
+        return _placeholder("✨ New features in this update", "error")
+
+    entries = data.get("entries", [])
+    if not entries:
+        return ""  # No features = no section (rare — refs differed but changelog empty)
+
+    # Sort by PR# ascending for deterministic body across re-runs
+    # (LLM-emitted entry order may vary; canonical sort collapses that variance).
+    # `lstrip("#")` tolerates LLM-emitted prefixes like `"#89"`. `or 0` covers
+    # null values. Without coercion a single bad entry would degrade the whole
+    # section to an error placeholder via _safe_render's TypeError catch.
+    entries = sorted(
+        entries,
+        key=lambda e: int(str(e.get("pr_number") or "0").lstrip("#") or "0"),
+    )
+
+    by_class: dict[str, list[dict]] = {
+        "needs-opt-in": [],
+        "ships-automatically": [],
+        "informational": [],
+    }
+    # Map any unknown classification to "informational" so the render loop
+    # (which only iterates the three keys above) doesn't silently drop entries
+    # with off-spec classification strings (e.g., LLM emits "NEEDS-OPT-IN" or
+    # a typo). The `setdefault`-style pattern would have created a new dict
+    # key but the render loop wouldn't have visited it.
+    for e in entries:
+        cls = e.get("classification")
+        by_class[cls if cls in by_class else "informational"].append(e)
+
+    content: list[str] = []
+    if by_class["needs-opt-in"]:
+        content.append("**Needs your attention** (action-required):")
+        content.append("")
+        for e in by_class["needs-opt-in"]:
+            content.append(f"- {_pr_label(e)} {e['title']} — needs opt-in.")
+            content.append(f"  {e['summary']}")
+        content.append("")
+    if by_class["ships-automatically"]:
+        content.append("**Ships through automatically** (informational):")
+        content.append("")
+        for e in by_class["ships-automatically"]:
+            content.append(f"- {_pr_label(e)} {e['title']} — applied this run")
+        content.append("")
+    if by_class["informational"]:
+        # Drop entries with null pr_number from the rollup — they'd render
+        # as the literal "#None" otherwise (LLM-emitted malformed entries
+        # without a PR reference can't be looked up anyway, so dropping
+        # them from the displayed list is preferable to a placeholder).
+        # The bullet strata above use ``_pr_label`` which coerces null to
+        # ``#?`` — preserves the entry where its prose detail is useful;
+        # the rollup is a tally so dropping is cleaner there.
+        rollup = [
+            e for e in by_class["informational"] if e.get("pr_number") is not None
+        ]
+        if rollup:
+            ids = ", ".join(_pr_label(e) for e in rollup)
+            n = len(rollup)
+            content.append(
+                f"**Internal / no downstream effect** ({n} {'entry' if n == 1 else 'entries'}): {ids}"
+            )
+            content.append("")
+    if not content:
+        # Entries existed but every stratum filtered out (e.g. all
+        # informational with null pr_number); suppress the section entirely
+        # rather than emit an orphaned `### ✨` header above empty content.
+        return ""
+    return "\n".join(["### ✨ New features in this update", "", *content])
+
+
+def _render_job_c(data: dict | None, template_advanced: bool = True) -> str:
+    """Render the 📦 Excluded-file upstream changes section."""
+    if not template_advanced:
+        return ""  # Job C is gated; no section if refs didn't differ
+    data = _validate_job_c(data)
+    if data is None:
+        return _placeholder("📦 Excluded-file upstream changes", "error")
+    status = data.get("status", "error")
+    if status == "rate_limited":
+        return _placeholder("📦 Excluded-file upstream changes", "rate_limited")
+    if status != "ok":
+        return _placeholder("📦 Excluded-file upstream changes", "error")
+
+    files = data.get("files", [])
+    if not files:
+        return ""
+
+    # Sort by file path for deterministic body across re-runs.
+    # `str(... or "")` coerces null/missing file fields without raising
+    # TypeError on mixed-type lists (the LLM may emit `"file": null` for a
+    # malformed entry). Same robustness rationale as Job B's pr_number sort.
+    files = sorted(files, key=lambda f: str(f.get("file") or ""))
+
+    by_class: dict[str, list[dict]] = {
+        "recommend-port": [],
+        "informational": [],
+        "skip": [],
+    }
+    # Map unknown classifications to "informational" — same rationale as
+    # Job B (avoid silent data loss from off-spec classification strings).
+    for f in files:
+        cls = f.get("classification")
+        by_class[cls if cls in by_class else "informational"].append(f)
+
+    content: list[str] = []
+    if by_class["recommend-port"]:
+        content.append("**Recommended to port** (action-required):")
+        content.append("")
+        for f in by_class["recommend-port"]:
+            content.append(f"- {_file_label(f)}: {f['summary']}")
+            content.append(f"  Diff: {f['diff_summary']}")
+        content.append("")
+    if by_class["informational"]:
+        content.append("**Informational**:")
+        content.append("")
+        for f in by_class["informational"]:
+            content.append(f"- {_file_label(f)}: {f['summary']}")
+        content.append("")
+    if by_class["skip"]:
+        # Drop entries with null file from the rollup — same rationale as
+        # Job B's informational rollup (see :func:`_render_job_b`).
+        rollup = [f for f in by_class["skip"] if f.get("file") is not None]
+        if rollup:
+            names = ", ".join(_file_label(f) for f in rollup)
+            n = len(rollup)
+            content.append(
+                f"**Skipped (template-internal)** ({n} {'file' if n == 1 else 'files'}): {names}"
+            )
+            content.append("")
+    if not content:
+        # Files existed but the skip rollup was the only non-empty
+        # stratum and every entry in it had null file (so the rollup
+        # got filtered out).  Suppress the section entirely rather
+        # than emit an orphaned `### 📦` header above empty content.
+        return ""
+    return "\n".join(["### 📦 Excluded-file upstream changes", "", *content])
+
+
+_DISABLED_NOTICE = (
+    "🔒 Agent disabled — `CLAUDE_CODE_OAUTH_TOKEN` not configured. "
+    "Set the secret in repo settings to enable."
+)
+
+
+def _disabled_section(section_title: str) -> str:
+    """Per-section placeholder when agent_enabled=False."""
+    return f"### {section_title}\n\n{_DISABLED_NOTICE}\n"
+
+
+def compose_body(inputs: AggregatorInputs) -> str:
+    """Compose the full PR body from existing #49 content + agent JSON outputs."""
+    agent_sections: list[str] = []
+
+    if not inputs.agent_enabled:
+        # Per-section disabled placeholders so structure is consistent across
+        # configured / not-configured runs. Each section that WOULD have run
+        # gets a skip notice; sections gated out (e.g. Job A with no conflicts)
+        # are omitted entirely.
+        if inputs.conflict_count > 0:
+            agent_sections.append(_disabled_section("🔧 Conflict resolutions"))
+        if inputs.template_advanced:
+            agent_sections.append(_disabled_section("✨ New features in this update"))
+            agent_sections.append(
+                _disabled_section("📦 Excluded-file upstream changes")
+            )
+    else:
+        # Each render is wrapped in try/except so a malformed item in one job's
+        # JSON (e.g. LLM emitted entry missing a required field) degrades to
+        # that section's error placeholder without nuking the other two
+        # sections.  See spec § Aggregator's four-state contract — sections
+        # must be independently failing.
+        section_a = _safe_render(
+            "🔧 Conflict resolutions",
+            lambda: _render_job_a(
+                _read_job_json(inputs.job_a_path), inputs.conflict_count
+            ),
+        )
+        if section_a:
+            agent_sections.append(section_a)
+
+        section_b = _safe_render(
+            "✨ New features in this update",
+            lambda: _render_job_b(
+                _read_job_json(inputs.job_b_path), inputs.template_advanced
+            ),
+        )
+        if section_b:
+            agent_sections.append(section_b)
+
+        section_c = _safe_render(
+            "📦 Excluded-file upstream changes",
+            lambda: _render_job_c(
+                _read_job_json(inputs.job_c_path), inputs.template_advanced
+            ),
+        )
+        if section_c:
+            agent_sections.append(section_c)
+
+    parts = [inputs.existing_body.rstrip()]
+    # Suppress the agent-analysis header entirely when no sections will follow
+    # it (e.g. agent_enabled=True with conflict_count=0 + template_advanced=False,
+    # or agent_disabled with both gates closed) — otherwise the body emits an
+    # orphaned `## Agent analysis` separator with nothing under it.
+    if agent_sections:
+        parts.extend(["", "---", "", "## Agent analysis", "", *agent_sections])
+    return "\n".join(parts) + "\n"
+
+
+def _safe_render(section_title: str, render_fn: Callable[[], str]) -> str:
+    """Run render_fn; on any exception, return that section's error placeholder.
+
+    Per-section isolation: a render-time crash on one job (e.g. KeyError from a
+    malformed item) must not affect the other two job sections. The render
+    callable is invoked and its result returned; only on exception do we
+    substitute an error placeholder.
+    """
+    try:
+        return render_fn()
+    except (KeyError, TypeError, ValueError, AttributeError):
+        return _placeholder(section_title, "error")
+
+
+BODY_LIMIT = 60_000
+SECTION_MARKERS = ["### 🔧 ", "### ✨ ", "### 📦 "]
+
+
+def compose_body_with_overflow(
+    inputs: AggregatorInputs, overflow_dir: Path
+) -> tuple[str, list[Path]]:
+    """Compose body; if > BODY_LIMIT chars, spill longest section(s) to overflow files.
+
+    Returns (body, overflow_paths). overflow_paths is empty if no spill occurred.
+    Each overflow path holds the displaced section content (caller posts as comments).
+    """
+    body = compose_body(inputs)
+    if len(body) <= BODY_LIMIT:
+        return body, []
+
+    overflow_dir.mkdir(parents=True, exist_ok=True)
+    overflow_paths: list[Path] = []
+    spill_index = 0
+    # Track which markers have already been spilled so a later iteration
+    # doesn't re-pick the (now-tiny) replacement section as longest. Without
+    # this guard, the replacement (still beginning with "### …") would match
+    # the section finder forever, producing useless overflow files of stub
+    # content while the loop spins.
+    spilled_markers: set[str] = set()
+
+    while len(body) > BODY_LIMIT:
+        # Find each not-yet-spilled section's start + length.
+        sections: list[tuple[str, int, int]] = []  # (header, start, end)
+        for marker in SECTION_MARKERS:
+            if marker in spilled_markers:
+                continue
+            start = body.find(marker)
+            if start == -1:
+                continue
+            # Section ends at the start of the NEXT known SECTION_MARKER, or
+            # EOF. Don't bare-find `\n### ` — agent-supplied text inside a
+            # section (Job A articulation, Job B/C summaries) may legitimately
+            # contain `### Sub-header` lines that would otherwise be mistaken
+            # for a section boundary, splitting the section prematurely.
+            other_starts = [
+                body.find(m, start + len(marker))
+                for m in SECTION_MARKERS
+                if m != marker
+            ]
+            other_starts = [s for s in other_starts if s != -1]
+            end = min(other_starts) if other_starts else len(body)
+            sections.append((marker, start, end))
+
+        if not sections:
+            # All agent sections already spilled; can't reduce further
+            # (existing #49 body alone exceeds the limit). Bail.
+            break
+
+        sections.sort(key=lambda s: s[2] - s[1], reverse=True)
+        marker, start, end = sections[0]
+        spilled_markers.add(marker)
+        spill_index += 1
+        overflow_path = overflow_dir / f"overflow-{spill_index}.md"
+        overflow_path.write_text(body[start:end], encoding="utf-8")
+        overflow_paths.append(overflow_path)
+
+        # Capture the FULL heading line (`### 🔧 Conflict resolutions`) so the
+        # replacement preserves the section-name signal, then strip the `### `
+        # prefix for the bold replacement (which intentionally uses non-`###`
+        # so the section finder skips it on subsequent iterations).
+        heading_end = body.find("\n", start)
+        if heading_end == -1:
+            heading_end = end
+        full_heading = body[start:heading_end].lstrip("# ").rstrip()
+        replacement = (
+            f"**{full_heading} — full analysis posted as a "
+            f"follow-up comment (overflow #{spill_index}).**\n\n"
+        )
+        body = body[:start] + replacement + body[end:]
+
+    return body, overflow_paths
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Compose copier-update PR body from agent JSON outputs."
+    )
+    p.add_argument(
+        "--existing-body",
+        type=Path,
+        required=True,
+        help="Path to the existing #49-shaped body markdown.",
+    )
+    p.add_argument("--agent-enabled", choices=["true", "false"], required=True)
+    p.add_argument(
+        "--job-a",
+        type=Path,
+        default=None,
+        help="Path to /tmp/agent-job-a.json (or absent).",
+    )
+    p.add_argument("--job-b", type=Path, default=None)
+    p.add_argument("--job-c", type=Path, default=None)
+    p.add_argument("--conflict-count", type=int, required=True)
+    p.add_argument(
+        "--template-advanced",
+        choices=["true", "false"],
+        default="true",
+        help="Whether the template ref changed; gates Jobs B/C section rendering.",
+    )
+    p.add_argument(
+        "--output-body", type=Path, required=True, help="Where to write composed body."
+    )
+    p.add_argument(
+        "--overflow-dir",
+        type=Path,
+        required=True,
+        help="Directory for overflow comment files.",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    inputs = AggregatorInputs(
+        existing_body=args.existing_body.read_text(encoding="utf-8"),
+        agent_enabled=(args.agent_enabled == "true"),
+        job_a_path=args.job_a,
+        job_b_path=args.job_b,
+        job_c_path=args.job_c,
+        conflict_count=args.conflict_count,
+        template_advanced=(args.template_advanced == "true"),
+    )
+    body, overflow_paths = compose_body_with_overflow(
+        inputs, overflow_dir=args.overflow_dir
+    )
+    args.output_body.write_text(body, encoding="utf-8")
+    if overflow_paths:
+        for p in overflow_paths:
+            print(f"OVERFLOW: {p}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/copier_update_prompts/job_a.md
+++ b/scripts/copier_update_prompts/job_a.md
@@ -1,0 +1,126 @@
+<!-- scripts/copier_update_prompts/job_a.md -->
+# Job A: copier-update conflict resolution
+
+You are an agent helping an operator review a `copier-update` PR for the
+`scholar-mcp` downstream consumer of the `pvliesdonk/fastmcp-server-template`.
+
+## Context
+
+The template was advanced from `${PREVIOUS_COMMIT}` to `${NEW_REF}`. `copier
+update --conflict=inline` ran and left conflict markers in some files because
+copier's 3-way merge could not auto-resolve them. Your job is to triage these
+conflicts: auto-commit the trivial mechanical ones, and write analysis comments
+for the rest.
+
+You have access to:
+- The downstream working tree at the current branch state (with conflict markers).
+- A clone of the template repo at `/tmp/template`. Use `git -C /tmp/template
+  checkout ${PREVIOUS_COMMIT}` and `git -C /tmp/template checkout ${NEW_REF}`
+  to inspect the template's state at either ref.
+
+## Conflict files
+
+The following files contain `<<<<<<< before updating ... >>>>>>>` markers:
+
+${CONFLICT_FILES_LIST}
+
+## Per-conflict task
+
+For each `<<<<<<<` / `>>>>>>>` region in each conflict file, decide one of:
+
+### Auto-resolvable
+
+A conflict is **auto-resolvable** if and only if you can articulate the precise
+transformation that resolves it in **one sentence** with **no ambiguity** about
+which downstream lines belong where. Examples of articulations that pass this
+bar:
+
+- "Moved 12 lines of `remote OIDC mode` customisation from a mid-file location
+  into the new `DOMAIN-OIDC-EXTRA` block at end-of-file; template body accepted
+  unchanged."
+- "Renamed sentinel marker `DOMAIN-DOCKER-START` to `DOMAIN-DOCKER-EXTRA-START`
+  to match the template's new naming convention; downstream content unchanged."
+
+If you cannot articulate the transformation in one sentence — or if there is any
+ambiguity about which downstream lines should go where — the conflict is NOT
+auto-resolvable.
+
+For auto-resolvable conflicts: write the resolved file to disk (replacing the
+conflict markers and surrounding region with the final content). Do NOT commit
+yet — accumulate auto-resolutions and commit once at the end.
+
+### Needs review
+
+For non-auto-resolvable conflicts: leave the markers in place. Write a
+`recommended_resolution` (one paragraph, concrete) and `reasoning` (one
+paragraph, explains why it can't be auto-resolved).
+
+## Final commit
+
+If you applied any auto-resolutions, run **once** at the end:
+
+```bash
+git add <files-you-modified>
+
+# Verify ONLY the conflict files you intended to stage are staged.
+# The list below MUST be a subset of CONFLICT_FILES_LIST. If it isn't,
+# something else got staged — abort, do NOT commit, and report status
+# error in the JSON. Anything else risks pushing unrelated edits to
+# the PR branch under the auto-resolve commit.
+git diff --cached --name-only
+
+git commit -m "auto-resolve N trivial conflicts (claude-code)" --author="claude-code <claude-code@anthropic.com>"
+```
+
+Capture the commit SHA via `git rev-parse HEAD`.
+
+## Output
+
+Write the following JSON to `/tmp/agent-job-a.json` (NOT to stdout — write the file):
+
+```json
+{
+  "status": "ok",
+  "auto_resolved": [
+    {
+      "file": "docs/deployment/oidc.md",
+      "region": "L42-L78",
+      "articulation": "Moved 12 lines of remote OIDC mode customisation into the new DOMAIN-OIDC-EXTRA block; template body accepted unchanged.",
+      "commit_sha": "abc1234"
+    }
+  ],
+  "needs_review": [
+    {
+      "file": "docs/guides/authentication.md",
+      "region": "L120-L145",
+      "recommended_resolution": "Lift the renamed anchor `#known-limitations-oidc-session-lifetime` into the EXTRA block while accepting the template's anchor in the body.",
+      "reasoning": "Conflict is between template's new MCP OAuth refresh section content and downstream's renamed cross-reference anchor. The rename affects three internal links so resolving requires choosing between (a) preserving the rename and updating template-body links to match, or (b) reverting to template anchor and dropping the rename. Operator preference."
+    }
+  ]
+}
+```
+
+If you encounter an unrecoverable error (e.g. file unreadable, git commit
+failed), write `{"status": "error", "message": "<one-line description>"}`
+instead and exit. If you receive a 429 / rate-limit response from any tool,
+write `{"status": "rate_limited", "message": "<details>"}`.
+
+The aggregator that consumes this JSON validates schema strictly. Any
+deviation from the shapes above will cause the section to render as
+"Agent failed" in the PR body.
+
+## Constraints
+
+- Tool access: file read/write on the working tree, file read on `/tmp/template`,
+  `git -C /tmp/template <subcommand>`, `git status`, `git diff`, `git add <path>`,
+  `git commit -m '<msg>'`. NO `git push`, NO branch operations, NO network calls.
+- Do not modify files outside the conflict files listed above.
+- Sentinel-block awareness: lines inside `<!-- DOMAIN-*-START -->` ... `<!-- DOMAIN-*-END -->`,
+  `<!-- PROJECT-*-START -->` ... `<!-- PROJECT-*-END -->`, `# CONFIG-*-START` ...
+  `# CONFIG-*-END`, `# PROJECT-*-START` ... `# PROJECT-*-END` are downstream-owned by
+  contract. When resolving conflicts inside these blocks, take the downstream side
+  unless there is a clear template-side correction (e.g. the marker name itself
+  was renamed by the template).
+
+If the auto-resolved list is empty (no trivial cases found), do NOT make any
+git commit; the `auto_resolved` array in the JSON is `[]`.

--- a/scripts/copier_update_prompts/job_b.md
+++ b/scripts/copier_update_prompts/job_b.md
@@ -1,0 +1,81 @@
+<!-- scripts/copier_update_prompts/job_b.md -->
+# Job B: copier-update changelog triage
+
+You are an agent helping an operator review a `copier-update` PR for the
+`scholar-mcp` downstream consumer of `pvliesdonk/fastmcp-server-template`.
+
+## Context
+
+The template was advanced from `${PREVIOUS_COMMIT}` to `${NEW_REF}`. The
+template's `CHANGELOG.md` between these two refs has new entries the operator
+hasn't seen before. Your job is to triage each entry: classify it by
+operator-relevance and write a one-paragraph summary.
+
+You have read-only access to:
+- A clone of the template repo at `/tmp/template`. Read
+  `/tmp/template/CHANGELOG.md` at the new ref.
+- The downstream working tree (read-only — do not modify).
+
+## Per-entry task
+
+For each entry in the CHANGELOG between `${PREVIOUS_COMMIT}` (exclusive) and
+`${NEW_REF}` (inclusive), classify as one of three:
+
+- **`ships-automatically`** — the change is in a template-owned file (NOT in
+  `_skip_if_exists`). Downstream gets it via this `copier update` with no
+  further action. Examples: new env var documented in `docs/configuration.md`
+  (template-owned), workflow change in `release.yml.jinja`.
+
+- **`needs-opt-in`** — downstream must wire something to benefit. Examples:
+  template wires a new helper in a `_skip_if_exists` file (`_server_deps.py`,
+  `tools.py`, etc.); template adds a new copier variable that defaults to a
+  conservative value but downstream may want to override; template adds a new
+  scaffold file that downstream may want to populate.
+
+- **`informational`** — internal template-side change with no downstream-facing
+  effect. Examples: changes to `template-ci.yml`, release-pipeline plumbing,
+  repo-internal docs (`docs/superpowers/`), CHANGELOG-only edits.
+
+## Reading copier.yml to disambiguate
+
+To decide between `ships-automatically` and `needs-opt-in`, read
+`/tmp/template/copier.yml` at `${NEW_REF}` and check `_skip_if_exists` and
+`_exclude`. Files listed in `_skip_if_exists` are downstream-owned starter
+files — changes in those files do NOT flow to downstream automatically.
+
+## Output
+
+Write the following JSON to `/tmp/agent-job-b.json`:
+
+```json
+{
+  "status": "ok",
+  "entries": [
+    {
+      "pr_number": 89,
+      "title": "wire register_server_info_tool",
+      "classification": "needs-opt-in",
+      "summary": "The template now wires `get_server_info` (via `register_server_info_tool`) by default in `make_server()`. This change ships through automatically since `server.py.jinja` is template-owned. To wire upstream version reporting, populate the DOMAIN-UPSTREAM sentinel inside the call. See template's CLAUDE.md `## Server Info Tool` section."
+    }
+  ]
+}
+```
+
+If the CHANGELOG between the two refs is empty (template advanced without
+publishing CHANGELOG entries — unusual), write `{"status": "ok", "entries": []}`.
+
+If you encounter an unrecoverable error, write
+`{"status": "error", "message": "<details>"}`. If rate-limited, write
+`{"status": "rate_limited", "message": "<details>"}`.
+
+## Constraints
+
+- Tool access: file read on `/tmp/template`, `git -C /tmp/template log` and
+  `git -C /tmp/template show`, `git -C /tmp/template checkout <ref>`. NO file
+  writes (other than the output JSON), NO git commits, NO network calls.
+- Use the CHANGELOG.md content directly. Do not infer entries from `git log`
+  alone — if a PR isn't in the CHANGELOG, it's not in scope (the CHANGELOG is
+  managed by python-semantic-release and is the canonical operator-facing
+  feed).
+- Per-entry summaries should be operator-actionable: tell the operator what
+  they got, why it matters, and what (if anything) they should do.

--- a/scripts/copier_update_prompts/job_c.md
+++ b/scripts/copier_update_prompts/job_c.md
@@ -1,0 +1,82 @@
+<!-- scripts/copier_update_prompts/job_c.md -->
+# Job C: copier-update excluded-file evolution
+
+You are an agent helping an operator review a `copier-update` PR for the
+`scholar-mcp` downstream consumer of `pvliesdonk/fastmcp-server-template`.
+
+## Context
+
+Some files in the template are listed under `_exclude` in `copier.yml` — they
+exist as `.jinja` source in the template repo for maintainer reference but are
+NEVER rendered to downstream. Examples: `tests/test_tools.py`, `docs/design.md`.
+
+Downstream often has its own version of these files (created at scaffold time,
+or hand-written later). Because the template doesn't render these to
+downstream, the upstream `.jinja` source can evolve without any changes
+flowing through. This job triages whether downstream's local copy of any such
+file would benefit from porting the upstream evolution.
+
+You have read-only access to:
+- A clone of the template repo at `/tmp/template`. Use `git -C /tmp/template
+  diff ${PREVIOUS_COMMIT}..${NEW_REF} -- <path>` to see what changed.
+- The downstream working tree at the current state (read-only — to inspect
+  the local copy).
+
+## Per-file task
+
+Read `/tmp/template/copier.yml` at `${NEW_REF}` to get the `_exclude` list.
+For each entry that is a `.jinja`-suffixed FILE (skip directory globs like
+`docs/superpowers`, stock excludes like `.git` / `*.pyc` / `~*`, and
+non-`.jinja` files like `uv.lock`):
+
+1. Run: `git -C /tmp/template diff ${PREVIOUS_COMMIT}..${NEW_REF} -- <path>`
+2. If the diff is empty → skip (not in output).
+3. If non-empty, classify the diff:
+   - **`recommend-port`** — the change adds operator-relevant value (new
+     test case, doc improvement, bug fix in a script). Downstream's local
+     copy of this file would benefit from porting the change manually.
+   - **`skip`** — template-maintainer concern only. Downstream doesn't need
+     to do anything (e.g. internal refactor, comment cleanup, change to a
+     test that downstream doesn't have).
+   - **`informational`** — small change with mixed value; downstream might
+     find it interesting but no clear action recommended.
+
+For each non-skipped file, also write `summary` (one sentence on what
+changed) and `diff_summary` (terse — line counts, function names changed,
+etc.; max ~80 chars).
+
+## Output
+
+Write to `/tmp/agent-job-c.json`:
+
+```json
+{
+  "status": "ok",
+  "files": [
+    {
+      "file": "tests/test_tools.py",
+      "classification": "recommend-port",
+      "summary": "Template added a smoke test for the new register_server_info_tool helper that downstream's local test_tools.py doesn't have.",
+      "diff_summary": "+15 lines test fixture for get_server_info"
+    }
+  ]
+}
+```
+
+If no excluded files evolved between the two refs, write
+`{"status": "ok", "files": []}`.
+
+If unrecoverable error: `{"status": "error", "message": "..."}`.
+If rate-limited: `{"status": "rate_limited", "message": "..."}`.
+
+## Constraints
+
+- Tool access: file read, `git -C /tmp/template log` / `diff` / `show` /
+  `checkout`. NO file writes (other than the output JSON), NO git commits,
+  NO network calls.
+- Skip directory globs in `_exclude`. Only process individual file paths
+  ending in `.jinja`.
+- The downstream working tree may not contain the same paths the template's
+  `_exclude` references (e.g. downstream may have deleted their `tests/test_tools.py`).
+  When that's the case, still report the upstream evolution but note in the
+  summary that downstream doesn't currently have a local copy.

--- a/src/scholar_mcp/cli.py
+++ b/src/scholar_mcp/cli.py
@@ -16,12 +16,21 @@ from typing import TYPE_CHECKING, cast
 
 import httpx
 import typer
+<<<<<<< before updating
 from fastmcp_pvl_core import configure_logging_from_env, normalise_http_path
 
 from scholar_mcp.config import _ENV_PREFIX
 
 if TYPE_CHECKING:
     from scholar_mcp._standards_sync import Loader
+=======
+from fastmcp_pvl_core import (
+    build_event_store,
+    configure_logging_from_env,
+    maybe_start_debugpy,
+    normalise_http_path,
+)
+>>>>>>> after updating
 
 logger = logging.getLogger(__name__)
 
@@ -92,10 +101,27 @@ def serve(
     env_http_path = os.environ.get(f"{_ENV_PREFIX}_HTTP_PATH")
     path = normalise_http_path(http_path or env_http_path)
 
+<<<<<<< before updating
     if transport != "http" and (
         host != "0.0.0.0" or port != 8000 or http_path is not None
     ):
         logger.warning("--host, --port and --path are only used with --transport http")
+=======
+    # Optional remote-debugger listener — placed in ``serve`` (not the
+    # typer root callback) so non-server commands like ``--help``,
+    # ``--version``, or future ``dump-config``-style subcommands are
+    # never blocked by ``SCHOLAR_MCP_DEBUG_WAIT=true``.  No-op
+    # unless ``SCHOLAR_MCP_DEBUG_PORT`` is set; ``debugpy`` is only
+    # present when the image was built with ``--build-arg DEBUG=true``
+    # (a missing import logs a WARNING and continues).  ``_root`` has
+    # already attached the StreamHandler by the time ``serve`` runs, so
+    # the helper's INFO/WARNING logs route through the configured
+    # formatter rather than Python's lastResort.
+    maybe_start_debugpy(_ENV_PREFIX)
+
+    config = ProjectConfig.from_env()
+    server = make_server(transport=transport, config=config)
+>>>>>>> after updating
 
     if transport == "http":
         try:

--- a/src/scholar_mcp/config.py
+++ b/src/scholar_mcp/config.py
@@ -27,6 +27,7 @@ class ProjectConfig:
     directly on this dataclass.
     """
 
+<<<<<<< before updating
     # CONFIG-FIELDS-START — scholar domain fields; kept across copier update
     server: ServerConfig = field(default_factory=ServerConfig)
     server_name: str | None = None
@@ -49,6 +50,33 @@ class ProjectConfig:
         """True when both EPO OPS credentials are set."""
         return (
             self.epo_consumer_key is not None and self.epo_consumer_secret is not None
+=======
+    # CONFIG-FIELDS-START — add domain fields below; kept across copier update
+    # (uncommenting the Path-typed examples below also requires adding
+    #  ``from pathlib import Path`` to the imports at the top of this file.)
+    # (example)
+    # vault_path: Path = Path("/data/vault")
+    #
+    # (example: enable optional authorization — see fastmcp-pvl-core's
+    #  README "Authorization" section for the full opt-in story.  Absence
+    #  of the path means no authorization middleware is installed.)
+    # acl_path: Path | None = None
+    # CONFIG-FIELDS-END
+
+    @classmethod
+    def from_env(cls) -> ProjectConfig:
+        """Load :class:`ProjectConfig` from ``SCHOLAR_MCP_*`` env vars."""
+        return cls(
+            server=ServerConfig.from_env(_ENV_PREFIX),
+            # CONFIG-FROM-ENV-START — populate domain fields below; kept across copier update
+            # (example)
+            # vault_path=Path(env(_ENV_PREFIX, "VAULT_PATH", "/data/vault")),
+            #
+            # (example: load ``acl_path`` from ``SCHOLAR_MCP_ACL_PATH``;
+            #  unset env var means no authorization middleware.)
+            # acl_path=Path(_p) if (_p := env(_ENV_PREFIX, "ACL_PATH")) else None,
+            # CONFIG-FROM-ENV-END
+>>>>>>> after updating
         )
 
 

--- a/src/scholar_mcp/server.py
+++ b/src/scholar_mcp/server.py
@@ -14,10 +14,20 @@ from importlib.metadata import version as _pkg_version
 from fastmcp import FastMCP
 from fastmcp.server.event_store import EventStore
 from fastmcp_pvl_core import (
+<<<<<<< before updating
     ServerConfig,
+=======
+    ServerConfig,  # noqa: F401  — re-exported for downstream projects' convenience
+>>>>>>> after updating
     build_auth,
     build_instructions,
     configure_logging_from_env,
+<<<<<<< before updating
+=======
+    register_file_exchange,
+    register_server_info_tool,
+    resolve_auth_mode,
+>>>>>>> after updating
     wire_middleware_stack,
 )
 from fastmcp_pvl_core import (
@@ -94,10 +104,20 @@ def make_server(
     """Construct the Scholar MCP FastMCP server.
 
     Args:
+<<<<<<< before updating
         transport: ``"stdio"`` / ``"http"`` / ``"sse"``.  Tools that depend
             on HTTP transport (e.g. artifact downloads) are wired only when
             transport != ``"stdio"``.
         config: Optional pre-loaded config; defaults to env-based load.
+=======
+        transport: ``"stdio"`` / ``"http"`` / ``"sse"``.  Used here for
+            logging only; MCP File Exchange wiring is gated by
+            ``register_file_exchange`` reading
+            ``SCHOLAR_MCP_TRANSPORT`` / ``FASTMCP_TRANSPORT`` and
+            ``SCHOLAR_MCP_FILE_EXCHANGE_ENABLED`` (default true on
+            HTTP/SSE, false on stdio).
+        config: Optional pre-loaded config; default loads from env.
+>>>>>>> after updating
 
     Returns:
         A configured :class:`fastmcp.FastMCP` instance.
@@ -127,9 +147,14 @@ def make_server(
     server_name = config.server_name or _DEFAULT_SERVER_NAME
 
     logger.info(
+<<<<<<< before updating
         "Server config: name=%s version=%s auth=%s mode=%s cache_dir=%s",
         server_name,
+=======
+        "Server config: version=%s name=scholar-mcp transport=%s auth=%s",
+>>>>>>> after updating
         pkg_ver,
+        transport,
         auth_mode,
         "read-only" if config.read_only else "read-write",
         config.cache_dir,
@@ -154,10 +179,27 @@ def make_server(
 
     wire_middleware_stack(mcp)
 
+    # Optional: enable opt-in per-subject authorization on tools / resources /
+    # prompts.  See fastmcp-pvl-core's README "Authorization" section for the
+    # design.  Tools, resources, and prompts opt in by setting
+    # ``meta={"required_scope": "<scope>"}``; absence of the key means
+    # unrestricted.  The middleware is only installed when ``acl_path`` is set.
+    #
+    # from fastmcp_pvl_core import (
+    #     AuthorizationMiddleware,
+    #     load_acl,
+    #     make_acl_authorizer,
+    # )
+    #
+    # if config.acl_path is not None:
+    #     authorizer = make_acl_authorizer(load_acl(config.acl_path))
+    #     mcp.add_middleware(AuthorizationMiddleware(authorizer=authorizer))
+
     register_tools(mcp)
     register_resources(mcp)
     register_prompts(mcp)
 
+<<<<<<< before updating
     if config.read_only:
         mcp.disable(tags={"write"})
     if not config.epo_configured:
@@ -165,5 +207,91 @@ def make_server(
         # otherwise the model sees ``search_patents``/etc. in its tool list and
         # fails at call time with an auth error.
         mcp.disable(tags={"patent"})
+=======
+    register_server_info_tool(
+        mcp,
+        server_name="scholar-mcp",
+        server_version=pkg_ver,
+        # DOMAIN-UPSTREAM-START — wire upstream version reporting for servers
+        # that talk to a remote service (paperless-mcp, etc.). The provider is
+        # a zero-arg callable; the simplest pattern is a module-level upstream
+        # client (typically constructed from env vars at import time) whose
+        # version method is referenced here. ``CurrentContext()`` is a FastMCP
+        # DI marker — it only resolves to a live context when used as a
+        # parameter default in a tool/resource handler, so it cannot be called
+        # directly from a zero-arg provider.
+        # Uncomment the kwargs below as additional arguments to this call:
+        # upstream_version=lambda: _upstream_client.remote_version(),
+        # upstream_label="paperless",
+        # DOMAIN-UPSTREAM-END
+    )
+
+    # DOMAIN-WIRING-START — project-specific wiring (custom HTTP routes,
+    # transforms, mode toggles, alternative middleware, additional registrations);
+    # kept across copier update. Leave empty for projects that don't customise
+    # make_server() beyond the standard scaffold.
+    # DOMAIN-WIRING-END
+
+    # DOMAIN-FILE-EXCHANGE-START — file-exchange wiring (download direction
+    # always; upload direction opt-in by uncommenting). Kept across copier
+    # update so opt-in customisations (consumer_sink=, produces=, upload
+    # receiver) survive subsequent template updates.
+    #
+    # To publish files from a tool body, capture the returned handle
+    # — see docs/guides/file-exchange.md for the module-level singleton
+    # pattern (e.g. ``_file_exchange = register_file_exchange(...)``).
+    register_file_exchange(
+        mcp,
+        namespace="scholar-mcp",
+        env_prefix=_ENV_PREFIX,
+        transport="auto",
+        # produces=("application/octet-stream",),  # uncomment + customise per project
+        # consumer_sink=_my_sink,                  # uncomment if this server consumes file_refs
+    )
+
+    # Optional upload direction — uncomment + flesh out the helpers below
+    # to accept agent-pushed files via POST /<namespace>/uploads/{token}.
+    # The route mounts only when transport is HTTP/SSE AND
+    # SCHOLAR_MCP_BASE_URL is set; sync receivers run in a thread.
+    # See docs/guides/file-exchange.md for the full pattern. When
+    # uncommenting, move the two ``from`` imports below to the
+    # module-level import block at the top of this file.
+    #
+    # from typing import Any
+    #
+    # from fastmcp_pvl_core import (
+    #     UploadRecord,
+    #     register_file_exchange_upload,
+    # )
+    #
+    # def _validate_upload_target(target_id: str, extra: dict[str, Any] | None) -> None:
+    #     """Pre-link validator: reject obviously bad target_ids in-band.
+    #
+    #     Runs inside create_upload_link before the token is minted, so an
+    #     LLM gets a clean tool error rather than after a wasted upload
+    #     round-trip.
+    #     """
+    #     # Example: reject anything outside the domain's allowlist.
+    #     # raise ValueError(f"target_id not allowed: {target_id}")
+    #     pass
+    #
+    # def _upload_receiver(record: UploadRecord, body: bytes) -> dict[str, Any]:
+    #     """Commit the uploaded bytes. Raise ValueError → 400,
+    #     FileExistsError → 409, anything else → 500 (with traceback
+    #     logged). Return value MUST be a dict — non-dict returns are
+    #     treated as receiver bugs (500 + WARNING log)."""
+    #     # TODO: replace with your storage logic.
+    #     return {"path": record.target_id, "size_bytes": len(body)}
+    #
+    # register_file_exchange_upload(
+    #     mcp,
+    #     namespace="scholar-mcp",
+    #     env_prefix=_ENV_PREFIX,
+    #     transport="auto",
+    #     receiver=_upload_receiver,
+    #     pre_link_validator=_validate_upload_target,
+    # )
+    # DOMAIN-FILE-EXCHANGE-END
+>>>>>>> after updating
 
     return mcp


### PR DESCRIPTION
## Template update: `v1.2.0` → `v1.6.1`

[Compare on GitHub](https://github.com/pvliesdonk/fastmcp-server-template/compare/v1.2.0...v1.6.1)

<details><summary>Release notes (v1.6.1)</summary>

- #123 fix(copier-update): OIDC permission + bare Write for Jobs B/C

</details>

<details><summary>Files changed (28)</summary>

```
 .copier-answers.yml                    |   2 +-
 .gemini/config.yaml                    |  18 ++
 .github/workflows/ci.yml               |  14 +-
 .github/workflows/copier-update.yml    | 302 +++++++++++++++++-
 .github/workflows/docs.yml             |   2 +-
 .github/workflows/release.yml          |  13 +-
 CLAUDE.md                              |  41 ++-
 Dockerfile                             |  28 +-
 README.md                              |  79 ++++-
 docs/configuration.md                  |  41 +++
 docs/deployment/docker.md              |  73 +++++
 docs/deployment/oidc.md                |  12 +
 docs/guides/authentication.md          |  28 ++
 docs/guides/file-exchange.md           | 288 +++++++++++++++++
 docs/index.md                          |  18 ++
 docs/installation.md                   |  13 +
 docs/prompts.md                        |  11 +
 docs/tools/index.md                    |  14 +
 mkdocs.yml                             |  36 +++
 pyproject.toml                         |  40 +++
 scripts/copier_update_aggregator.py    | 547 +++++++++++++++++++++++++++++++++
 scripts/copier_update_prompts/job_a.md | 126 ++++++++
 scripts/copier_update_prompts/job_b.md |  81 +++++
 scripts/copier_update_prompts/job_c.md |  82 +++++
 src/scholar_mcp/cli.py                 |  26 ++
 src/scholar_mcp/config.py              |  28 ++
 src/scholar_mcp/server.py              | 128 ++++++++
 src/scholar_mcp/static/icons/.gitkeep  |   0
 28 files changed, 2063 insertions(+), 28 deletions(-)
```

</details>

### ⚠️ 13 file(s) with unresolved conflict markers

The `<<<<<<< before updating` markers **are committed to this branch** — resolve them before merging:

- `Dockerfile`
- `README.md`
- `docs/configuration.md`
- `docs/deployment/docker.md`
- `docs/index.md`
- `docs/installation.md`
- `docs/prompts.md`
- `docs/tools/index.md`
- `mkdocs.yml`
- `pyproject.toml`
- `src/scholar_mcp/cli.py`
- `src/scholar_mcp/config.py`
- `src/scholar_mcp/server.py`

---

> **Note:** `--skip-answered` was passed, so any **new** template variables introduced since the last update were silently filled with their copier defaults. Skim `.copier-answers.yml` for unexpected new keys.