### PR TITLE
chore(copier): update template from v1.4.0 to v1.5.0

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by `copier update`.
-_commit: v1.4.0
+_commit: v1.5.0
 _src_path: https://github.com/pvliesdonk/fastmcp-server-template
 docker_registry: ghcr.io/pvliesdonk
 domain_description: FastMCP server for Semantic Scholar with OpenAlex enrichment and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,8 @@ The config is in `_skip_if_exists`, so domain-specific additions (shellcheck, ya
 
 Trivial exceptions: pure typo fixes and automated dependency bumps (Dependabot / Renovate) may skip the issue.
 
+**Bot reviewers (claude-review, gemini-code-assist) are merge gates, not pair reviewers.** Local review must be complete before the PR opens. If a bot finds anything on first run, the local review was incomplete — that is a discipline failure to investigate, not "address-and-move-on." Run a local code-review pass on the cumulative diff before `gh pr create`; the bots are not a substitute.
+
 ## GitHub Review Types
 
 GitHub has two distinct review mechanisms — **both must be read and addressed**:

--- a/README.md
+++ b/README.md
@@ -131,6 +131,45 @@ Core environment variables shared across all `fastmcp-pvl-core`-based services:
 
 Domain-specific variables go below under [Domain configuration](#domain-configuration).
 
+## Authorization (opt-in)
+
+This server inherits opt-in per-subject authorization from `fastmcp-pvl-core`.  The default posture is **off** — every authenticated caller can use every tool, resource, and prompt.  Turn it on by pointing `SCHOLAR_MCP_ACL_PATH` at a TOML ACL file; the middleware is installed only when the path is set, and individual tools opt in by declaring `meta={"required_scope": "<scope>"}` at registration.  A tool without `required_scope` is unrestricted regardless of caller.
+
+Wire it in by uncommenting the `acl_path` field in `src/scholar_mcp/config.py` and the `AuthorizationMiddleware` stanza in `src/scholar_mcp/server.py` — both ship as commented stubs in the scaffold.
+
+### ACL TOML schema
+
+```toml
+[subjects]
+"user:alice@example.com" = ["read", "write"]
+"user:admin@example.com" = ["*"]              # wildcard — any required scope passes
+"service:ci-bot"         = ["read"]
+"local"                  = ["*"]              # auth-disabled subject (no bearer / OIDC vars set)
+```
+
+- **Subject strings are opaque.** The `<kind>:<id>` convention is documentation only; the library treats each subject as a literal string.
+- **`*` is the only library-treated special scope** — it grants every required scope.  Subject-side wildcards (`*` as an ACL key) are rejected at load time.
+- **Scope vocabulary is domain-defined.** Per-project or per-folder gating is encoded into the scope string itself (e.g. `read:project-foo`, `write:vault/personal`); `fastmcp-pvl-core` treats every scope except `*` as opaque.
+
+### Subject ↔ bearer-token alignment
+
+The subject string used as a *value* in the bearer-tokens TOML (`SCHOLAR_MCP_BEARER_TOKENS_FILE`) is the same string used as a *key* in the ACL TOML.  Same string, opposite roles — keep the two files consistent when adding or removing a principal.  See [Mapped bearer tokens](docs/guides/authentication.md#mapped-bearer-tokens-multi-subject) in the authentication guide for the bearer-tokens TOML schema.
+
+In single-token mode (`SCHOLAR_MCP_BEARER_TOKEN`) every authenticated caller shares one subject — the library's default (currently `"bearer-anon"`), override with `SCHOLAR_MCP_BEARER_DEFAULT_SUBJECT`; reference *that* string as the ACL key.  When no auth is configured (no `SCHOLAR_MCP_BEARER_TOKEN`, `SCHOLAR_MCP_BEARER_TOKENS_FILE`, or OIDC env vars set — common in stdio dev rigs but also possible on HTTP), every request resolves to the literal subject `"local"` — reference that string as the ACL key for un-authenticated local sessions.
+
+### Load semantics
+
+The ACL file is loaded **once at server startup**.  Restart the server to pick up changes; live reload is not part of the initial implementation.  `load_acl` fails fast with `ConfigurationError` on every malformed condition, so a typo in the ACL file aborts startup rather than silently denying requests.
+
+### Privacy default
+
+Denied requests are logged at WARNING with the subject string for audit attribution.  The wire-side error payload **omits** the subject by default to limit cross-user information disclosure.  For internal-only servers where the subject is safe to surface to clients, construct the middleware with `AuthorizationMiddleware(..., expose_subject_in_error=True)`.
+
+### See also
+
+- [fastmcp-pvl-core README — Authorization](https://github.com/pvliesdonk/fastmcp-pvl-core#authorization-opt-in--authorizationmiddleware) — full design, the `check_authorization` per-call helper, and per-token subject mapping.
+- [Authorization submodule spec](https://github.com/pvliesdonk/fastmcp-pvl-core/blob/main/docs/specs/authorization-submodule.md) — design rationale and deviations table.
+
 ## GitHub secrets
 
 CI workflows reference three repository secrets. Configure them via **Settings → Secrets and variables → Actions** or with `gh secret set`:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -114,7 +114,9 @@ When both bearer and OIDC auth are configured, the server uses multi-auth — ei
 
 | Variable | Default | Description |
 |---|---|---|
-| `SCHOLAR_MCP_BEARER_TOKEN` | -- | Static bearer token. When set, HTTP clients must send `Authorization: Bearer <token>`. |
+| `SCHOLAR_MCP_BEARER_TOKEN` | -- | Static bearer token. When set, HTTP clients must send `Authorization: Bearer <token>`. Every authenticated caller shares one subject (see `SCHOLAR_MCP_BEARER_DEFAULT_SUBJECT`). |
+| `SCHOLAR_MCP_BEARER_TOKENS_FILE` | -- | Path to a TOML file mapping bearer tokens to per-caller subjects. When set, takes precedence over `SCHOLAR_MCP_BEARER_TOKEN`. See [Mapped bearer tokens](guides/authentication.md#mapped-bearer-tokens-multi-subject) in the authentication guide. |
+| `SCHOLAR_MCP_BEARER_DEFAULT_SUBJECT` | `bearer-anon` | Single-token-mode subject string. Used as the ACL key when wiring opt-in authorization. |
 | `SCHOLAR_MCP_AUTH_MODE` | *(auto)* | Force auth mode: `remote` or `oidc-proxy`. When unset, auto-detected from which OIDC env vars are present. |
 | `SCHOLAR_MCP_BASE_URL` | -- | Public base URL of this server (e.g. `https://mcp.example.com`). Required for both OIDC modes. |
 | `SCHOLAR_MCP_OIDC_CONFIG_URL` | -- | OIDC discovery endpoint URL (e.g. `https://auth.example.com/.well-known/openid-configuration`). |
@@ -124,6 +126,7 @@ When both bearer and OIDC auth are configured, the server uses multi-auth — ei
 | `SCHOLAR_MCP_OIDC_AUDIENCE` | -- | Expected JWT audience claim. When set, the token's `aud` must match. Used by both modes. |
 | `SCHOLAR_MCP_OIDC_REQUIRED_SCOPES` | `openid` | Comma-separated required scopes (e.g. `openid,profile`). Used by both modes. |
 | `SCHOLAR_MCP_OIDC_VERIFY_ACCESS_TOKEN` | `false` | (`oidc-proxy` only) Set `true` to verify the upstream `access_token` as a JWT instead of the `id_token`. Use when your provider issues JWT access tokens. |
+| `SCHOLAR_MCP_ACL_PATH` | -- | (scaffold) Path to a TOML ACL file enabling opt-in per-subject authorization. Requires uncommenting the matching scaffold in `src/scholar_mcp/config.py` and `src/scholar_mcp/server.py`; see [Authorization (opt-in)](https://github.com/pvliesdonk/scholar-mcp#authorization-opt-in) in the README. |
 
 See [Authentication guide](guides/authentication.md) for setup instructions and [OIDC deployment](deployment/oidc.md) for provider-specific configuration.
 
@@ -157,3 +160,10 @@ Rate limiting is automatic and not configurable:
 - **With API key**: ~0.1s between Semantic Scholar requests
 - **Without API key**: ~1.1s between requests
 - **Retry**: automatic exponential backoff on HTTP 429 (up to 3 retries)
+
+<!-- DOMAIN-CONFIG-VARS-START -->
+<!-- Future project-specific config notes go here; kept across copier
+     update. Scholar's domain config is already documented in the
+     per-domain sections above (Core, PDF Conversion, EPO, Google Books,
+     Server, Authentication, Cache TTLs, Rate Limiting). -->
+<!-- DOMAIN-CONFIG-VARS-END -->

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -62,6 +62,21 @@ Authorization: Bearer your-generated-token
 - Development and testing environments
 - Any scenario where full OIDC is overkill
 
+### Mapped bearer tokens (multi-subject)
+
+The bearer-token mode above shares one subject across every authenticated caller — by default the library's `bearer-anon`, override with `SCHOLAR_MCP_BEARER_DEFAULT_SUBJECT`.  For audit logs and authorization that distinguish callers, switch to mapped-token mode by pointing `SCHOLAR_MCP_BEARER_TOKENS_FILE` at a TOML file:
+
+```toml
+# tokens.toml
+[tokens]
+"ghp_alice_xxxxxxxx" = "user:alice@example.com"
+"sk_ci_yyyyyyyy"     = "service:ci-bot"
+```
+
+Each token resolves to a distinct subject string for downstream attribution.  Subject strings are opaque — the `<kind>:<id>` convention (`user:`, `service:`, `token:`) is documentation only.  When `BEARER_TOKENS_FILE` is set it overrides `BEARER_TOKEN` (a `WARNING` is logged if both are present).  A missing or malformed file aborts startup with `ConfigurationError` rather than silently denying every request.
+
+For the per-tool authorization that consumes these subjects, see the **Authorization (opt-in)** section of the project [README](https://github.com/pvliesdonk/scholar-mcp#authorization-opt-in).
+
 ---
 
 ## Remote auth

--- a/docs/index.md
+++ b/docs/index.md
@@ -92,3 +92,16 @@ See [Installation](installation.md) for all methods including Linux packages.
 - [Claude Code plugin](guides/claude-code-plugin.md) -- install as a Claude Code plugin
 - [Claude Desktop setup](guides/claude-desktop.md) -- get started with Claude Desktop
 - [Docker deployment](deployment/docker.md) -- production Docker Compose setup
+
+<!-- DOMAIN-INDEX-FEATURES-START -->
+<!-- Future template-managed features section; kept across copier update.
+     Scholar's feature list is already documented in the "What it does"
+     body above (Papers / Patents / Books / Standards / Cross-source
+     Utility / PDF conversion / Async task queue). -->
+<!-- DOMAIN-INDEX-FEATURES-END -->
+
+<!-- DOMAIN-INDEX-USE-CASES-START -->
+<!-- Future template-managed use-cases section; kept across copier update.
+     Scholar's use cases are covered in the README "What you can do with it"
+     section and the Guides index. -->
+<!-- DOMAIN-INDEX-USE-CASES-END -->

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -81,3 +81,10 @@ cd scholar-mcp
 uv sync --extra dev --extra mcp
 uv run scholar-mcp serve
 ```
+
+<!-- DOMAIN-INSTALL-EXTRA-START -->
+<!-- Future template-managed install-extras section; kept across copier
+     update. Scholar's install steps are already documented in the
+     per-method sections above (uvx / pip / Docker / Linux packages /
+     from source). -->
+<!-- DOMAIN-INSTALL-EXTRA-END -->

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -4,12 +4,6 @@ MCP prompts are reusable prompt templates exposed to clients. The scaffold
 ships a minimal set defined in `src/scholar_mcp/_server_prompts.py`; add
 domain-specific prompts there and document them in this page.
 
-## Built-in prompts
-
-_None in the scaffold._ Define prompts with `@mcp.prompt(...)` decorators in
-`src/scholar_mcp/_server_prompts.py` and list them here with their arguments,
-usage, and example output.
-
 ## Example
 
 ```python
@@ -21,3 +15,11 @@ def summarize(topic: str) -> str:
 
 See the [FastMCP prompts documentation](https://gofastmcp.com/servers/prompts)
 for the full prompt API.
+
+<!-- DOMAIN-PROMPTS-LIST-START -->
+## Built-in prompts
+
+_None in the scaffold._ Define prompts with `@mcp.prompt(...)` decorators in
+`src/scholar_mcp/_server_prompts.py` and list them here with their arguments,
+usage, and example output.
+<!-- DOMAIN-PROMPTS-LIST-END -->

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -2,6 +2,8 @@
 
 Scholar MCP provides 28 tools organised by scholarly source type: **Papers**, **Patents**, **Books**, and **Standards** are peer source domains; the remaining sections (Cross-source Utility, PDF Conversion, Task Polling) are cross-cutting. All tools return JSON.
 
+<!-- DOMAIN-TOOLS-LIST-START -->
+
 !!! info "Coverage by domain"
     Per-domain depth is uneven — papers currently have the richest tool surface (citation graph, recommendations, cross-referencing to all three other domains); standards are the leanest. That reflects public data availability, not a value hierarchy. Parity work is tracked in [GitHub issues](https://github.com/pvliesdonk/scholar-mcp/issues) and [milestones](https://github.com/pvliesdonk/scholar-mcp/milestones).
 
@@ -752,3 +754,4 @@ The `hint` field gives expected duration — keep polling until the task complet
 List all active (non-expired) background tasks.
 
 **Returns:** JSON list of `{"task_id": "...", "status": "..."}` dicts.
+<!-- DOMAIN-TOOLS-LIST-END -->

--- a/src/scholar_mcp/config.py
+++ b/src/scholar_mcp/config.py
@@ -42,6 +42,12 @@ class ProjectConfig:
     epo_consumer_secret: str | None = None
     google_books_api_key: str | None = None
     github_token: str | None = None
+    # Opt-in per-subject authorization: uncomment to enable. See pvl-core's
+    # README "Authorization" section + scholar's README "Authorization
+    # (opt-in)" section for the wire-in story. Also requires uncommenting
+    # the matching AuthorizationMiddleware stanza in ``server.py`` and the
+    # env-load below in ``load_config``.
+    # acl_path: Path | None = None
     # CONFIG-FIELDS-END
 
     @property
@@ -71,6 +77,14 @@ def load_config() -> ProjectConfig:
     # GitHub-tooling env name users expect.
     github_token = os.environ.get("SCHOLAR_GITHUB_TOKEN") or None
 
+    # Opt-in per-subject authorization (see CONFIG-FIELDS-START comment above
+    # and scholar's README "Authorization (opt-in)" section). Activation
+    # requires THREE coordinated edits: (1) uncomment the ``acl_path`` field
+    # declaration above, (2) uncomment the env-load below, (3) uncomment the
+    # ``acl_path=acl_path`` kwarg in the ProjectConfig(...) call below — plus
+    # the matching AuthorizationMiddleware stanza in server.py.
+    # acl_path = Path(_p) if (_p := env(_ENV_PREFIX, "ACL_PATH")) else None
+
     config = ProjectConfig(
         server=server,
         server_name=server_name,
@@ -86,6 +100,7 @@ def load_config() -> ProjectConfig:
         epo_consumer_secret=env(_ENV_PREFIX, "EPO_CONSUMER_SECRET"),
         google_books_api_key=env(_ENV_PREFIX, "GOOGLE_BOOKS_API_KEY"),
         github_token=github_token,
+        # acl_path=acl_path,  # uncomment alongside the field + env-load above
     )
     # CONFIG-FROM-ENV-END
 

--- a/src/scholar_mcp/server.py
+++ b/src/scholar_mcp/server.py
@@ -229,6 +229,22 @@ def make_server(
 
     wire_middleware_stack(mcp)
 
+    # Optional: enable opt-in per-subject authorization on tools / resources /
+    # prompts.  See fastmcp-pvl-core's README "Authorization" section for the
+    # design.  Tools, resources, and prompts opt in by setting
+    # ``meta={"required_scope": "<scope>"}``; absence of the key means
+    # unrestricted.  The middleware is only installed when ``acl_path`` is set.
+    #
+    # from fastmcp_pvl_core import (
+    #     AuthorizationMiddleware,
+    #     load_acl,
+    #     make_acl_authorizer,
+    # )
+    #
+    # if config.acl_path is not None:
+    #     authorizer = make_acl_authorizer(load_acl(config.acl_path))
+    #     mcp.add_middleware(AuthorizationMiddleware(authorizer=authorizer))
+
     register_tools(mcp)
     register_resources(mcp)
     register_prompts(mcp)


### PR DESCRIPTION
## Summary

Adopts the v1.5.0 release of the [`fastmcp-server-template`](https://github.com/pvliesdonk/fastmcp-server-template) — Step 5 of the stepwise template-adoption sequence (continues #178/#185/#187/#189; the precursor pvl-core 2.x bump landed in #191).

- **Mapped bearer tokens (multi-subject)** documentation in `docs/guides/authentication.md` + two new env vars in `docs/configuration.md` (`SCHOLAR_MCP_BEARER_TOKENS_FILE`, `SCHOLAR_MCP_BEARER_DEFAULT_SUBJECT`) — the pvl-core 2.x feature now has a documented user-facing surface.
- **Opt-in per-subject authorization scaffold** added (commented-out) in `src/scholar_mcp/config.py` and `src/scholar_mcp/server.py`. Activation requires three coordinated uncomments per the inline guidance; `SCHOLAR_MCP_ACL_PATH` documented in `docs/configuration.md` with a `(scaffold)` annotation.
- **README "Authorization (opt-in)" section** with the ACL TOML schema, subject↔bearer-token alignment notes, load semantics, and privacy default.
- **DOMAIN-* sentinel blocks** added/refined across `docs/**` to make future template-managed sections land cleanly. All sentinels follow the pure-HTML-comment pattern (no rendered orphan headings).
- **Bot-reviewer paragraph** in `CLAUDE.md` (template-shipped).
- `.copier-answers.yml` `_commit` bumped `v1.4.0` → `v1.5.0`.

Closes #192.

## Notable decisions during local review

- **Tool count drift across `README.md` / `docs/tools/index.md` / `docs/index.md` / `docs/guides/claude-code-plugin.md` / `mkdocs.yml`** — pre-existing, several files outside this PR's diff. Tracked separately: #194.
- **`DOMAIN-AUTH-EXTRA` sentinel** in `docs/guides/authentication.md` still renders a visible `## Project-specific notes` heading (template-shipped from v1.3.0 or earlier). Out-of-scope for this PR; tracker filed upstream: [pvliesdonk/fastmcp-server-template#130](https://github.com/pvliesdonk/fastmcp-server-template/issues/130).
- **`CLAUDE.md` bot-reviewer paragraph** intentionally adopted as template-shipped without local edits; any rewrite is a template-side concern.

Two related upstream issues filed during the work:

- [pvliesdonk/fastmcp-pvl-core#69](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/69) — `build_oidc_proxy_auth` should normalize `OIDCProxy.__init__` discovery failures to `ConfigurationError` for symmetry with `build_remote_auth`.
- [pvliesdonk/fastmcp-server-template#126](https://github.com/pvliesdonk/fastmcp-server-template/issues/126) — workflow step name `Build #49 body content` contains stale internal issue reference.
- [pvliesdonk/fastmcp-server-template#129](https://github.com/pvliesdonk/fastmcp-server-template/issues/129) — three silent-failure patterns in the copier-update workflow + aggregator (replaces an earlier #127 that contained factual inaccuracies; that issue was closed with an explanation).

## Local review (gating, completed before push)

Cumulative diff against `origin/main`: 11 files, 130 insertions, 8 deletions. Zero executable code added (the `config.py` / `server.py` scaffold edits are commented-out opt-in wiring); the rest is documentation + sentinel adoption.

- `pr-review-toolkit:code-reviewer` (primary) — initial pass surfaced 5 findings (severity 30-85), all addressed; re-dispatch returned CLEAN.
- `pr-review-toolkit:comment-analyzer` (specialized for doc-heavy diff) — returned CLEAN on first pass.
- `feature-dev:code-reviewer` (second opinion) — initial pass surfaced 5 findings (3 in-scope addressed, 2 deferred with trackers); re-dispatch returned CLEAN.

## Test plan

- [x] `uv run pre-commit run --all-files` — green
- [x] `uv run ruff check --fix . && uv run ruff format --check .` — green
- [x] `uv run mypy src/ tests/` — clean (104 source files)
- [x] `uv run pytest -x -q` — 1039 passed, 4 deselected
- [x] `uv run mkdocs build --strict` — built successfully
- [ ] claude-review LGTM on first push
- [ ] (after flip-to-ready) gemini-code-assist LGTM
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)