### PR TITLE
chore(copier): update template from v1.3.0 to v1.4.0

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by `copier update`.
-_commit: v1.3.0
+_commit: v1.4.0
 _src_path: https://github.com/pvliesdonk/fastmcp-server-template
 docker_registry: ghcr.io/pvliesdonk
 domain_description: FastMCP server for Semantic Scholar with OpenAlex enrichment and

--- a/.github/workflows/copier-update.yml
+++ b/.github/workflows/copier-update.yml
@@ -259,7 +259,8 @@ jobs:
           steps.changes.outputs.changed == 'true' &&
           steps.agent-prereq.outputs.agent_enabled == 'true' &&
           steps.meta.outputs.conflict_count > 0 &&
-          steps.clone-template.outputs.template_clone_ok == 'true'
+          steps.clone-template.outputs.template_clone_ok == 'true' &&
+          steps.prepare-prompt-a.outcome == 'success'
         continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
@@ -293,7 +294,8 @@ jobs:
           steps.changes.outputs.changed == 'true' &&
           steps.agent-prereq.outputs.agent_enabled == 'true' &&
           steps.meta.outputs.template_advanced == 'true' &&
-          steps.clone-template.outputs.template_clone_ok == 'true'
+          steps.clone-template.outputs.template_clone_ok == 'true' &&
+          steps.prepare-prompt-b.outcome == 'success'
         continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
@@ -327,7 +329,8 @@ jobs:
           steps.changes.outputs.changed == 'true' &&
           steps.agent-prereq.outputs.agent_enabled == 'true' &&
           steps.meta.outputs.template_advanced == 'true' &&
-          steps.clone-template.outputs.template_clone_ok == 'true'
+          steps.clone-template.outputs.template_clone_ok == 'true' &&
+          steps.prepare-prompt-c.outcome == 'success'
         continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
@@ -474,10 +477,10 @@ jobs:
 
       - name: Compose PR body via aggregator
         id: compose
-        # Reads the existing #49-shaped body data + three /tmp/agent-job-*.json
+        # Reads the existing PR body content + three /tmp/agent-job-*.json
         # files (any may be missing/errored) and writes the composed PR body.
         # Failure-tolerant: if aggregator crashes, PR still opens with the
-        # existing #49 body (no agent sections).
+        # existing PR body content (no agent sections).
         if: steps.changes.outputs.changed == 'true'
         continue-on-error: true
         env:
@@ -489,12 +492,20 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Pre-compute optional --job-* flags. Under ``set -euo pipefail`` a bare
+          # ``$( [ -f x ] && echo ... )`` returns exit 1 from the subshell when the
+          # file is missing; in GNU bash that doesn't propagate to set -e because
+          # the substitution is a word in a larger command, but it's fragile across
+          # shells. The ``|| true`` makes the success-path explicit.
+          job_a_flag=$( [ -f /tmp/agent-job-a.json ] && echo "--job-a /tmp/agent-job-a.json" || true )
+          job_b_flag=$( [ -f /tmp/agent-job-b.json ] && echo "--job-b /tmp/agent-job-b.json" || true )
+          job_c_flag=$( [ -f /tmp/agent-job-c.json ] && echo "--job-c /tmp/agent-job-c.json" || true )
           python3 scripts/copier_update_aggregator.py \
             --existing-body /tmp/aggregator/existing-body.md \
             --agent-enabled "${AGENT_ENABLED}" \
-            $( [ -f /tmp/agent-job-a.json ] && echo "--job-a /tmp/agent-job-a.json" ) \
-            $( [ -f /tmp/agent-job-b.json ] && echo "--job-b /tmp/agent-job-b.json" ) \
-            $( [ -f /tmp/agent-job-c.json ] && echo "--job-c /tmp/agent-job-c.json" ) \
+            ${job_a_flag} \
+            ${job_b_flag} \
+            ${job_c_flag} \
             --conflict-count "${CONFLICT_COUNT}" \
             --template-advanced "${TEMPLATE_ADVANCED}" \
             --output-body /tmp/aggregator/composed-body.md \
@@ -521,7 +532,7 @@ jobs:
           title="chore(copier): update to ${REF}"
 
           # Prefer the aggregator's composed body; fall back to the plain
-          # #49 body if the aggregator step failed (continue-on-error: true).
+          # PR body if the aggregator step failed (continue-on-error: true).
           if [ -f /tmp/aggregator/composed-body.md ]; then
             body_file=/tmp/aggregator/composed-body.md
           else

--- a/.github/workflows/copier-update.yml
+++ b/.github/workflows/copier-update.yml
@@ -84,6 +84,9 @@ jobs:
       - name: Read template ref + collect conflict files
         if: steps.changes.outputs.changed == 'true'
         id: meta
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          PREVIOUS_COMMIT: ${{ steps.copier.outputs.prev_ref }}
         run: |
           set -euo pipefail
           # Parse `_commit:` from .copier-answers.yml without depending on
@@ -94,6 +97,25 @@ jobs:
             echo "::error::could not read _commit from .copier-answers.yml"
             exit 1
           fi
+          # Detect whether the template ref actually changed (agent jobs B/C
+          # should fire even when no conflicts but the template advanced).
+          if [ -n "${PREVIOUS_COMMIT}" ] && [ "${PREVIOUS_COMMIT}" != "${ref}" ]; then
+            template_advanced=true
+          else
+            template_advanced=false
+          fi
+          echo "template_advanced=${template_advanced}" >> "$GITHUB_OUTPUT"
+          # Surface previous_commit / new_ref under stable names so the
+          # downstream agent + aggregator steps can reference them via
+          # `steps.meta.outputs.*` regardless of which earlier step produced
+          # the value.  `previous_commit` may be empty on first-ever update.
+          echo "previous_commit=${PREVIOUS_COMMIT}" >> "$GITHUB_OUTPUT"
+          echo "new_ref=${ref}" >> "$GITHUB_OUTPUT"
+          # Pre-detect any existing PR on the copier/update branch so the
+          # aggregator's overflow-comment step has a PR number to post to
+          # (set to 0 when no PR exists yet — overflow posting is best-effort).
+          pr_number=$(gh pr view copier/update --json number --jq .number 2>/dev/null || echo 0)
+          echo "pr_number=${pr_number}" >> "$GITHUB_OUTPUT"
           # `--conflict=inline` writes standard `<<<<<<< before updating`
           # markers (not `.rej` sidecars).  Collect files that contain at
           # least one conflict marker; skip binary files with `git grep -I`.
@@ -131,6 +153,188 @@ jobs:
             printf '%s\n' "${conflict_files}"
             echo "CONFLICT_FILES_EOF"
           } >> "$GITHUB_OUTPUT"
+
+      - name: Clone template at both refs (for agent context)
+        id: clone-template
+        # Provides /tmp/template at both old (downstream's previous _commit)
+        # and new (just-applied) refs so the three claude-code agent steps can
+        # read template-side history (CHANGELOG, conflict files at the old
+        # ref, excluded-file evolution diffs).
+        # Failure-tolerant: if clone fails, agent steps see the missing dir
+        # and write error placeholders; PR still opens.
+        if: steps.changes.outputs.changed == 'true' && (steps.meta.outputs.conflict_count > 0 || steps.meta.outputs.template_advanced == 'true')
+        continue-on-error: true
+        env:
+          PREVIOUS_COMMIT: ${{ steps.meta.outputs.previous_commit }}
+          TEMPLATE_REPO: ${{ steps.meta.outputs.template_repo }}
+        run: |
+          set -euo pipefail
+          rm -rf /tmp/template
+          if [ -z "${TEMPLATE_REPO}" ]; then
+            echo "::notice::template_repo unresolved; skipping clone (agent steps will skip)"
+            exit 0
+          fi
+          git clone --filter=blob:none \
+            "https://github.com/${TEMPLATE_REPO}.git" \
+            /tmp/template
+          # Verify both refs are reachable
+          git -C /tmp/template fetch --tags
+          if [ -n "${PREVIOUS_COMMIT}" ]; then
+            git -C /tmp/template rev-parse "${PREVIOUS_COMMIT}^{commit}" >/dev/null
+          fi
+          echo "template_clone_ok=true" >> "$GITHUB_OUTPUT"
+
+      - name: Check claude-code token availability
+        id: agent-prereq
+        if: steps.changes.outputs.changed == 'true'
+        # Detect whether the downstream repo has CLAUDE_CODE_OAUTH_TOKEN
+        # configured. Without it, the three agent steps skip and the
+        # aggregator renders "agent disabled" placeholders.
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          if [ -n "${CLAUDE_CODE_OAUTH_TOKEN}" ]; then
+            echo "agent_enabled=true"  >> "$GITHUB_OUTPUT"
+          else
+            echo "agent_enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::CLAUDE_CODE_OAUTH_TOKEN not set; skipping agent analysis. Set in repo secrets to enable."
+          fi
+
+      # Jobs A, B, C are independent — they share no data dependency, only
+      # the cloned `/tmp/template` workspace and the per-job env vars.
+      # Currently sequential for simplicity (single workflow job, fewer
+      # `needs:` edges); could be parallelized into separate jobs if wall-
+      # clock latency becomes an issue. Don't make A→B→C serial for
+      # ordering reasons — there is no ordering reason. Agent JSON outputs
+      # land in distinct `/tmp/agent-job-{a,b,c}.json` files; the
+      # aggregator step reads each independently.
+      #
+      # Each agent step has TWO sub-steps:
+      #   1. Pre-render its prompt via `envsubst` and capture into a step
+      #      output (heredoc form for multi-line content).
+      #   2. Invoke claude-code-action with `prompt:` set to the rendered
+      #      content. claude-code-action@v1 only accepts `prompt:` (a
+      #      string) as a public input — there is NO `prompt_file:` input
+      #      on the user-facing wrapper (the action internally writes the
+      #      resolved prompt to `${RUNNER_TEMP}/claude-prompts/claude-prompt.txt`
+      #      from the `prompt:` value).
+      #
+      # envsubst's restricted-form `'${VAR1} ${VAR2}'` only substitutes
+      # those listed; any other `$VAR` references in the prompt body
+      # (e.g. shell-pattern examples) stay literal.
+      #
+      # Multi-line `CONFLICT_FILES_LIST` is safe via envsubst's file-to-file
+      # I/O — no argv quoting. Same pattern is used in release.yml.jinja's
+      # mcpb manifest rendering.
+      #
+      # Each agent step constrains tool access via `claude_args
+      # --allowed-tools` to enforce the spec's per-job tool boundaries
+      # (Job A: file read/write + git commit on the working tree; Jobs B/C:
+      # read-only). Without this, a prompt-injection-vulnerable model could
+      # bypass the prose constraints in the prompt body.
+
+      - name: Pre-render Job A prompt
+        id: prepare-prompt-a
+        if: |
+          steps.changes.outputs.changed == 'true' &&
+          steps.agent-prereq.outputs.agent_enabled == 'true' &&
+          steps.meta.outputs.conflict_count > 0 &&
+          steps.clone-template.outputs.template_clone_ok == 'true'
+        env:
+          PREVIOUS_COMMIT: ${{ steps.meta.outputs.previous_commit }}
+          NEW_REF: ${{ steps.meta.outputs.new_ref }}
+          CONFLICT_FILES_LIST: ${{ steps.meta.outputs.conflict_files }}
+        run: |
+          envsubst '${PREVIOUS_COMMIT} ${NEW_REF} ${CONFLICT_FILES_LIST}' \
+            < scripts/copier_update_prompts/job_a.md \
+            > /tmp/agent-prompt-a.md
+          {
+            echo "prompt<<PROMPT_EOF"
+            cat /tmp/agent-prompt-a.md
+            echo "PROMPT_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Agent Job A — Conflict resolution
+        if: |
+          steps.changes.outputs.changed == 'true' &&
+          steps.agent-prereq.outputs.agent_enabled == 'true' &&
+          steps.meta.outputs.conflict_count > 0 &&
+          steps.clone-template.outputs.template_clone_ok == 'true'
+        continue-on-error: true
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: ${{ steps.prepare-prompt-a.outputs.prompt }}
+          claude_args: |
+            --allowed-tools "Read,Edit,Write,Bash(git status:*),Bash(git diff:*),Bash(git add:*),Bash(git commit:*),Bash(git rev-parse:*),Bash(git -C /tmp/template:*)"
+
+      - name: Pre-render Job B prompt
+        id: prepare-prompt-b
+        if: |
+          steps.changes.outputs.changed == 'true' &&
+          steps.agent-prereq.outputs.agent_enabled == 'true' &&
+          steps.meta.outputs.template_advanced == 'true' &&
+          steps.clone-template.outputs.template_clone_ok == 'true'
+        env:
+          PREVIOUS_COMMIT: ${{ steps.meta.outputs.previous_commit }}
+          NEW_REF: ${{ steps.meta.outputs.new_ref }}
+        run: |
+          envsubst '${PREVIOUS_COMMIT} ${NEW_REF}' \
+            < scripts/copier_update_prompts/job_b.md \
+            > /tmp/agent-prompt-b.md
+          {
+            echo "prompt<<PROMPT_EOF"
+            cat /tmp/agent-prompt-b.md
+            echo "PROMPT_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Agent Job B — Changelog triage
+        if: |
+          steps.changes.outputs.changed == 'true' &&
+          steps.agent-prereq.outputs.agent_enabled == 'true' &&
+          steps.meta.outputs.template_advanced == 'true' &&
+          steps.clone-template.outputs.template_clone_ok == 'true'
+        continue-on-error: true
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: ${{ steps.prepare-prompt-b.outputs.prompt }}
+          claude_args: |
+            --allowed-tools "Read,Bash(cat:*),Bash(git -C /tmp/template:*)"
+
+      - name: Pre-render Job C prompt
+        id: prepare-prompt-c
+        if: |
+          steps.changes.outputs.changed == 'true' &&
+          steps.agent-prereq.outputs.agent_enabled == 'true' &&
+          steps.meta.outputs.template_advanced == 'true' &&
+          steps.clone-template.outputs.template_clone_ok == 'true'
+        env:
+          PREVIOUS_COMMIT: ${{ steps.meta.outputs.previous_commit }}
+          NEW_REF: ${{ steps.meta.outputs.new_ref }}
+        run: |
+          envsubst '${PREVIOUS_COMMIT} ${NEW_REF}' \
+            < scripts/copier_update_prompts/job_c.md \
+            > /tmp/agent-prompt-c.md
+          {
+            echo "prompt<<PROMPT_EOF"
+            cat /tmp/agent-prompt-c.md
+            echo "PROMPT_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Agent Job C — Excluded-file evolution
+        if: |
+          steps.changes.outputs.changed == 'true' &&
+          steps.agent-prereq.outputs.agent_enabled == 'true' &&
+          steps.meta.outputs.template_advanced == 'true' &&
+          steps.clone-template.outputs.template_clone_ok == 'true'
+        continue-on-error: true
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: ${{ steps.prepare-prompt-c.outputs.prompt }}
+          claude_args: |
+            --allowed-tools "Read,Bash(cat:*),Bash(git -C /tmp/template:*)"
 
       - name: Ensure PR labels exist
         if: steps.changes.outputs.changed == 'true'
@@ -174,19 +378,27 @@ jobs:
         id: diff
         run: |
           set -euo pipefail
-          # `copier/update` is always `main + 1 commit` because the previous
-          # step does `git checkout -B` off the checked-out default branch
-          # before making a single commit, so HEAD~1..HEAD captures exactly
-          # this update's delta — no merge-base math needed.
-          diff_count=$(git diff --name-only HEAD~1 HEAD | wc -l | tr -d ' ')
+          # `copier/update` may have 1 or 2 commits ahead of main:
+          #   1 commit  — the chore(copier) commit only (no Job A auto-commit
+          #               because no conflicts arose, or Job A didn't run).
+          #   2 commits — Job A's "auto-resolve N trivial conflicts" commit
+          #               (made on default branch, carried forward into
+          #               copier/update via `git checkout -B`) PLUS the chore
+          #               commit on top.
+          # Always diff against main rather than HEAD~1 so Job A's
+          # auto-resolved files are reflected in the diff stat regardless
+          # of how many commits are stacked.
+          git fetch origin main --depth=50
+          diff_count=$(git diff --name-only origin/main HEAD | wc -l | tr -d ' ')
           echo "diff_count=${diff_count}" >> "$GITHUB_OUTPUT"
           {
             echo "diff_stat<<DIFF_STAT_EOF"
-            git diff --stat HEAD~1 HEAD
+            git diff --stat origin/main HEAD
             echo "DIFF_STAT_EOF"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Open or update PR
+      - name: Build PR body content
+        id: build-body
         if: steps.changes.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
@@ -199,8 +411,7 @@ jobs:
           DIFF_STAT: ${{ steps.diff.outputs.diff_stat }}
         run: |
           set -euo pipefail
-          branch="copier/update"
-          title="chore(copier): update to ${REF}"
+          mkdir -p /tmp/aggregator
 
           # Fetch release notes for the target ref.  Empty when the release
           # isn't cut yet (e.g. a manual `--vcs-ref` run targeting an unreleased
@@ -257,10 +468,70 @@ jobs:
           body+=$'\n\n'"---"
           body+=$'\n\n'"> **Note:** \`--skip-answered\` was passed, so any **new** template variables introduced since the last update were silently filled with their copier defaults. Skim \`.copier-answers.yml\` for unexpected new keys."
 
+          # Persist for the aggregator (Compose PR body) and as the fallback
+          # body when the aggregator step fails.
+          printf '%s' "${body}" > /tmp/aggregator/existing-body.md
+
+      - name: Compose PR body via aggregator
+        id: compose
+        # Reads the existing #49-shaped body data + three /tmp/agent-job-*.json
+        # files (any may be missing/errored) and writes the composed PR body.
+        # Failure-tolerant: if aggregator crashes, PR still opens with the
+        # existing #49 body (no agent sections).
+        if: steps.changes.outputs.changed == 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          AGENT_ENABLED: ${{ steps.agent-prereq.outputs.agent_enabled }}
+          CONFLICT_COUNT: ${{ steps.meta.outputs.conflict_count }}
+          TEMPLATE_ADVANCED: ${{ steps.meta.outputs.template_advanced }}
+          PR_NUMBER: ${{ steps.meta.outputs.pr_number || '0' }}
+        run: |
+          set -euo pipefail
+
+          python3 scripts/copier_update_aggregator.py \
+            --existing-body /tmp/aggregator/existing-body.md \
+            --agent-enabled "${AGENT_ENABLED}" \
+            $( [ -f /tmp/agent-job-a.json ] && echo "--job-a /tmp/agent-job-a.json" ) \
+            $( [ -f /tmp/agent-job-b.json ] && echo "--job-b /tmp/agent-job-b.json" ) \
+            $( [ -f /tmp/agent-job-c.json ] && echo "--job-c /tmp/agent-job-c.json" ) \
+            --conflict-count "${CONFLICT_COUNT}" \
+            --template-advanced "${TEMPLATE_ADVANCED}" \
+            --output-body /tmp/aggregator/composed-body.md \
+            --overflow-dir /tmp/aggregator/overflow
+
+          echo "composed_body_path=/tmp/aggregator/composed-body.md" >> "$GITHUB_OUTPUT"
+
+          # Post overflow comments if any (best-effort: requires PR_NUMBER>0).
+          if [ "${PR_NUMBER}" != "0" ] && [ -d /tmp/aggregator/overflow ]; then
+            for overflow_file in /tmp/aggregator/overflow/overflow-*.md; do
+              [ -f "$overflow_file" ] || continue
+              gh pr comment "${PR_NUMBER}" --body-file "$overflow_file" || true
+            done
+          fi
+
+      - name: Open or update PR
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          REF: ${{ steps.meta.outputs.ref }}
+        run: |
+          set -euo pipefail
+          branch="copier/update"
+          title="chore(copier): update to ${REF}"
+
+          # Prefer the aggregator's composed body; fall back to the plain
+          # #49 body if the aggregator step failed (continue-on-error: true).
+          if [ -f /tmp/aggregator/composed-body.md ]; then
+            body_file=/tmp/aggregator/composed-body.md
+          else
+            body_file=/tmp/aggregator/existing-body.md
+          fi
+
           if gh pr view "${branch}" --json state --jq '.state' 2>/dev/null | grep -q OPEN; then
             gh pr edit "${branch}" \
               --title "${title}" \
-              --body "${body}" \
+              --body-file "${body_file}" \
               --add-label copier \
               --add-label dependencies
           else
@@ -268,7 +539,7 @@ jobs:
               --base main \
               --head "${branch}" \
               --title "${title}" \
-              --body "${body}" \
+              --body-file "${body_file}" \
               --label copier \
               --label dependencies
           fi

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -138,3 +138,15 @@ services:
 | `v1` | Latest minor in 1.x |
 
 Multi-arch: `linux/amd64` and `linux/arm64`.
+
+
+<!-- DOMAIN-DOCKER-EXTRA-START -->
+<!-- Project-specific notes for Docker deployment; kept across copier update. -->
+
+## Project-specific notes
+
+<!-- Add domain-specific caveats here (e.g. "the /data/uploads volume must
+     be writable by UID Y", "container needs cap_add: SYS_PTRACE for
+     debugging tools"). Use sub-headings to organize if needed. -->
+
+<!-- DOMAIN-DOCKER-EXTRA-END -->

--- a/docs/deployment/oidc.md
+++ b/docs/deployment/oidc.md
@@ -200,3 +200,15 @@ labels:
 
 - **Dedicated hostname** (preferred): give the MCP server its own hostname (e.g., `myservice.example.com`) so discovery routes do not collide.
 - **External auth gateway**: use `mcp-auth-proxy` as a sidecar instead of native OIDC. The MCP server runs unauthenticated behind the proxy, and the proxy handles OAuth discovery at its own routes.
+
+
+<!-- DOMAIN-OIDC-EXTRA-START -->
+<!-- Project-specific notes for OIDC deployment; kept across copier update. -->
+
+## Project-specific notes
+
+<!-- Add domain-specific caveats here (e.g. "Keycloak requires X claim",
+     "Authelia token-cache quirk for /admin paths", "this server's audience
+     claim must include 'mcp'"). Use sub-headings to organize if needed. -->
+
+<!-- DOMAIN-OIDC-EXTRA-END -->

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -254,3 +254,16 @@ These upstream issues are actively tracked:
 - [modelcontextprotocol/python-sdk#1326](https://github.com/modelcontextprotocol/python-sdk/issues/1326) — SSE refresh deadlock
 
 When these are resolved, OIDC sessions should persist indefinitely via automatic token refresh with no changes needed server-side.
+
+
+<!-- DOMAIN-AUTH-EXTRA-START -->
+<!-- Project-specific notes for authentication; kept across copier update. -->
+
+## Project-specific notes
+
+<!-- Add domain-specific caveats here (e.g. "paperless-mcp tokens expire
+     every 60 min", "this server requires the 'admin' scope for write tools",
+     "bearer-token middleware skips /health for liveness probes"). Use
+     sub-headings to organize if needed. -->
+
+<!-- DOMAIN-AUTH-EXTRA-END -->

--- a/scripts/copier_update_aggregator.py
+++ b/scripts/copier_update_aggregator.py
@@ -1,0 +1,484 @@
+"""Compose the copier-update PR body from three claude-code agent JSON outputs.
+
+Reads /tmp/agent-job-{a,b,c}.json (or paths passed via CLI), validates each
+against an inline schema, and composes a markdown PR body that extends the
+existing #49-shaped body (delta/notes/diff/conflicts) with three new sections
+(conflict resolutions, changelog triage, excluded-file evolution).
+
+Failure-tolerant: missing/skipped/rate-limited/errored agent outputs render
+as state-specific placeholders without affecting other sections. The existing
+#49 sections always render regardless of agent state.
+
+Exit codes:
+- 0: composed body written successfully (even if some sections are placeholders)
+- 1: catastrophic failure (e.g. existing body file missing, output path unwritable)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+@dataclass
+class AggregatorInputs:
+    existing_body: str
+    agent_enabled: bool
+    job_a_path: Path | None
+    job_b_path: Path | None
+    job_c_path: Path | None
+    conflict_count: int
+    template_advanced: bool = True
+    """Whether the template ref actually changed.
+
+    Jobs B and C only fire when `template_advanced=True`. When False (e.g. a
+    `workflow_dispatch` re-run with the same vcs-ref), Jobs B/C section
+    rendering is suppressed entirely rather than rendered as 'Agent failed'.
+    Defaults to True for backward compatibility with callers that don't pass
+    the flag (Job A's `conflict_count` already gates its own section).
+    """
+
+
+def _read_job_json(path: Path | None) -> dict | None:
+    """Read and JSON-parse an agent output file. Returns None if missing or unreadable."""
+    if path is None or not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def _validate_job_a(data: dict | None) -> dict | None:
+    """Return data if it has the expected schema, else None (treated as errored).
+
+    Validates ONLY the top-level shape (`status` is a str; `auto_resolved` /
+    `needs_review` are lists). Item-level shape (each entry's `file`,
+    `commit_sha`, `articulation` keys) is intentionally NOT validated here —
+    a malformed item raises KeyError at render time and `_safe_render` catches
+    it, degrading to that section's error placeholder. This matches the spec's
+    section-level isolation contract; do not extend item-level validation here
+    expecting it to change failure granularity (it won't).
+    """
+    if data is None:
+        return None
+    if not isinstance(data.get("status"), str):
+        return None
+    if data["status"] == "ok" and not isinstance(data.get("auto_resolved", []), list):
+        return None
+    if data["status"] == "ok" and not isinstance(data.get("needs_review", []), list):
+        return None
+    return data
+
+
+def _validate_job_b(data: dict | None) -> dict | None:
+    """Return data if it has the expected schema, else None (treated as errored)."""
+    if data is None:
+        return None
+    if not isinstance(data.get("status"), str):
+        return None
+    if data["status"] == "ok" and not isinstance(data.get("entries", []), list):
+        return None
+    return data
+
+
+def _validate_job_c(data: dict | None) -> dict | None:
+    """Return data if it has the expected schema, else None (treated as errored)."""
+    if data is None:
+        return None
+    if not isinstance(data.get("status"), str):
+        return None
+    if data["status"] == "ok" and not isinstance(data.get("files", []), list):
+        return None
+    return data
+
+
+def _placeholder(section_title: str, status: str) -> str:
+    """Render a state-specific placeholder for a section."""
+    if status == "rate_limited":
+        msg = "⏳ Agent rate-limited — full analysis will retry on next cron."
+    else:  # generic error or missing-but-expected
+        msg = "⚠️ Agent failed — see workflow log."
+    return f"### {section_title}\n\n{msg}\n"
+
+
+def _render_job_a(data: dict | None, conflict_count: int) -> str:
+    """Render the 🔧 Conflict resolutions section."""
+    if conflict_count == 0:
+        return ""  # Job A is gated; no section if no conflicts
+    data = _validate_job_a(data)
+    if data is None:
+        return _placeholder("🔧 Conflict resolutions", "error")
+    status = data.get("status", "error")
+    if status == "rate_limited":
+        return _placeholder("🔧 Conflict resolutions", "rate_limited")
+    if status != "ok":
+        return _placeholder("🔧 Conflict resolutions", "error")
+
+    lines = ["### 🔧 Conflict resolutions", ""]
+    auto = data.get("auto_resolved", [])
+    if auto:
+        lines.append("**Auto-committed by claude-code** — VERIFY before merging:")
+        lines.append("")
+        for item in auto:
+            lines.append(
+                f"- `{item['file']}` (commit {item['commit_sha']}): "
+                f"_{item['articulation']}_"
+            )
+        lines.append("")
+    review = data.get("needs_review", [])
+    if review:
+        lines.append(
+            "**Needs review** — conflict markers remain, operator must resolve:"
+        )
+        lines.append("")
+        for item in review:
+            lines.append(f"- `{item['file']}`: {item['reasoning']}")
+            lines.append(f"  Recommended approach: {item['recommended_resolution']}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def _render_job_b(data: dict | None, template_advanced: bool = True) -> str:
+    """Render the ✨ New features in this update section."""
+    if not template_advanced:
+        return ""  # Job B is gated; no section if refs didn't differ
+    data = _validate_job_b(data)
+    if data is None:
+        return _placeholder("✨ New features in this update", "error")
+    status = data.get("status", "error")
+    if status == "rate_limited":
+        return _placeholder("✨ New features in this update", "rate_limited")
+    if status != "ok":
+        return _placeholder("✨ New features in this update", "error")
+
+    entries = data.get("entries", [])
+    if not entries:
+        return ""  # No features = no section (rare — refs differed but changelog empty)
+
+    # Sort by PR# ascending for deterministic body across re-runs
+    # (LLM-emitted entry order may vary; canonical sort collapses that variance).
+    # `lstrip("#")` tolerates LLM-emitted prefixes like `"#89"`. `or 0` covers
+    # null values. Without coercion a single bad entry would degrade the whole
+    # section to an error placeholder via _safe_render's TypeError catch.
+    entries = sorted(
+        entries,
+        key=lambda e: int(str(e.get("pr_number") or "0").lstrip("#") or "0"),
+    )
+
+    by_class: dict[str, list[dict]] = {
+        "needs-opt-in": [],
+        "ships-automatically": [],
+        "informational": [],
+    }
+    # Map any unknown classification to "informational" so the render loop
+    # (which only iterates the three keys above) doesn't silently drop entries
+    # with off-spec classification strings (e.g., LLM emits "NEEDS-OPT-IN" or
+    # a typo). The `setdefault`-style pattern would have created a new dict
+    # key but the render loop wouldn't have visited it.
+    for e in entries:
+        cls = e.get("classification")
+        by_class[cls if cls in by_class else "informational"].append(e)
+
+    lines = ["### ✨ New features in this update", ""]
+    if by_class["needs-opt-in"]:
+        lines.append("**Needs your attention** (action-required):")
+        lines.append("")
+        for e in by_class["needs-opt-in"]:
+            lines.append(f"- #{e['pr_number']} {e['title']} — needs opt-in.")
+            lines.append(f"  {e['summary']}")
+        lines.append("")
+    if by_class["ships-automatically"]:
+        lines.append("**Ships through automatically** (informational):")
+        lines.append("")
+        for e in by_class["ships-automatically"]:
+            lines.append(f"- #{e['pr_number']} {e['title']} — applied this run")
+        lines.append("")
+    if by_class["informational"]:
+        ids = ", ".join(f"#{e['pr_number']}" for e in by_class["informational"])
+        n = len(by_class["informational"])
+        lines.append(
+            f"**Internal / no downstream effect** ({n} {'entry' if n == 1 else 'entries'}): {ids}"
+        )
+        lines.append("")
+    return "\n".join(lines)
+
+
+def _render_job_c(data: dict | None, template_advanced: bool = True) -> str:
+    """Render the 📦 Excluded-file upstream changes section."""
+    if not template_advanced:
+        return ""  # Job C is gated; no section if refs didn't differ
+    data = _validate_job_c(data)
+    if data is None:
+        return _placeholder("📦 Excluded-file upstream changes", "error")
+    status = data.get("status", "error")
+    if status == "rate_limited":
+        return _placeholder("📦 Excluded-file upstream changes", "rate_limited")
+    if status != "ok":
+        return _placeholder("📦 Excluded-file upstream changes", "error")
+
+    files = data.get("files", [])
+    if not files:
+        return ""
+
+    # Sort by file path for deterministic body across re-runs.
+    # `str(... or "")` coerces null/missing file fields without raising
+    # TypeError on mixed-type lists (the LLM may emit `"file": null` for a
+    # malformed entry). Same robustness rationale as Job B's pr_number sort.
+    files = sorted(files, key=lambda f: str(f.get("file") or ""))
+
+    by_class: dict[str, list[dict]] = {
+        "recommend-port": [],
+        "informational": [],
+        "skip": [],
+    }
+    # Map unknown classifications to "informational" — same rationale as
+    # Job B (avoid silent data loss from off-spec classification strings).
+    for f in files:
+        cls = f.get("classification")
+        by_class[cls if cls in by_class else "informational"].append(f)
+
+    lines = ["### 📦 Excluded-file upstream changes", ""]
+    if by_class["recommend-port"]:
+        lines.append("**Recommended to port** (action-required):")
+        lines.append("")
+        for f in by_class["recommend-port"]:
+            lines.append(f"- `{f['file']}`: {f['summary']}")
+            lines.append(f"  Diff: {f['diff_summary']}")
+        lines.append("")
+    if by_class["informational"]:
+        lines.append("**Informational**:")
+        lines.append("")
+        for f in by_class["informational"]:
+            lines.append(f"- `{f['file']}`: {f['summary']}")
+        lines.append("")
+    if by_class["skip"]:
+        names = ", ".join(f"`{f['file']}`" for f in by_class["skip"])
+        n = len(by_class["skip"])
+        lines.append(
+            f"**Skipped (template-internal)** ({n} {'file' if n == 1 else 'files'}): {names}"
+        )
+        lines.append("")
+    return "\n".join(lines)
+
+
+_DISABLED_NOTICE = (
+    "🔒 Agent disabled — `CLAUDE_CODE_OAUTH_TOKEN` not configured. "
+    "Set the secret in repo settings to enable."
+)
+
+
+def _disabled_section(section_title: str) -> str:
+    """Per-section placeholder when agent_enabled=False."""
+    return f"### {section_title}\n\n{_DISABLED_NOTICE}\n"
+
+
+def compose_body(inputs: AggregatorInputs) -> str:
+    """Compose the full PR body from existing #49 content + agent JSON outputs."""
+    parts = [inputs.existing_body.rstrip(), "", "---", "", "## Agent analysis", ""]
+
+    if not inputs.agent_enabled:
+        # Per-section disabled placeholders so structure is consistent across
+        # configured / not-configured runs. Each section that WOULD have run
+        # gets a skip notice; sections gated out (e.g. Job A with no conflicts)
+        # are omitted entirely.
+        if inputs.conflict_count > 0:
+            parts.append(_disabled_section("🔧 Conflict resolutions"))
+        if inputs.template_advanced:
+            parts.append(_disabled_section("✨ New features in this update"))
+            parts.append(_disabled_section("📦 Excluded-file upstream changes"))
+        return "\n".join(parts) + "\n"
+
+    # Each render is wrapped in try/except so a malformed item in one job's
+    # JSON (e.g. LLM emitted entry missing a required field) degrades to that
+    # section's error placeholder without nuking the other two sections.
+    # See spec § Aggregator's four-state contract — sections must be
+    # independently failing.
+    section_a = _safe_render(
+        "🔧 Conflict resolutions",
+        lambda: _render_job_a(_read_job_json(inputs.job_a_path), inputs.conflict_count),
+    )
+    if section_a:
+        parts.append(section_a)
+
+    section_b = _safe_render(
+        "✨ New features in this update",
+        lambda: _render_job_b(
+            _read_job_json(inputs.job_b_path), inputs.template_advanced
+        ),
+    )
+    if section_b:
+        parts.append(section_b)
+
+    section_c = _safe_render(
+        "📦 Excluded-file upstream changes",
+        lambda: _render_job_c(
+            _read_job_json(inputs.job_c_path), inputs.template_advanced
+        ),
+    )
+    if section_c:
+        parts.append(section_c)
+
+    return "\n".join(parts) + "\n"
+
+
+def _safe_render(section_title: str, render_fn: Callable[[], str]) -> str:
+    """Run render_fn; on any exception, return that section's error placeholder.
+
+    Per-section isolation: a render-time crash on one job (e.g. KeyError from a
+    malformed item) must not affect the other two job sections. The render
+    callable is invoked and its result returned; only on exception do we
+    substitute an error placeholder.
+    """
+    try:
+        return render_fn()
+    except (KeyError, TypeError, ValueError, AttributeError):
+        return _placeholder(section_title, "error")
+
+
+BODY_LIMIT = 60_000
+SECTION_MARKERS = ["### 🔧 ", "### ✨ ", "### 📦 "]
+
+
+def compose_body_with_overflow(
+    inputs: AggregatorInputs, overflow_dir: Path
+) -> tuple[str, list[Path]]:
+    """Compose body; if > BODY_LIMIT chars, spill longest section(s) to overflow files.
+
+    Returns (body, overflow_paths). overflow_paths is empty if no spill occurred.
+    Each overflow path holds the displaced section content (caller posts as comments).
+    """
+    body = compose_body(inputs)
+    if len(body) <= BODY_LIMIT:
+        return body, []
+
+    overflow_dir.mkdir(parents=True, exist_ok=True)
+    overflow_paths: list[Path] = []
+    spill_index = 0
+    # Track which markers have already been spilled so a later iteration
+    # doesn't re-pick the (now-tiny) replacement section as longest. Without
+    # this guard, the replacement (still beginning with "### …") would match
+    # the section finder forever, producing useless overflow files of stub
+    # content while the loop spins.
+    spilled_markers: set[str] = set()
+
+    while len(body) > BODY_LIMIT:
+        # Find each not-yet-spilled section's start + length.
+        sections: list[tuple[str, int, int]] = []  # (header, start, end)
+        for marker in SECTION_MARKERS:
+            if marker in spilled_markers:
+                continue
+            start = body.find(marker)
+            if start == -1:
+                continue
+            # Section ends at the start of the NEXT known SECTION_MARKER, or
+            # EOF. Don't bare-find `\n### ` — agent-supplied text inside a
+            # section (Job A articulation, Job B/C summaries) may legitimately
+            # contain `### Sub-header` lines that would otherwise be mistaken
+            # for a section boundary, splitting the section prematurely.
+            other_starts = [
+                body.find(m, start + len(marker))
+                for m in SECTION_MARKERS
+                if m != marker
+            ]
+            other_starts = [s for s in other_starts if s != -1]
+            end = min(other_starts) if other_starts else len(body)
+            sections.append((marker, start, end))
+
+        if not sections:
+            # All agent sections already spilled; can't reduce further
+            # (existing #49 body alone exceeds the limit). Bail.
+            break
+
+        sections.sort(key=lambda s: s[2] - s[1], reverse=True)
+        marker, start, end = sections[0]
+        spilled_markers.add(marker)
+        spill_index += 1
+        overflow_path = overflow_dir / f"overflow-{spill_index}.md"
+        overflow_path.write_text(body[start:end], encoding="utf-8")
+        overflow_paths.append(overflow_path)
+
+        # Capture the FULL heading line (`### 🔧 Conflict resolutions`) so the
+        # replacement preserves the section-name signal, then strip the `### `
+        # prefix for the bold replacement (which intentionally uses non-`###`
+        # so the section finder skips it on subsequent iterations).
+        heading_end = body.find("\n", start)
+        if heading_end == -1:
+            heading_end = end
+        full_heading = body[start:heading_end].lstrip("# ").rstrip()
+        replacement = (
+            f"**{full_heading} — full analysis posted as a "
+            f"follow-up comment (overflow #{spill_index}).**\n\n"
+        )
+        body = body[:start] + replacement + body[end:]
+
+    return body, overflow_paths
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Compose copier-update PR body from agent JSON outputs."
+    )
+    p.add_argument(
+        "--existing-body",
+        type=Path,
+        required=True,
+        help="Path to the existing #49-shaped body markdown.",
+    )
+    p.add_argument("--agent-enabled", choices=["true", "false"], required=True)
+    p.add_argument(
+        "--job-a",
+        type=Path,
+        default=None,
+        help="Path to /tmp/agent-job-a.json (or absent).",
+    )
+    p.add_argument("--job-b", type=Path, default=None)
+    p.add_argument("--job-c", type=Path, default=None)
+    p.add_argument("--conflict-count", type=int, required=True)
+    p.add_argument(
+        "--template-advanced",
+        choices=["true", "false"],
+        default="true",
+        help="Whether the template ref changed; gates Jobs B/C section rendering.",
+    )
+    p.add_argument(
+        "--output-body", type=Path, required=True, help="Where to write composed body."
+    )
+    p.add_argument(
+        "--overflow-dir",
+        type=Path,
+        required=True,
+        help="Directory for overflow comment files.",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    inputs = AggregatorInputs(
+        existing_body=args.existing_body.read_text(encoding="utf-8"),
+        agent_enabled=(args.agent_enabled == "true"),
+        job_a_path=args.job_a,
+        job_b_path=args.job_b,
+        job_c_path=args.job_c,
+        conflict_count=args.conflict_count,
+        template_advanced=(args.template_advanced == "true"),
+    )
+    body, overflow_paths = compose_body_with_overflow(
+        inputs, overflow_dir=args.overflow_dir
+    )
+    args.output_body.write_text(body, encoding="utf-8")
+    if overflow_paths:
+        for p in overflow_paths:
+            print(f"OVERFLOW: {p}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/copier_update_aggregator.py
+++ b/scripts/copier_update_aggregator.py
@@ -2,12 +2,12 @@
 
 Reads /tmp/agent-job-{a,b,c}.json (or paths passed via CLI), validates each
 against an inline schema, and composes a markdown PR body that extends the
-existing #49-shaped body (delta/notes/diff/conflicts) with three new sections
+existing PR-body content (delta/notes/diff/conflicts) with three new sections
 (conflict resolutions, changelog triage, excluded-file evolution).
 
 Failure-tolerant: missing/skipped/rate-limited/errored agent outputs render
-as state-specific placeholders without affecting other sections. The existing
-#49 sections always render regardless of agent state.
+as state-specific placeholders without affecting other sections. The
+existing PR-body sections always render regardless of agent state.
 
 Exit codes:
 - 0: composed body written successfully (even if some sections are placeholders)
@@ -164,9 +164,11 @@ def _render_job_b(data: dict | None, template_advanced: bool = True) -> str:
 
     # Sort by PR# ascending for deterministic body across re-runs
     # (LLM-emitted entry order may vary; canonical sort collapses that variance).
-    # `lstrip("#")` tolerates LLM-emitted prefixes like `"#89"`. `or 0` covers
-    # null values. Without coercion a single bad entry would degrade the whole
-    # section to an error placeholder via _safe_render's TypeError catch.
+    # `lstrip("#")` tolerates LLM-emitted prefixes like `"#89"`. `or "0"` covers
+    # null values — and also a literal `pr_number: 0` (falsy in Python). Since
+    # PR #0 does not exist on GitHub, conflating it with null here is safe.
+    # Without coercion a single bad entry would degrade the whole section to an
+    # error placeholder via _safe_render's TypeError catch.
     entries = sorted(
         entries,
         key=lambda e: int(str(e.get("pr_number") or "0").lstrip("#") or "0"),
@@ -280,7 +282,7 @@ def _disabled_section(section_title: str) -> str:
 
 
 def compose_body(inputs: AggregatorInputs) -> str:
-    """Compose the full PR body from existing #49 content + agent JSON outputs."""
+    """Compose the full PR body from existing PR-body content + agent JSON outputs."""
     parts = [inputs.existing_body.rstrip(), "", "---", "", "## Agent analysis", ""]
 
     if not inputs.agent_enabled:
@@ -338,7 +340,11 @@ def _safe_render(section_title: str, render_fn: Callable[[], str]) -> str:
     """
     try:
         return render_fn()
-    except (KeyError, TypeError, ValueError, AttributeError):
+    except (KeyError, IndexError, TypeError, ValueError, AttributeError):
+        # IndexError is defensive — current render paths access items by key
+        # (raising KeyError, already caught), but a future render that indexes
+        # into a list field would raise IndexError on empty input. Including it
+        # here keeps per-section isolation honest if such a path is added.
         return _placeholder(section_title, "error")
 
 
@@ -393,7 +399,7 @@ def compose_body_with_overflow(
 
         if not sections:
             # All agent sections already spilled; can't reduce further
-            # (existing #49 body alone exceeds the limit). Bail.
+            # (existing PR body alone exceeds the limit). Bail.
             break
 
         sections.sort(key=lambda s: s[2] - s[1], reverse=True)
@@ -429,7 +435,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--existing-body",
         type=Path,
         required=True,
-        help="Path to the existing #49-shaped body markdown.",
+        help="Path to the existing PR-body markdown.",
     )
     p.add_argument("--agent-enabled", choices=["true", "false"], required=True)
     p.add_argument(

--- a/scripts/copier_update_prompts/job_a.md
+++ b/scripts/copier_update_prompts/job_a.md
@@ -69,7 +69,7 @@ git add <files-you-modified>
 # the PR branch under the auto-resolve commit.
 git diff --cached --name-only
 
-git commit -m "auto-resolve N trivial conflicts (claude-code)" --author="claude-code <claude-code@anthropic.com>"
+git commit -m "auto-resolve N trivial conflicts (claude-code)" --author="github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
 ```
 
 Capture the commit SHA via `git rev-parse HEAD`.

--- a/scripts/copier_update_prompts/job_a.md
+++ b/scripts/copier_update_prompts/job_a.md
@@ -1,0 +1,126 @@
+<!-- scripts/copier_update_prompts/job_a.md -->
+# Job A: copier-update conflict resolution
+
+You are an agent helping an operator review a `copier-update` PR for the
+`scholar-mcp` downstream consumer of the `pvliesdonk/fastmcp-server-template`.
+
+## Context
+
+The template was advanced from `${PREVIOUS_COMMIT}` to `${NEW_REF}`. `copier
+update --conflict=inline` ran and left conflict markers in some files because
+copier's 3-way merge could not auto-resolve them. Your job is to triage these
+conflicts: auto-commit the trivial mechanical ones, and write analysis comments
+for the rest.
+
+You have access to:
+- The downstream working tree at the current branch state (with conflict markers).
+- A clone of the template repo at `/tmp/template`. Use `git -C /tmp/template
+  checkout ${PREVIOUS_COMMIT}` and `git -C /tmp/template checkout ${NEW_REF}`
+  to inspect the template's state at either ref.
+
+## Conflict files
+
+The following files contain `<<<<<<< before updating ... >>>>>>>` markers:
+
+${CONFLICT_FILES_LIST}
+
+## Per-conflict task
+
+For each `<<<<<<<` / `>>>>>>>` region in each conflict file, decide one of:
+
+### Auto-resolvable
+
+A conflict is **auto-resolvable** if and only if you can articulate the precise
+transformation that resolves it in **one sentence** with **no ambiguity** about
+which downstream lines belong where. Examples of articulations that pass this
+bar:
+
+- "Moved 12 lines of `remote OIDC mode` customisation from a mid-file location
+  into the new `DOMAIN-OIDC-EXTRA` block at end-of-file; template body accepted
+  unchanged."
+- "Renamed sentinel marker `DOMAIN-DOCKER-START` to `DOMAIN-DOCKER-EXTRA-START`
+  to match the template's new naming convention; downstream content unchanged."
+
+If you cannot articulate the transformation in one sentence — or if there is any
+ambiguity about which downstream lines should go where — the conflict is NOT
+auto-resolvable.
+
+For auto-resolvable conflicts: write the resolved file to disk (replacing the
+conflict markers and surrounding region with the final content). Do NOT commit
+yet — accumulate auto-resolutions and commit once at the end.
+
+### Needs review
+
+For non-auto-resolvable conflicts: leave the markers in place. Write a
+`recommended_resolution` (one paragraph, concrete) and `reasoning` (one
+paragraph, explains why it can't be auto-resolved).
+
+## Final commit
+
+If you applied any auto-resolutions, run **once** at the end:
+
+```bash
+git add <files-you-modified>
+
+# Verify ONLY the conflict files you intended to stage are staged.
+# The list below MUST be a subset of CONFLICT_FILES_LIST. If it isn't,
+# something else got staged — abort, do NOT commit, and report status
+# error in the JSON. Anything else risks pushing unrelated edits to
+# the PR branch under the auto-resolve commit.
+git diff --cached --name-only
+
+git commit -m "auto-resolve N trivial conflicts (claude-code)" --author="claude-code <claude-code@anthropic.com>"
+```
+
+Capture the commit SHA via `git rev-parse HEAD`.
+
+## Output
+
+Write the following JSON to `/tmp/agent-job-a.json` (NOT to stdout — write the file):
+
+```json
+{
+  "status": "ok",
+  "auto_resolved": [
+    {
+      "file": "docs/deployment/oidc.md",
+      "region": "L42-L78",
+      "articulation": "Moved 12 lines of remote OIDC mode customisation into the new DOMAIN-OIDC-EXTRA block; template body accepted unchanged.",
+      "commit_sha": "abc1234"
+    }
+  ],
+  "needs_review": [
+    {
+      "file": "docs/guides/authentication.md",
+      "region": "L120-L145",
+      "recommended_resolution": "Lift the renamed anchor `#known-limitations-oidc-session-lifetime` into the EXTRA block while accepting the template's anchor in the body.",
+      "reasoning": "Conflict is between template's new MCP OAuth refresh section content and downstream's renamed cross-reference anchor. The rename affects three internal links so resolving requires choosing between (a) preserving the rename and updating template-body links to match, or (b) reverting to template anchor and dropping the rename. Operator preference."
+    }
+  ]
+}
+```
+
+If you encounter an unrecoverable error (e.g. file unreadable, git commit
+failed), write `{"status": "error", "message": "<one-line description>"}`
+instead and exit. If you receive a 429 / rate-limit response from any tool,
+write `{"status": "rate_limited", "message": "<details>"}`.
+
+The aggregator that consumes this JSON validates schema strictly. Any
+deviation from the shapes above will cause the section to render as
+"Agent failed" in the PR body.
+
+## Constraints
+
+- Tool access: file read/write on the working tree, file read on `/tmp/template`,
+  `git -C /tmp/template <subcommand>`, `git status`, `git diff`, `git add <path>`,
+  `git commit -m '<msg>'`. NO `git push`, NO branch operations, NO network calls.
+- Do not modify files outside the conflict files listed above.
+- Sentinel-block awareness: lines inside `<!-- DOMAIN-*-START -->` ... `<!-- DOMAIN-*-END -->`,
+  `<!-- PROJECT-*-START -->` ... `<!-- PROJECT-*-END -->`, `# CONFIG-*-START` ...
+  `# CONFIG-*-END`, `# PROJECT-*-START` ... `# PROJECT-*-END` are downstream-owned by
+  contract. When resolving conflicts inside these blocks, take the downstream side
+  unless there is a clear template-side correction (e.g. the marker name itself
+  was renamed by the template).
+
+If the auto-resolved list is empty (no trivial cases found), do NOT make any
+git commit; the `auto_resolved` array in the JSON is `[]`.

--- a/scripts/copier_update_prompts/job_b.md
+++ b/scripts/copier_update_prompts/job_b.md
@@ -1,0 +1,81 @@
+<!-- scripts/copier_update_prompts/job_b.md -->
+# Job B: copier-update changelog triage
+
+You are an agent helping an operator review a `copier-update` PR for the
+`scholar-mcp` downstream consumer of `pvliesdonk/fastmcp-server-template`.
+
+## Context
+
+The template was advanced from `${PREVIOUS_COMMIT}` to `${NEW_REF}`. The
+template's `CHANGELOG.md` between these two refs has new entries the operator
+hasn't seen before. Your job is to triage each entry: classify it by
+operator-relevance and write a one-paragraph summary.
+
+You have read-only access to:
+- A clone of the template repo at `/tmp/template`. Read
+  `/tmp/template/CHANGELOG.md` at the new ref.
+- The downstream working tree (read-only — do not modify).
+
+## Per-entry task
+
+For each entry in the CHANGELOG between `${PREVIOUS_COMMIT}` (exclusive) and
+`${NEW_REF}` (inclusive), classify as one of three:
+
+- **`ships-automatically`** — the change is in a template-owned file (NOT in
+  `_skip_if_exists`). Downstream gets it via this `copier update` with no
+  further action. Examples: new env var documented in `docs/configuration.md`
+  (template-owned), workflow change in `release.yml.jinja`.
+
+- **`needs-opt-in`** — downstream must wire something to benefit. Examples:
+  template wires a new helper in a `_skip_if_exists` file (`_server_deps.py`,
+  `tools.py`, etc.); template adds a new copier variable that defaults to a
+  conservative value but downstream may want to override; template adds a new
+  scaffold file that downstream may want to populate.
+
+- **`informational`** — internal template-side change with no downstream-facing
+  effect. Examples: changes to `template-ci.yml`, release-pipeline plumbing,
+  repo-internal docs (`docs/superpowers/`), CHANGELOG-only edits.
+
+## Reading copier.yml to disambiguate
+
+To decide between `ships-automatically` and `needs-opt-in`, read
+`/tmp/template/copier.yml` at `${NEW_REF}` and check `_skip_if_exists` and
+`_exclude`. Files listed in `_skip_if_exists` are downstream-owned starter
+files — changes in those files do NOT flow to downstream automatically.
+
+## Output
+
+Write the following JSON to `/tmp/agent-job-b.json`:
+
+```json
+{
+  "status": "ok",
+  "entries": [
+    {
+      "pr_number": 89,
+      "title": "wire register_server_info_tool",
+      "classification": "needs-opt-in",
+      "summary": "The template now wires `get_server_info` (via `register_server_info_tool`) by default in `make_server()`. This change ships through automatically since `server.py.jinja` is template-owned. To wire upstream version reporting, populate the DOMAIN-UPSTREAM sentinel inside the call. See template's CLAUDE.md `## Server Info Tool` section."
+    }
+  ]
+}
+```
+
+If the CHANGELOG between the two refs is empty (template advanced without
+publishing CHANGELOG entries — unusual), write `{"status": "ok", "entries": []}`.
+
+If you encounter an unrecoverable error, write
+`{"status": "error", "message": "<details>"}`. If rate-limited, write
+`{"status": "rate_limited", "message": "<details>"}`.
+
+## Constraints
+
+- Tool access: file read on `/tmp/template`, `git -C /tmp/template log` and
+  `git -C /tmp/template show`, `git -C /tmp/template checkout <ref>`. NO file
+  writes (other than the output JSON), NO git commits, NO network calls.
+- Use the CHANGELOG.md content directly. Do not infer entries from `git log`
+  alone — if a PR isn't in the CHANGELOG, it's not in scope (the CHANGELOG is
+  managed by python-semantic-release and is the canonical operator-facing
+  feed).
+- Per-entry summaries should be operator-actionable: tell the operator what
+  they got, why it matters, and what (if anything) they should do.

--- a/scripts/copier_update_prompts/job_c.md
+++ b/scripts/copier_update_prompts/job_c.md
@@ -1,0 +1,82 @@
+<!-- scripts/copier_update_prompts/job_c.md -->
+# Job C: copier-update excluded-file evolution
+
+You are an agent helping an operator review a `copier-update` PR for the
+`scholar-mcp` downstream consumer of `pvliesdonk/fastmcp-server-template`.
+
+## Context
+
+Some files in the template are listed under `_exclude` in `copier.yml` — they
+exist as `.jinja` source in the template repo for maintainer reference but are
+NEVER rendered to downstream. Examples: `tests/test_tools.py`, `docs/design.md`.
+
+Downstream often has its own version of these files (created at scaffold time,
+or hand-written later). Because the template doesn't render these to
+downstream, the upstream `.jinja` source can evolve without any changes
+flowing through. This job triages whether downstream's local copy of any such
+file would benefit from porting the upstream evolution.
+
+You have read-only access to:
+- A clone of the template repo at `/tmp/template`. Use `git -C /tmp/template
+  diff ${PREVIOUS_COMMIT}..${NEW_REF} -- <path>` to see what changed.
+- The downstream working tree at the current state (read-only — to inspect
+  the local copy).
+
+## Per-file task
+
+Read `/tmp/template/copier.yml` at `${NEW_REF}` to get the `_exclude` list.
+For each entry that is a `.jinja`-suffixed FILE (skip directory globs like
+`docs/superpowers`, stock excludes like `.git` / `*.pyc` / `~*`, and
+non-`.jinja` files like `uv.lock`):
+
+1. Run: `git -C /tmp/template diff ${PREVIOUS_COMMIT}..${NEW_REF} -- <path>`
+2. If the diff is empty → skip (not in output).
+3. If non-empty, classify the diff:
+   - **`recommend-port`** — the change adds operator-relevant value (new
+     test case, doc improvement, bug fix in a script). Downstream's local
+     copy of this file would benefit from porting the change manually.
+   - **`skip`** — template-maintainer concern only. Downstream doesn't need
+     to do anything (e.g. internal refactor, comment cleanup, change to a
+     test that downstream doesn't have).
+   - **`informational`** — small change with mixed value; downstream might
+     find it interesting but no clear action recommended.
+
+For each non-skipped file, also write `summary` (one sentence on what
+changed) and `diff_summary` (terse — line counts, function names changed,
+etc.; max ~80 chars).
+
+## Output
+
+Write to `/tmp/agent-job-c.json`:
+
+```json
+{
+  "status": "ok",
+  "files": [
+    {
+      "file": "tests/test_tools.py",
+      "classification": "recommend-port",
+      "summary": "Template added a smoke test for the new register_server_info_tool helper that downstream's local test_tools.py doesn't have.",
+      "diff_summary": "+15 lines test fixture for get_server_info"
+    }
+  ]
+}
+```
+
+If no excluded files evolved between the two refs, write
+`{"status": "ok", "files": []}`.
+
+If unrecoverable error: `{"status": "error", "message": "..."}`.
+If rate-limited: `{"status": "rate_limited", "message": "..."}`.
+
+## Constraints
+
+- Tool access: file read, `git -C /tmp/template log` / `diff` / `show` /
+  `checkout`. NO file writes (other than the output JSON), NO git commits,
+  NO network calls.
+- Skip directory globs in `_exclude`. Only process individual file paths
+  ending in `.jinja`.
+- The downstream working tree may not contain the same paths the template's
+  `_exclude` references (e.g. downstream may have deleted their `tests/test_tools.py`).
+  When that's the case, still report the upstream evolution but note in the
+  summary that downstream doesn't currently have a local copy.


### PR DESCRIPTION
## Summary

Step 4 of the stepwise v1.2.0 → v1.6.1 template update sequence.

**Adoptions**:

- **`copier-update.yml`** — claude-code agent wiring: three agent jobs (A: conflict resolution, B: drift detection, C: rich PR-body composition) plus the aggregator (`scripts/copier_update_aggregator.py`, 484 lines) and three prompt files (`scripts/copier_update_prompts/job_{a,b,c}.md`, ~280 lines). Gracefully degrades when `CLAUDE_CODE_OAUTH_TOKEN` is not set — agent steps skip with a `::notice::`, plain PR body is used. We don't currently have that secret set; bodies will stay plain until/unless we add it.
- **Three doc sentinels** — `DOMAIN-AUTH-EXTRA` in `docs/guides/authentication.md`, `DOMAIN-OIDC-EXTRA` in `docs/deployment/oidc.md`, `DOMAIN-DOCKER-EXTRA` in `docs/deployment/docker.md`. Empty placeholders for future project-specific notes.

**One conflict, resolved**:

- `docs/deployment/docker.md`: kept our detailed `APP_UID`/`APP_GID` build-args content + Image tags table (matches what our Dockerfile actually exposes) over the template's brief `PUID`/`PGID` env-var phrasing (would have been incorrect). Appended the new `DOMAIN-DOCKER-EXTRA` sentinel block at the end.

**One local deviation from template** (filed upstream as pvliesdonk/fastmcp-server-template#126):

- Renamed workflow step `Build #49 body content` → `Build PR body content`. The template's `#49` is an internal tracking reference that GitHub renders as a live hyperlink to the downstream's *unrelated* issue #49 in workflow run logs — confusing UX. The rename will sync cleanly once the upstream fix lands.

Closes #188

## Test plan

- [x] `uv run ruff check .` / `ruff format --check .` / `mypy src/ tests/` — clean
- [x] `uv run pytest -x -q` — 1037 passed
- [x] `uv run pre-commit run` — all hooks pass
- [x] Aggregator script `scripts/copier_update_aggregator.py` — stdlib-only imports (no `uv sync` dependency in the workflow environment), ruff/format clean
- [x] Workflow `if:` gating manually traced through the secret-not-set path: `agent-prereq` → `agent_enabled=false` → all 3 agent steps skip → aggregator falls back to `/tmp/aggregator/existing-body.md`
- [x] `Dockerfile` cross-check: uses `ARG APP_UID=1000` / `ARG APP_GID=1000` (lines 30-40), matches our kept docs content
- [x] Local-review circus: both reviewers clean after addressing the `#49` stale-reference finding

🤖 Generated with [Claude Code](https://claude.com/claude-code)