### PR TITLE
chore(copier): update template from v1.5.0 to v1.5.1

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by `copier update`.
-_commit: v1.5.0
+_commit: v1.5.1
 _src_path: https://github.com/pvliesdonk/fastmcp-server-template
 docker_registry: ghcr.io/pvliesdonk
 domain_description: FastMCP server for Semantic Scholar with OpenAlex enrichment and

--- a/.env.example
+++ b/.env.example
@@ -17,4 +17,8 @@
 # SCHOLAR_MCP_OIDC_REQUIRED_SCOPES=openid
 # SCHOLAR_MCP_OIDC_JWT_SIGNING_KEY=<hex-string>
 
+# --- Remote debugger (development only — image must be built with --build-arg DEBUG=true) ---
+# SCHOLAR_MCP_DEBUG_PORT=5678
+# SCHOLAR_MCP_DEBUG_WAIT=false   # set true to block startup until the IDE attaches
+
 # --- Domain (populate from your ProjectConfig) ---

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,18 +12,30 @@ ENV UV_COMPILE_BYTECODE=1 \
 
 WORKDIR /app
 
+# Optional remote-debugger listener.  Default off so production images stay
+# lean; pass ``--build-arg DEBUG=true`` to install the ``[debug]`` extra
+# (debugpy) and bake the listener into the image.  Accepts the same boolean
+# vocabulary as runtime ``parse_bool`` (``true``/``1``/``yes``/``on``,
+# case-insensitive); anything else is treated as off.  See
+# ``docs/deployment/docker.md`` for the full attach workflow.
+ARG DEBUG=false
+
 # DOCKERFILE-UV-EXTRAS-START — append `--extra <name>` flags below to pull domain-specific extras; kept across copier update
-# Install dependencies first (cache layer).
+# Install dependencies first (cache layer).  The ``$( ... )`` shell
+# expansion appends ``--extra debug`` only when ``--build-arg DEBUG=true``;
+# default builds get the lean install.
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     --mount=type=bind,source=uv.lock,target=uv.lock \
-    uv sync --frozen --no-install-project --no-dev --extra all
+    uv sync --frozen --no-install-project --no-dev --extra all \
+        $( case "$DEBUG" in [Tt][Rr][Uu][Ee]|1|[Yy][Ee][Ss]|[Oo][Nn]) echo "--extra debug" ;; esac )
 
 # Copy source and install project.
 COPY pyproject.toml uv.lock README.md /app/
 COPY src/ /app/src/
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-dev --extra all
+    uv sync --frozen --no-dev --extra all \
+        $( case "$DEBUG" in [Tt][Rr][Uu][Ee]|1|[Yy][Ee][Ss]|[Oo][Nn]) echo "--extra debug" ;; esac )
 # DOCKERFILE-UV-EXTRAS-END
 
 # Create non-root user with configurable UID/GID for bind-mount compatibility.
@@ -44,6 +56,12 @@ ENV PATH="/app/.venv/bin:$PATH" \
     FASTMCP_HOME=/data/state/fastmcp
 
 EXPOSE 8000
+# Remote debugger: ``EXPOSE`` is metadata — nothing actually listens unless
+# the image was built with ``--build-arg DEBUG=true`` (which installs
+# debugpy) AND ``SCHOLAR_MCP_DEBUG_PORT`` is set at runtime.  Always
+# declared so the toggled ``[debug]`` extra has a stable port surface
+# to reach with ``-p 127.0.0.1:5678:5678``.
+EXPOSE 5678
 
 # DOCKERFILE-VOLUMES-START — mounted volume list; kept across copier update
 VOLUME ["/data/service", "/data/state"]

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ docker pull ghcr.io/pvliesdonk/scholar-mcp:latest
 
 A `compose.yml` ships at the repo root as a starting point — copy `.env.example` to `.env`, edit, and `docker compose up -d`.
 
+To attach a remote Python debugger (development only — the protocol is unauthenticated), see [Remote debugging](docs/deployment/docker.md#remote-debugging).
+
 ### Linux packages (.deb / .rpm)
 
 Download `.deb` or `.rpm` packages from the [GitHub Releases](https://github.com/pvliesdonk/scholar-mcp/releases) page. Both install a hardened systemd unit; env configuration is sourced from `/etc/scholar-mcp/env` (copy from the shipped `/etc/scholar-mcp/env.example`).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -161,6 +161,17 @@ Rate limiting is automatic and not configurable:
 - **Without API key**: ~1.1s between requests
 - **Retry**: automatic exponential backoff on HTTP 429 (up to 3 retries)
 
+## Remote debugging
+
+Optional development-only listener. Requires the `[debug]` extra (Docker images: built with `--build-arg DEBUG=true`; pip / uv installs: `pip install 'pvliesdonk-scholar-mcp[debug]'`). When `debugpy` isn't importable the helper logs a `WARNING` and continues — there's no hard failure.
+
+| Variable | Default | Description |
+|---|---|---|
+| `SCHOLAR_MCP_DEBUG_PORT` | -- | TCP port for the `debugpy` listener (e.g. `5678`). Unset = listener disabled. |
+| `SCHOLAR_MCP_DEBUG_WAIT` | `false` | Block startup until the IDE attaches. Useful for debugging early-startup code paths. |
+
+See [Docker deployment → Remote debugging](deployment/docker.md#remote-debugging) for the IDE-attach walkthrough.
+
 <!-- DOMAIN-CONFIG-VARS-START -->
 <!-- Future project-specific config notes go here; kept across copier
      update. Scholar's domain config is already documented in the

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -97,6 +97,8 @@ See [Configuration](../configuration.md) for the full reference. Key variables f
 | `SCHOLAR_MCP_BEARER_TOKEN` | -- | Bearer token for HTTP auth |
 | `FASTMCP_LOG_LEVEL` | `INFO` | Logging level (use `-v` or set to `DEBUG` for verbose output) |
 | `FASTMCP_ENABLE_RICH_LOGGING` | `true` | Set `false` for structured JSON logging with aggregators |
+| `SCHOLAR_MCP_DEBUG_PORT` | -- | Remote-debugger TCP port (see [Remote debugging](#remote-debugging); requires `--build-arg DEBUG=true` image) |
+| `SCHOLAR_MCP_DEBUG_WAIT` | `false` | Block startup until IDE attaches (see [Remote debugging](#remote-debugging)) |
 
 For OIDC authentication, see [OIDC deployment](oidc.md).
 
@@ -138,6 +140,52 @@ services:
 | `v1` | Latest minor in 1.x |
 
 Multi-arch: `linux/amd64` and `linux/arm64`.
+
+## Remote debugging
+
+Production images ship without `debugpy` to keep the image lean.  To attach a remote Python debugger from VS Code or PyCharm:
+
+1. **Build with the debug extra:**
+
+    ```bash
+    docker build --build-arg DEBUG=true -t scholar-mcp:debug .
+    ```
+
+    This installs the `[debug]` optional-dependency group (which pulls `debugpy` transitively from `fastmcp-pvl-core`).  Default builds (`DEBUG=false`) skip it.
+
+2. **Run with the debug env vars set and the port mapped:**
+
+    ```bash
+    docker run --rm \
+      -e SCHOLAR_MCP_DEBUG_PORT=5678 \
+      -e SCHOLAR_MCP_DEBUG_WAIT=true \
+      -p 127.0.0.1:5678:5678 \
+      -p 8000:8000 \
+      scholar-mcp:debug
+    ```
+
+    | Env var | Effect |
+    |---------|--------|
+    | `SCHOLAR_MCP_DEBUG_PORT` | TCP port the debugger listens on (any value parsing to ``0`` disables; non-numeric or out-of-range values log a WARNING and the listener stays off) |
+    | `SCHOLAR_MCP_DEBUG_WAIT` | When truthy (``1``/``true``/``yes``/``on``), block startup until the IDE attaches.  Default is non-blocking. |
+
+3. **Attach from VS Code** — add a launch config:
+
+    ```json
+    {
+      "name": "Attach to scholar-mcp",
+      "type": "debugpy",
+      "request": "attach",
+      "connect": { "host": "localhost", "port": 5678 }
+    }
+    ```
+
+    PyCharm uses *Run → Edit Configurations → Python Debug Server* with the same host/port.
+
+!!! danger "Never publish the debug port on a public network"
+    The debug listener binds `0.0.0.0` inside the container so the IDE can reach it from the host, but **debugpy's DAP protocol is unauthenticated** — any peer that can reach the port has arbitrary code execution as the server process.  Always bind the port mapping to localhost (`-p 127.0.0.1:5678:5678`) or tunnel via `kubectl port-forward` / SSH.  Production images should be built with default `DEBUG=false`.
+
+When the helper is invoked but `debugpy` isn't installed (e.g. someone sets `DEBUG_PORT` on a non-debug image), it logs a WARNING and continues — safe failure mode.
 
 
 <!-- DOMAIN-DOCKER-EXTRA-START -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,14 @@ dependencies = [
 [project.optional-dependencies]
 # PROJECT-EXTRAS-START — domain optional-dependency groups; kept across copier update
 mcp = ["fastmcp[tasks]>=3.2.0,<4"]
+# Pulls debugpy transitively via fastmcp-pvl-core's [debug] extra.  The
+# version range is inherited from the [project] dependency on
+# fastmcp-pvl-core above; pip resolves a single, consistent version.
+debug = ["fastmcp-pvl-core[debug]"]
+# ``all`` is the production-features rollup — what a published-package consumer
+# installs with ``pip install pvliesdonk-scholar-mcp[all]``.  Debug is opt-in
+# separately (``--extra debug`` or, in the Dockerfile, ``--build-arg DEBUG=true``)
+# so ``[all]`` images stay lean.  CI uses ``--all-extras`` which picks up both.
 all = ["fastmcp[tasks]>=3.2.0,<4"]
 # PROJECT-EXTRAS-END
 

--- a/scripts/copier_update_aggregator.py
+++ b/scripts/copier_update_aggregator.py
@@ -108,6 +108,28 @@ def _placeholder(section_title: str, status: str) -> str:
     return f"### {section_title}\n\n{msg}\n"
 
 
+def _pr_label(entry: dict) -> str:
+    """Render an entry's pr_number as ``#N``, or ``#?`` when null/missing.
+
+    LLM-emitted entries without a PR reference would otherwise render as
+    the literal ``#None`` in the body via Python's ``None.__str__`` inside
+    an f-string.  Used by Job B's three render strata.
+    """
+    pr = entry.get("pr_number")
+    return f"#{pr}" if pr is not None else "#?"
+
+
+def _file_label(entry: dict) -> str:
+    """Render an entry's file as ``\\`name\\```, or ``\\`(unnamed)\\``` when null/missing.
+
+    Same null-safety rationale as :func:`_pr_label` but for Job C's file
+    field; without coercion a null ``file`` renders as the literal
+    backticked ``\\`None\\```.
+    """
+    name = entry.get("file")
+    return f"`{name}`" if name is not None else "`(unnamed)`"
+
+
 def _render_job_a(data: dict | None, conflict_count: int) -> str:
     """Render the 🔧 Conflict resolutions section."""
     if conflict_count == 0:
@@ -121,28 +143,33 @@ def _render_job_a(data: dict | None, conflict_count: int) -> str:
     if status != "ok":
         return _placeholder("🔧 Conflict resolutions", "error")
 
-    lines = ["### 🔧 Conflict resolutions", ""]
+    content: list[str] = []
     auto = data.get("auto_resolved", [])
     if auto:
-        lines.append("**Auto-committed by claude-code** — VERIFY before merging:")
-        lines.append("")
+        content.append("**Auto-committed by claude-code** — VERIFY before merging:")
+        content.append("")
         for item in auto:
-            lines.append(
+            content.append(
                 f"- `{item['file']}` (commit {item['commit_sha']}): "
                 f"_{item['articulation']}_"
             )
-        lines.append("")
+        content.append("")
     review = data.get("needs_review", [])
     if review:
-        lines.append(
+        content.append(
             "**Needs review** — conflict markers remain, operator must resolve:"
         )
-        lines.append("")
+        content.append("")
         for item in review:
-            lines.append(f"- `{item['file']}`: {item['reasoning']}")
-            lines.append(f"  Recommended approach: {item['recommended_resolution']}")
-        lines.append("")
-    return "\n".join(lines)
+            content.append(f"- `{item['file']}`: {item['reasoning']}")
+            content.append(f"  Recommended approach: {item['recommended_resolution']}")
+        content.append("")
+    if not content:
+        # Status was "ok" but the LLM reported neither auto-resolved nor
+        # needs-review entries.  Suppress the section entirely rather than
+        # emitting an orphaned `### 🔧` header above empty content.
+        return ""
+    return "\n".join(["### 🔧 Conflict resolutions", "", *content])
 
 
 def _render_job_b(data: dict | None, template_advanced: bool = True) -> str:
@@ -188,28 +215,44 @@ def _render_job_b(data: dict | None, template_advanced: bool = True) -> str:
         cls = e.get("classification")
         by_class[cls if cls in by_class else "informational"].append(e)
 
-    lines = ["### ✨ New features in this update", ""]
+    content: list[str] = []
     if by_class["needs-opt-in"]:
-        lines.append("**Needs your attention** (action-required):")
-        lines.append("")
+        content.append("**Needs your attention** (action-required):")
+        content.append("")
         for e in by_class["needs-opt-in"]:
-            lines.append(f"- #{e['pr_number']} {e['title']} — needs opt-in.")
-            lines.append(f"  {e['summary']}")
-        lines.append("")
+            content.append(f"- {_pr_label(e)} {e['title']} — needs opt-in.")
+            content.append(f"  {e['summary']}")
+        content.append("")
     if by_class["ships-automatically"]:
-        lines.append("**Ships through automatically** (informational):")
-        lines.append("")
+        content.append("**Ships through automatically** (informational):")
+        content.append("")
         for e in by_class["ships-automatically"]:
-            lines.append(f"- #{e['pr_number']} {e['title']} — applied this run")
-        lines.append("")
+            content.append(f"- {_pr_label(e)} {e['title']} — applied this run")
+        content.append("")
     if by_class["informational"]:
-        ids = ", ".join(f"#{e['pr_number']}" for e in by_class["informational"])
-        n = len(by_class["informational"])
-        lines.append(
-            f"**Internal / no downstream effect** ({n} {'entry' if n == 1 else 'entries'}): {ids}"
-        )
-        lines.append("")
-    return "\n".join(lines)
+        # Drop entries with null pr_number from the rollup — they'd render
+        # as the literal "#None" otherwise (LLM-emitted malformed entries
+        # without a PR reference can't be looked up anyway, so dropping
+        # them from the displayed list is preferable to a placeholder).
+        # The bullet strata above use ``_pr_label`` which coerces null to
+        # ``#?`` — preserves the entry where its prose detail is useful;
+        # the rollup is a tally so dropping is cleaner there.
+        rollup = [
+            e for e in by_class["informational"] if e.get("pr_number") is not None
+        ]
+        if rollup:
+            ids = ", ".join(_pr_label(e) for e in rollup)
+            n = len(rollup)
+            content.append(
+                f"**Internal / no downstream effect** ({n} {'entry' if n == 1 else 'entries'}): {ids}"
+            )
+            content.append("")
+    if not content:
+        # Entries existed but every stratum filtered out (e.g. all
+        # informational with null pr_number); suppress the section entirely
+        # rather than emit an orphaned `### ✨` header above empty content.
+        return ""
+    return "\n".join(["### ✨ New features in this update", "", *content])
 
 
 def _render_job_c(data: dict | None, template_advanced: bool = True) -> str:
@@ -246,28 +289,38 @@ def _render_job_c(data: dict | None, template_advanced: bool = True) -> str:
         cls = f.get("classification")
         by_class[cls if cls in by_class else "informational"].append(f)
 
-    lines = ["### 📦 Excluded-file upstream changes", ""]
+    content: list[str] = []
     if by_class["recommend-port"]:
-        lines.append("**Recommended to port** (action-required):")
-        lines.append("")
+        content.append("**Recommended to port** (action-required):")
+        content.append("")
         for f in by_class["recommend-port"]:
-            lines.append(f"- `{f['file']}`: {f['summary']}")
-            lines.append(f"  Diff: {f['diff_summary']}")
-        lines.append("")
+            content.append(f"- {_file_label(f)}: {f['summary']}")
+            content.append(f"  Diff: {f['diff_summary']}")
+        content.append("")
     if by_class["informational"]:
-        lines.append("**Informational**:")
-        lines.append("")
+        content.append("**Informational**:")
+        content.append("")
         for f in by_class["informational"]:
-            lines.append(f"- `{f['file']}`: {f['summary']}")
-        lines.append("")
+            content.append(f"- {_file_label(f)}: {f['summary']}")
+        content.append("")
     if by_class["skip"]:
-        names = ", ".join(f"`{f['file']}`" for f in by_class["skip"])
-        n = len(by_class["skip"])
-        lines.append(
-            f"**Skipped (template-internal)** ({n} {'file' if n == 1 else 'files'}): {names}"
-        )
-        lines.append("")
-    return "\n".join(lines)
+        # Drop entries with null file from the rollup — same rationale as
+        # Job B's informational rollup (see :func:`_render_job_b`).
+        rollup = [f for f in by_class["skip"] if f.get("file") is not None]
+        if rollup:
+            names = ", ".join(_file_label(f) for f in rollup)
+            n = len(rollup)
+            content.append(
+                f"**Skipped (template-internal)** ({n} {'file' if n == 1 else 'files'}): {names}"
+            )
+            content.append("")
+    if not content:
+        # Files existed but the skip rollup was the only non-empty
+        # stratum and every entry in it had null file (so the rollup
+        # got filtered out).  Suppress the section entirely rather
+        # than emit an orphaned `### 📦` header above empty content.
+        return ""
+    return "\n".join(["### 📦 Excluded-file upstream changes", "", *content])
 
 
 _DISABLED_NOTICE = (
@@ -283,7 +336,7 @@ def _disabled_section(section_title: str) -> str:
 
 def compose_body(inputs: AggregatorInputs) -> str:
     """Compose the full PR body from existing PR-body content + agent JSON outputs."""
-    parts = [inputs.existing_body.rstrip(), "", "---", "", "## Agent analysis", ""]
+    agent_sections: list[str] = []
 
     if not inputs.agent_enabled:
         # Per-section disabled placeholders so structure is consistent across
@@ -291,42 +344,52 @@ def compose_body(inputs: AggregatorInputs) -> str:
         # gets a skip notice; sections gated out (e.g. Job A with no conflicts)
         # are omitted entirely.
         if inputs.conflict_count > 0:
-            parts.append(_disabled_section("🔧 Conflict resolutions"))
+            agent_sections.append(_disabled_section("🔧 Conflict resolutions"))
         if inputs.template_advanced:
-            parts.append(_disabled_section("✨ New features in this update"))
-            parts.append(_disabled_section("📦 Excluded-file upstream changes"))
-        return "\n".join(parts) + "\n"
+            agent_sections.append(_disabled_section("✨ New features in this update"))
+            agent_sections.append(
+                _disabled_section("📦 Excluded-file upstream changes")
+            )
+    else:
+        # Each render is wrapped in try/except so a malformed item in one job's
+        # JSON (e.g. LLM emitted entry missing a required field) degrades to
+        # that section's error placeholder without nuking the other two
+        # sections.  See spec § Aggregator's four-state contract — sections
+        # must be independently failing.
+        section_a = _safe_render(
+            "🔧 Conflict resolutions",
+            lambda: _render_job_a(
+                _read_job_json(inputs.job_a_path), inputs.conflict_count
+            ),
+        )
+        if section_a:
+            agent_sections.append(section_a)
 
-    # Each render is wrapped in try/except so a malformed item in one job's
-    # JSON (e.g. LLM emitted entry missing a required field) degrades to that
-    # section's error placeholder without nuking the other two sections.
-    # See spec § Aggregator's four-state contract — sections must be
-    # independently failing.
-    section_a = _safe_render(
-        "🔧 Conflict resolutions",
-        lambda: _render_job_a(_read_job_json(inputs.job_a_path), inputs.conflict_count),
-    )
-    if section_a:
-        parts.append(section_a)
+        section_b = _safe_render(
+            "✨ New features in this update",
+            lambda: _render_job_b(
+                _read_job_json(inputs.job_b_path), inputs.template_advanced
+            ),
+        )
+        if section_b:
+            agent_sections.append(section_b)
 
-    section_b = _safe_render(
-        "✨ New features in this update",
-        lambda: _render_job_b(
-            _read_job_json(inputs.job_b_path), inputs.template_advanced
-        ),
-    )
-    if section_b:
-        parts.append(section_b)
+        section_c = _safe_render(
+            "📦 Excluded-file upstream changes",
+            lambda: _render_job_c(
+                _read_job_json(inputs.job_c_path), inputs.template_advanced
+            ),
+        )
+        if section_c:
+            agent_sections.append(section_c)
 
-    section_c = _safe_render(
-        "📦 Excluded-file upstream changes",
-        lambda: _render_job_c(
-            _read_job_json(inputs.job_c_path), inputs.template_advanced
-        ),
-    )
-    if section_c:
-        parts.append(section_c)
-
+    parts = [inputs.existing_body.rstrip()]
+    # Suppress the agent-analysis header entirely when no sections will follow
+    # it (e.g. agent_enabled=True with conflict_count=0 + template_advanced=False,
+    # or agent_disabled with both gates closed) — otherwise the body emits an
+    # orphaned `## Agent analysis` separator with nothing under it.
+    if agent_sections:
+        parts.extend(["", "---", "", "## Agent analysis", "", *agent_sections])
     return "\n".join(parts) + "\n"
 
 

--- a/src/scholar_mcp/cli.py
+++ b/src/scholar_mcp/cli.py
@@ -16,7 +16,11 @@ from typing import TYPE_CHECKING, cast
 
 import httpx
 import typer
-from fastmcp_pvl_core import configure_logging_from_env, normalise_http_path
+from fastmcp_pvl_core import (
+    configure_logging_from_env,
+    maybe_start_debugpy,
+    normalise_http_path,
+)
 
 from scholar_mcp.config import _ENV_PREFIX
 
@@ -107,6 +111,18 @@ def serve(
         raise typer.Exit(code=1) from exc
     env_http_path = os.environ.get(f"{_ENV_PREFIX}_HTTP_PATH")
     path = normalise_http_path(http_path or env_http_path)
+
+    # Optional remote-debugger listener — placed in ``serve`` (not the
+    # typer root callback) so non-server commands like ``--help``,
+    # ``--version``, or future ``dump-config``-style subcommands are
+    # never blocked by ``SCHOLAR_MCP_DEBUG_WAIT=true``.  No-op
+    # unless ``SCHOLAR_MCP_DEBUG_PORT`` is set; ``debugpy`` is only
+    # present when the image was built with ``--build-arg DEBUG=true``
+    # (a missing import logs a WARNING and continues).  ``_root`` has
+    # already attached the StreamHandler by the time ``serve`` runs, so
+    # the helper's INFO/WARNING logs route through the configured
+    # formatter rather than Python's lastResort.
+    maybe_start_debugpy(_ENV_PREFIX)
 
     if transport != "http" and (
         host != "0.0.0.0" or port != 8000 or http_path is not None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -121,6 +121,24 @@ def test_serve_stdio_invokes_make_server() -> None:
     mock_server.run.assert_called_once_with(transport="stdio")
 
 
+def test_serve_calls_maybe_start_debugpy() -> None:
+    """`serve` invokes ``maybe_start_debugpy`` with the scholar-mcp env prefix.
+
+    The call is a no-op unless ``SCHOLAR_MCP_DEBUG_PORT`` is set, but it must
+    happen on every ``serve`` invocation so operators can attach a debugger by
+    setting the env var without rebuilding or rewriting the entrypoint.
+    """
+    mock_server = MagicMock()
+    with (
+        patch("scholar_mcp.server.make_server", return_value=mock_server),
+        patch("scholar_mcp.server.build_event_store"),
+        patch("scholar_mcp.cli.maybe_start_debugpy") as mock_debugpy,
+    ):
+        result = CliRunner().invoke(app, ["serve"])
+    assert result.exit_code == 0
+    mock_debugpy.assert_called_once_with("SCHOLAR_MCP")
+
+
 def test_serve_import_error_exits_1() -> None:
     """If fastmcp isn't installed (import fails), serve exits 1."""
     with patch.dict("sys.modules", {"scholar_mcp.server": None}):

--- a/uv.lock
+++ b/uv.lock
@@ -642,6 +642,31 @@ wheels = [
 ]
 
 [[package]]
+name = "debugpy"
+version = "1.8.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/b7/cd8080344452e4874aae67c40d8940e2b4d47b01601a8fd9f44786c757c7/debugpy-1.8.20.tar.gz", hash = "sha256:55bc8701714969f1ab89a6d5f2f3d40c36f91b2cbe2f65d98bf8196f6a6a2c33", size = 1645207, upload-time = "2026-01-29T23:03:28.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/56/c3baf5cbe4dd77427fd9aef99fcdade259ad128feeb8a786c246adb838e5/debugpy-1.8.20-cp311-cp311-macosx_15_0_universal2.whl", hash = "sha256:eada6042ad88fa1571b74bd5402ee8b86eded7a8f7b827849761700aff171f1b", size = 2208318, upload-time = "2026-01-29T23:03:36.481Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/7d/4fa79a57a8e69fe0d9763e98d1110320f9ecd7f1f362572e3aafd7417c9d/debugpy-1.8.20-cp311-cp311-manylinux_2_34_x86_64.whl", hash = "sha256:7de0b7dfeedc504421032afba845ae2a7bcc32ddfb07dae2c3ca5442f821c344", size = 3171493, upload-time = "2026-01-29T23:03:37.775Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/f2/1e8f8affe51e12a26f3a8a8a4277d6e60aa89d0a66512f63b1e799d424a4/debugpy-1.8.20-cp311-cp311-win32.whl", hash = "sha256:773e839380cf459caf73cc533ea45ec2737a5cc184cf1b3b796cd4fd98504fec", size = 5209240, upload-time = "2026-01-29T23:03:39.109Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/92/1cb532e88560cbee973396254b21bece8c5d7c2ece958a67afa08c9f10dc/debugpy-1.8.20-cp311-cp311-win_amd64.whl", hash = "sha256:1f7650546e0eded1902d0f6af28f787fa1f1dbdbc97ddabaf1cd963a405930cb", size = 5233481, upload-time = "2026-01-29T23:03:40.659Z" },
+    { url = "https://files.pythonhosted.org/packages/14/57/7f34f4736bfb6e00f2e4c96351b07805d83c9a7b33d28580ae01374430f7/debugpy-1.8.20-cp312-cp312-macosx_15_0_universal2.whl", hash = "sha256:4ae3135e2089905a916909ef31922b2d733d756f66d87345b3e5e52b7a55f13d", size = 2550686, upload-time = "2026-01-29T23:03:42.023Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/78/b193a3975ca34458f6f0e24aaf5c3e3da72f5401f6054c0dfd004b41726f/debugpy-1.8.20-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:88f47850a4284b88bd2bfee1f26132147d5d504e4e86c22485dfa44b97e19b4b", size = 4310588, upload-time = "2026-01-29T23:03:43.314Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/55/f14deb95eaf4f30f07ef4b90a8590fc05d9e04df85ee379712f6fb6736d7/debugpy-1.8.20-cp312-cp312-win32.whl", hash = "sha256:4057ac68f892064e5f98209ab582abfee3b543fb55d2e87610ddc133a954d390", size = 5331372, upload-time = "2026-01-29T23:03:45.526Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/39/2bef246368bd42f9bd7cba99844542b74b84dacbdbea0833e610f384fee8/debugpy-1.8.20-cp312-cp312-win_amd64.whl", hash = "sha256:a1a8f851e7cf171330679ef6997e9c579ef6dd33c9098458bd9986a0f4ca52e3", size = 5372835, upload-time = "2026-01-29T23:03:47.245Z" },
+    { url = "https://files.pythonhosted.org/packages/15/e2/fc500524cc6f104a9d049abc85a0a8b3f0d14c0a39b9c140511c61e5b40b/debugpy-1.8.20-cp313-cp313-macosx_15_0_universal2.whl", hash = "sha256:5dff4bb27027821fdfcc9e8f87309a28988231165147c31730128b1c983e282a", size = 2539560, upload-time = "2026-01-29T23:03:48.738Z" },
+    { url = "https://files.pythonhosted.org/packages/90/83/fb33dcea789ed6018f8da20c5a9bc9d82adc65c0c990faed43f7c955da46/debugpy-1.8.20-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:84562982dd7cf5ebebfdea667ca20a064e096099997b175fe204e86817f64eaf", size = 4293272, upload-time = "2026-01-29T23:03:50.169Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/25/b1e4a01bfb824d79a6af24b99ef291e24189080c93576dfd9b1a2815cd0f/debugpy-1.8.20-cp313-cp313-win32.whl", hash = "sha256:da11dea6447b2cadbf8ce2bec59ecea87cc18d2c574980f643f2d2dfe4862393", size = 5331208, upload-time = "2026-01-29T23:03:51.547Z" },
+    { url = "https://files.pythonhosted.org/packages/13/f7/a0b368ce54ffff9e9028c098bd2d28cfc5b54f9f6c186929083d4c60ba58/debugpy-1.8.20-cp313-cp313-win_amd64.whl", hash = "sha256:eb506e45943cab2efb7c6eafdd65b842f3ae779f020c82221f55aca9de135ed7", size = 5372930, upload-time = "2026-01-29T23:03:53.585Z" },
+    { url = "https://files.pythonhosted.org/packages/33/2e/f6cb9a8a13f5058f0a20fe09711a7b726232cd5a78c6a7c05b2ec726cff9/debugpy-1.8.20-cp314-cp314-macosx_15_0_universal2.whl", hash = "sha256:9c74df62fc064cd5e5eaca1353a3ef5a5d50da5eb8058fcef63106f7bebe6173", size = 2538066, upload-time = "2026-01-29T23:03:54.999Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/56/6ddca50b53624e1ca3ce1d1e49ff22db46c47ea5fb4c0cc5c9b90a616364/debugpy-1.8.20-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:077a7447589ee9bc1ff0cdf443566d0ecf540ac8aa7333b775ebcb8ce9f4ecad", size = 4269425, upload-time = "2026-01-29T23:03:56.518Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/d9/d64199c14a0d4c476df46c82470a3ce45c8d183a6796cfb5e66533b3663c/debugpy-1.8.20-cp314-cp314-win32.whl", hash = "sha256:352036a99dd35053b37b7803f748efc456076f929c6a895556932eaf2d23b07f", size = 5331407, upload-time = "2026-01-29T23:03:58.481Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/d9/1f07395b54413432624d61524dfd98c1a7c7827d2abfdb8829ac92638205/debugpy-1.8.20-cp314-cp314-win_amd64.whl", hash = "sha256:a98eec61135465b062846112e5ecf2eebb855305acc1dfbae43b72903b8ab5be", size = 5372521, upload-time = "2026-01-29T23:03:59.864Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/c3/7f67dea8ccf8fdcb9c99033bbe3e90b9e7395415843accb81428c441be2d/debugpy-1.8.20-py2.py3-none-any.whl", hash = "sha256:5be9bed9ae3be00665a06acaa48f8329d2b9632f15fd09f6a9a8c8d9907e54d7", size = 5337658, upload-time = "2026-01-29T23:04:17.404Z" },
+]
+
+[[package]]
 name = "decorator"
 version = "5.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -806,6 +831,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6d/4a/161f08dd9ce9feec3ef72687bb4112f377cd7afaa45b81add3e6281b2ff1/fastmcp_pvl_core-2.1.0.tar.gz", hash = "sha256:46bf41e032c15d4533fbd032cb4d9dbadf852f0509973b9e0b23c1cbbe7b49ca", size = 333983, upload-time = "2026-05-10T09:06:02.342Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/de/2918c68e3423dc7562f0d6df48cd99f23cd322f8a7db9be1292b5e8d4368/fastmcp_pvl_core-2.1.0-py3-none-any.whl", hash = "sha256:d5baf34f6f1cf425d6e4e104fbe8a584d9d97dd2035561bb5a4e9bc85d6ac53f", size = 89834, upload-time = "2026-05-10T09:06:00.755Z" },
+]
+
+[package.optional-dependencies]
+debug = [
+    { name = "debugpy" },
 ]
 
 [[package]]
@@ -1898,6 +1928,9 @@ dependencies = [
 all = [
     { name = "fastmcp", extra = ["tasks"] },
 ]
+debug = [
+    { name = "fastmcp-pvl-core", extra = ["debug"] },
+]
 mcp = [
     { name = "fastmcp", extra = ["tasks"] },
 ]
@@ -1926,12 +1959,13 @@ requires-dist = [
     { name = "fastmcp", extras = ["tasks"], marker = "extra == 'all'", specifier = ">=3.2.0,<4" },
     { name = "fastmcp", extras = ["tasks"], marker = "extra == 'mcp'", specifier = ">=3.2.0,<4" },
     { name = "fastmcp-pvl-core", specifier = ">=2.1.0,<3" },
+    { name = "fastmcp-pvl-core", extras = ["debug"], marker = "extra == 'debug'" },
     { name = "httpx" },
     { name = "lxml", specifier = ">=5.0" },
     { name = "python-epo-ops-client", specifier = ">=4.2" },
     { name = "typer", specifier = ">=0.12" },
 ]
-provides-extras = ["mcp", "all"]
+provides-extras = ["mcp", "debug", "all"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Adopts the v1.5.1 release of the [`fastmcp-server-template`](https://github.com/pvliesdonk/fastmcp-server-template) — Step 6 of the stepwise template-adoption sequence (continues #195).

Upstream v1.5.1 bundles two changes:

- **`feat(docker): optional debug extra + remote-debugger wiring`** (upstream PR #115) — a new `[debug]` extra installs `debugpy` via `fastmcp-pvl-core[debug]`. The Dockerfile installs it conditionally when built with `--build-arg DEBUG=true`. At runtime, `maybe_start_debugpy(_ENV_PREFIX)` is called early in `cli.py:serve` so the listener only opens when `SCHOLAR_MCP_DEBUG_PORT` is set; missing-debugpy is a logged WARNING, not a hard failure.
- **`fix(aggregator): three follow-ups from #109 review`** (upstream PR #114) — refactors `scripts/copier_update_aggregator.py` so `## Agent analysis` is only rendered when at least one agent section has content (fixes the dangling-header case).

## Notable conflict-resolution decisions

- **`pyproject.toml` `all` extra deliberately omits `debug`.** Comment added inline. Rationale: `all` is the production-features rollup users get from `pip install pvliesdonk-scholar-mcp[all]`; `debug` stays opt-in (Docker: `--build-arg DEBUG=true`; pip: `--extra debug`). CI uses `--all-extras` and so picks up both.
- **`Dockerfile` keeps `--extra all`** alongside the new conditional `$(case "$DEBUG"... echo "--extra debug" ...)`. Both `uv sync` invocations get the same flags (deps-cache layer + project-install layer) per the CLAUDE.md sentinel rule.
- **`docs/deployment/docker.md` env-var table preserved scholar's richer set** (S2_API_KEY / CACHE_DIR / DOCLING_URL / FASTMCP_LOG_LEVEL etc.) and appended the two new debug env vars.
- **`docs/configuration.md` adds a new "Remote debugging" section** (between Rate Limiting and the DOMAIN-CONFIG-VARS sentinel) for the canonical env-var reference. Cross-links to the Docker deployment walkthrough.
- **`cli.py` `maybe_start_debugpy(_ENV_PREFIX)` placement** is after the `ConfigurationError` catch so config failures still print cleanly to stderr before debugpy can block. Scholar's existing `--host/--port/--path` warning preserved.
- **`scripts/copier_update_aggregator.py`** adopted the upstream refactor with scholar's local docstring fix preserved ("PR-body content" instead of stale "#49 content" — applied during the v1.4.0 adoption per the local patch for upstream issue #126).
- **`tests/test_cli.py`** new test asserts `maybe_start_debugpy("SCHOLAR_MCP")` is called on `serve` invocation, raising patch coverage on the new line above the 80% gate.

Closes #197.

## Local review (gating, completed before push)

Cumulative diff against `origin/main`: 11 files, 309 insertions, 87 deletions. Two real code changes (aggregator refactor; debugpy wiring in cli.py); rest is configuration + documentation.

- `pr-review-toolkit:code-reviewer` (primary) — first pass surfaced 2 findings (broken docker.md table header, missing SCHOLAR_MCP_DEBUG_* from canonical configuration.md); both fixed; re-dispatch returned CLEAN.
- `pr-review-toolkit:silent-failure-hunter` — returned CLEAN on first pass with one non-blocking, conscious-choice observation about template-shipped aggregator behavior.
- `feature-dev:code-reviewer` (second opinion) — first pass surfaced 2 findings (missing test for `maybe_start_debugpy` call; judgment call on `all` omitting `debug`); test added, judgment defended in writing inside `pyproject.toml`; re-dispatch returned CLEAN.

## Test plan

- [x] `uv run pre-commit run --all-files` — green
- [x] `uv run ruff check --fix . && uv run ruff format --check .` — green
- [x] `uv run mypy src/ tests/` — clean (104 source files)
- [x] `uv run pytest -x -q` — 1040 passed, 4 deselected
- [x] `uv run mkdocs build --strict` — built successfully
- [x] Patch coverage on `cli.py`: 92% (new `maybe_start_debugpy` line exercised by new test)
- [ ] claude-review LGTM on first push
- [ ] (after flip-to-ready) gemini-code-assist LGTM
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)