### PR TITLE
chore(deps): bundle CVE-driven uv.lock bumps (pip 26.1.1, python-multipart 0.0.28)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1799,11 +1799,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.0.1"
+version = "26.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/48/83/0d7d4e9efe3344b8e2fe25d93be44f64b65364d3c8d7bc6dc90198d5422e/pip-26.0.1.tar.gz", hash = "sha256:c4037d8a277c89b320abe636d59f91e6d0922d08a05b60e85e53b296613346d8", size = 1812747, upload-time = "2026-02-05T02:20:18.702Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/48/cb9b7a682f6fe01a4221e1728941dd4ac3cd9090a17db3779d6ff490b602/pip-26.1.1.tar.gz", hash = "sha256:d36762751d156a4ee895de8af39aa0abeeeb577f93a2eca6ab62467bbf0f8a78", size = 1840400, upload-time = "2026-05-04T19:02:21.248Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/f0/c81e05b613866b76d2d1066490adf1a3dbc4ee9d9c839961c3fc8a6997af/pip-26.0.1-py3-none-any.whl", hash = "sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b", size = 1787723, upload-time = "2026-02-05T02:20:16.416Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/eb/fea4d1d51c49832120f7f285d07306db3960f423a2612c6057caf3e8196f/pip-26.1.1-py3-none-any.whl", hash = "sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb", size = 1812777, upload-time = "2026-05-04T19:02:18.9Z" },
 ]
 
 [[package]]
@@ -2294,11 +2294,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.26"
+version = "0.0.28"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/54/a85eb421fbdd5007bc5af39d0f4ed9fa609e0fedbfdc2adcf0b34526870e/python_multipart-0.0.28.tar.gz", hash = "sha256:8550da197eac0f7ab748961fc9509b999fa2662ea25cef857f05249f6893c0f8", size = 45314, upload-time = "2026-05-10T11:05:16.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/a2/43bbc5860b5034e2af4ef99a0e04d726ff329c43e192ef3abaa8d7ecfce5/python_multipart-0.0.28-py3-none-any.whl", hash = "sha256:10faac07eb966c3f48dc415f9dee46c04cb10d58d30a35677db8027c825ed9b6", size = 29438, upload-time = "2026-05-10T11:05:15.052Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bundle two Dependabot bumps into one `uv.lock` update so the pip-audit CVE findings clear in a single CI run.

| Package | Was | Now | Closes Dependabot alert | Supersedes |
|---|---|---|---|---|
| `pip` | 26.0.1 | 26.1.1 | #10 (≤26.0.1, medium) + #11 (<26.1, medium) | #172 |
| `python-multipart` | 0.0.26 | 0.0.28 | #12 (<0.0.27, **high** — unbounded multipart headers DoS) | #173 |

`uv lock --upgrade-package` picked **slightly newer patch versions** than what the Dependabot PRs proposed (26.1.1 vs 26.1; 0.0.28 vs 0.0.27). Both land strictly above the patched-version line for every alert.

Closes #179
Supersedes #172, supersedes #173

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy src/ tests/` — clean (104 files)
- [x] `uv run pytest -x -q` — 1029 passed
- [x] **Reproduced the CI pip-audit step locally:** `uv export --all-extras --no-extra dev --no-extra docs --frozen --no-emit-project --no-hashes | uvx pip-audit --strict -r ...` → **"No known vulnerabilities found"**
- [x] Local-review circus: both reviewers clean

## Scope verification

`git diff --cached uv.lock` touches exactly 12 lines — the `version`, `sdist`, and `wheels` entries of `pip` and `python-multipart` only. No `pyproject.toml` change (both are transitive: `pip-api` pulls `pip`; `mcp` pulls `python-multipart`). No collateral transitive bumps. PyPI hashes verified for both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)