### PR TITLE
chore(copier): update to v2.5.1

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,9 +1,10 @@
 # Changes here will be overwritten by `copier update`.
-_commit: v2.3.0
+_commit: v2.5.1
 _src_path: https://github.com/pvliesdonk/fastmcp-server-template
 docker_registry: ghcr.io/pvliesdonk
 domain_description: FastMCP server for Semantic Scholar with OpenAlex enrichment and
     docling PDF conversion
+enable_authorization: false
 env_prefix: SCHOLAR_MCP
 github_org: pvliesdonk
 human_name: Scholar MCP

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,8 +50,12 @@ jobs:
       - name: Install Chromium
         run: uv run playwright install --with-deps chromium
 
-      - name: Run config-wizard smoke test
-        run: uv run pytest tests/test_config_wizard_smoke.py -v -m browser
+      - name: Run config-wizard browser tests
+        # Both the template-owned smoke suite and the project-owned domain suite
+        # (test_config_wizard_domain.py). -m browser selects the browser-marked
+        # tests in each; the seeded domain placeholder is skipped until a
+        # consumer replaces it with real assertions.
+        run: uv run pytest tests/test_config_wizard_smoke.py tests/test_config_wizard_domain.py -v -m browser
 
   deploy:
     # Publish versioned docs with mike, serving from the gh-pages branch:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,9 @@ The config is in `_skip_if_exists`, so domain-specific additions (shellcheck, ya
 
 Trivial exceptions: pure typo fixes and automated dependency bumps (Dependabot / Renovate) may skip the issue.
 
+<!-- TEMPLATE-TRACKING-START -->
 **Bot reviewers (claude-review, gemini-code-assist) are merge gates, not pair reviewers.** Local review must be complete before the PR opens. If a bot finds anything on first run, the local review was incomplete — that is a discipline failure to investigate, not "address-and-move-on." Run a local code-review pass on the cumulative diff before `gh pr create`; the bots are not a substitute.
+<!-- TEMPLATE-TRACKING-END -->
 
 ## GitHub Review Types
 
@@ -160,6 +162,7 @@ These sentinel blocks in `Dockerfile` are preserved across `copier update`. Add 
 
 For services that talk to a remote upstream (e.g. paperless, an HTTP API), wire the upstream version inside the `DOMAIN-UPSTREAM-START` / `DOMAIN-UPSTREAM-END` sentinel in `src/scholar_mcp/server.py`. Pass `upstream_version=` (a zero-arg callable returning a dict / str / None) and optionally `upstream_label="<service>"` (default `"upstream"`). The simplest pattern is a module-level upstream client (typically constructed from env vars at import time) whose version method is referenced from the callable — `CurrentContext()` is a FastMCP DI marker that only resolves inside parameter defaults, so it cannot be called directly from a zero-arg provider. The block is preserved across `copier update`.
 
+<!-- TEMPLATE-TRACKING-START -->
 ## Shared Infrastructure
 
 Shared infrastructure (auth providers, middleware stack, logging bootstrap, event store factory, CLI scaffolding, release pipeline, Docker entrypoint, nfpm packaging, mcpb bundle) lives upstream in two places:
@@ -176,6 +179,7 @@ Fixes and improvements to shared code land in those repos and propagate here via
 - **Domain-only fix** (anything inside a `DOMAIN-*`, `CONFIG-*`, or `PROJECT-*` sentinel block, `tools.py`, `resources.py`, `prompts.py`, `domain.py`, `tests/`): PR on this repo directly.
 
 If a conflict marker appears in a copier-update bot PR, the conflict itself often signals a template bug — investigate whether the template's version needs fixing before resolving locally.
+<!-- TEMPLATE-TRACKING-END -->
 
 <!-- ===== TEMPLATE-OWNED SECTIONS END ===== -->
 

--- a/FORKING.md
+++ b/FORKING.md
@@ -1,0 +1,88 @@
+# Forking: detaching from the template
+
+This project was generated from the
+[`fastmcp-server-template`](https://github.com/pvliesdonk/fastmcp-server-template)
+copier template and, by default, **tracks** it: the weekly
+`copier-update` workflow opens PRs that pull in template and `fastmcp-pvl-core`
+improvements, and `CLAUDE.md` routes fixes back upstream.
+
+A **fork** is different. If you are taking sole ownership of this server, or
+want an opinionated variant that no longer follows the fleet, you should
+**detach**: stop tracking the template and remove the fleet-wide automation and
+guidance that no longer applies. A fork is not a downstream — after detaching,
+template and `fastmcp-pvl-core` changes are yours to port manually.
+
+Detaching is mechanical. Run the steps below once, then commit.
+
+## Step 1 — Stop tracking the template
+
+```bash
+rm -f .copier-answers.yml
+```
+
+This removes the link copier uses to reattach. The weekly cron that ran
+`copier update` is deleted in Step 2.
+
+## Step 2 — Prune template-origin CI and fleet review wiring
+
+```bash
+rm -f .github/workflows/copier-update.yml \
+      .github/workflows/claude.yml \
+      .github/workflows/claude-code-review.yml
+rm -rf .gemini
+rm -f scripts/copier_update_aggregator.py
+rm -rf scripts/copier_update_prompts
+```
+
+What this removes and why:
+
+- `copier-update.yml` — template-update automation; meaningless once detached.
+- `claude.yml`, `claude-code-review.yml` — fleet review-bot wiring.
+- `.gemini/` — gemini-code-assist fleet scope control.
+- `scripts/copier_update_aggregator.py`, `scripts/copier_update_prompts/` —
+  the orchestration that only `copier-update.yml` invoked; dead weight once
+  that workflow is gone.
+
+**Keep** your own CI and release workflows: `ci.yml`, `codeql.yml`,
+`coverage-status.yml`, `docs.yml`, and `release.yml`. (`release.yml` still needs
+the `RELEASE_TOKEN` secret; only its `copier-update` justification is gone.)
+
+## Step 3 — Scrub template-tracking guidance from `CLAUDE.md`
+
+```bash
+# -i.bak + rm keeps this portable across GNU sed (Linux) and BSD sed (macOS),
+# which disagree on the in-place flag's syntax.
+sed -i.bak '/<!-- TEMPLATE-TRACKING-START -->/,/<!-- TEMPLATE-TRACKING-END -->/d' CLAUDE.md && rm -f CLAUDE.md.bak
+```
+
+This deletes the template-coupled sections — the bot-reviewer merge-gate
+paragraph, **Shared Infrastructure**, and **Contributing fixes upstream** —
+while keeping the fork-neutral contributor guidance (Conventions, the PR
+acceptance gates, the Logging Standard, the config contract, GitHub Review
+Types). If your fork added its own `.claude/CLAUDE.md`, apply the same scrub
+there.
+
+## Step 4 — README cleanup (optional)
+
+These leftover references are harmless but now misleading:
+
+- The **Template** badge at the top of `README.md` (the
+  `![Template](https://img.shields.io/badge/dynamic/yaml?...&label=template)`
+  entry) points at the now-deleted `.copier-answers.yml`. Remove it.
+- In the secrets table, the `RELEASE_TOKEN` row lists `copier-update.yml` as a
+  consumer. Drop that workflow from the row.
+- The `### \`uv.lock\` refresh after \`copier update\`` subsection no longer
+  applies. Remove it.
+
+## You are now standalone
+
+Remove this guide (it no longer applies once detached) and commit the result:
+
+```bash
+rm -f FORKING.md
+git add -A
+git commit -m "chore: detach from fastmcp-server-template"
+```
+
+Future template or `fastmcp-pvl-core` fixes are no longer delivered
+automatically — pull in anything you want by hand.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A [FastMCP](https://github.com/jlowin/fastmcp) server for the scholarly citation landscape — **papers**, **patents**, **books**, and **standards** — giving LLMs a unified way to search, cross-reference, and retrieve prior art across all four source types via [Semantic Scholar](https://www.semanticscholar.org/), [EPO Open Patent Services](https://www.epo.org/en/searching-for-patents/data/web-services/ops), [Open Library](https://openlibrary.org/), and standards bodies (NIST, IETF, W3C, ETSI), with [OpenAlex](https://openalex.org/) enrichment and optional [docling-serve](https://github.com/DS4SD/docling-serve) PDF/full-text conversion.
 
-**[Documentation](https://pvliesdonk.github.io/scholar-mcp/)** | **[PyPI](https://pypi.org/project/pvliesdonk-scholar-mcp/)** | **[Docker](https://github.com/pvliesdonk/scholar-mcp/pkgs/container/scholar-mcp)**
+**[Documentation](https://pvliesdonk.github.io/scholar-mcp/)** | **[Config wizard](https://pvliesdonk.github.io/scholar-mcp/latest/configuration-generator/)** | **[PyPI](https://pypi.org/project/pvliesdonk-scholar-mcp/)** | **[Docker](https://github.com/pvliesdonk/scholar-mcp/pkgs/container/scholar-mcp)**
 
 ## Features
 
@@ -135,44 +135,9 @@ Core environment variables shared across all `fastmcp-pvl-core`-based services:
 
 Domain-specific variables go below under [Domain configuration](#domain-configuration).
 
-## Authorization (opt-in)
+## Authentication
 
-This server inherits opt-in per-subject authorization from `fastmcp-pvl-core`.  The default posture is **off** — every authenticated caller can use every tool, resource, and prompt.  Turn it on by pointing `SCHOLAR_MCP_ACL_PATH` at a TOML ACL file; the middleware is installed only when the path is set, and individual tools opt in by declaring `meta={"required_scope": "<scope>"}` at registration.  A tool without `required_scope` is unrestricted regardless of caller.
-
-Wire it in by uncommenting the `acl_path` field in `src/scholar_mcp/config.py` and the `AuthorizationMiddleware` stanza in `src/scholar_mcp/server.py` — both ship as commented stubs in the scaffold.
-
-### ACL TOML schema
-
-```toml
-[subjects]
-"user:alice@example.com" = ["read", "write"]
-"user:admin@example.com" = ["*"]              # wildcard — any required scope passes
-"service:ci-bot"         = ["read"]
-"local"                  = ["*"]              # auth-disabled subject (no bearer / OIDC vars set)
-```
-
-- **Subject strings are opaque.** The `<kind>:<id>` convention is documentation only; the library treats each subject as a literal string.
-- **`*` is the only library-treated special scope** — it grants every required scope.  Subject-side wildcards (`*` as an ACL key) are rejected at load time.
-- **Scope vocabulary is domain-defined.** Per-project or per-folder gating is encoded into the scope string itself (e.g. `read:project-foo`, `write:vault/personal`); `fastmcp-pvl-core` treats every scope except `*` as opaque.
-
-### Subject ↔ bearer-token alignment
-
-The subject string used as a *value* in the bearer-tokens TOML (`SCHOLAR_MCP_BEARER_TOKENS_FILE`) is the same string used as a *key* in the ACL TOML.  Same string, opposite roles — keep the two files consistent when adding or removing a principal.  See [Mapped bearer tokens](docs/guides/authentication.md#mapped-bearer-tokens-multi-subject) in the authentication guide for the bearer-tokens TOML schema.
-
-In single-token mode (`SCHOLAR_MCP_BEARER_TOKEN`) every authenticated caller shares one subject — the library's default (currently `"bearer-anon"`), override with `SCHOLAR_MCP_BEARER_DEFAULT_SUBJECT`; reference *that* string as the ACL key.  When no auth is configured (no `SCHOLAR_MCP_BEARER_TOKEN`, `SCHOLAR_MCP_BEARER_TOKENS_FILE`, or OIDC env vars set — common in stdio dev rigs but also possible on HTTP), every request resolves to the literal subject `"local"` — reference that string as the ACL key for un-authenticated local sessions.
-
-### Load semantics
-
-The ACL file is loaded **once at server startup**.  Restart the server to pick up changes; live reload is not part of the initial implementation.  `load_acl` fails fast with `ConfigurationError` on every malformed condition, so a typo in the ACL file aborts startup rather than silently denying requests.
-
-### Privacy default
-
-Denied requests are logged at WARNING with the subject string for audit attribution.  The wire-side error payload **omits** the subject by default to limit cross-user information disclosure.  For internal-only servers where the subject is safe to surface to clients, construct the middleware with `AuthorizationMiddleware(..., expose_subject_in_error=True)`.
-
-### See also
-
-- [fastmcp-pvl-core README — Authorization](https://github.com/pvliesdonk/fastmcp-pvl-core#authorization-opt-in--authorizationmiddleware) — full design, the `check_authorization` per-call helper, and per-token subject mapping.
-- [Authorization submodule spec](https://github.com/pvliesdonk/fastmcp-pvl-core/blob/main/docs/specs/authorization-submodule.md) — design rationale and deviations table.
+Callers authenticate via a bearer token or OIDC (mutually exclusive). See the [Authentication guide](docs/guides/authentication.md) for setup, mapped multi-subject tokens, OIDC, and troubleshooting.
 
 ## GitHub secrets
 

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -75,8 +75,6 @@ The bearer-token mode above shares one subject across every authenticated caller
 
 Each token resolves to a distinct subject string for downstream attribution. Subject strings are opaque: the `<kind>:<id>` convention (`user:`, `service:`, `token:`) is documentation only. When `BEARER_TOKENS_FILE` is set it overrides `BEARER_TOKEN` (a `WARNING` is logged if both are present). A missing or malformed file aborts startup with `ConfigurationError` rather than silently denying every request.
 
-For the per-tool authorization that consumes these subjects, see the **Authorization (opt-in)** section of the project [README](https://github.com/pvliesdonk/scholar-mcp#authorization-opt-in).
-
 ---
 
 ## Remote auth
@@ -122,10 +120,10 @@ Full OAuth 2.1 authentication using an external identity provider. The MCP serve
 
 ### How it works
 
-The server uses FastMCP's built-in `OIDCProxy`. No external auth sidecar needed:
+The server proxies OIDC itself — no external auth sidecar to deploy:
 
 ```
-Client → scholar-mcp (OIDCProxy) → OIDC Provider
+Client → mcp-server → OIDC Provider
 ```
 
 1. Client connects to the server

--- a/docs/javascripts/config-wizard/generators.js
+++ b/docs/javascripts/config-wizard/generators.js
@@ -50,6 +50,28 @@ const systemdLine = (k, v) => {
   return `Environment="${k}=${escaped}"`;
 };
 
+// Validate a loaded wizard spec before any generator runs. The generators
+// iterate spec.questions and dereference spec.meta.{projectName,dockerImage,
+// envPrefix} with no per-field guard at the use site, so an incomplete spec
+// (hand-edited, or served mid-migration) must fail loudly here rather than
+// reach the generators and emit
+// undefined-laden artifacts the user copy-pastes. The JSON Schema enforces the
+// same shape, but only in the Python test lane — never at runtime, which is what
+// this guards. Throws Error with a specific message on the first violation.
+export function validateSpec(spec) {
+  if (!spec || typeof spec !== "object" || !Array.isArray(spec.questions)) {
+    throw new Error("wizard-spec.json is malformed (missing questions array)");
+  }
+  if (!spec.meta || typeof spec.meta !== "object") {
+    throw new Error("wizard-spec.json is malformed (missing meta block)");
+  }
+  for (const k of ["projectName", "dockerImage", "envPrefix"]) {
+    if (typeof spec.meta[k] !== "string" || spec.meta[k] === "") {
+      throw new Error(`wizard-spec.json is malformed (meta.${k} missing or empty)`);
+    }
+  }
+}
+
 // Build {VAR: value} from the spec + answers. Empty non-secret answers are
 // dropped; a visible secret left empty becomes a placeholder so the artifact is
 // still complete and signals "replace me".

--- a/docs/javascripts/config-wizard/wizard-spec-schema.json
+++ b/docs/javascripts/config-wizard/wizard-spec-schema.json
@@ -68,6 +68,15 @@
         {
           "if": { "required": ["type"], "properties": { "type": { "const": "select" } } },
           "then": { "required": ["options"] }
+        },
+        {
+          "$comment": "A dockerVolume/dockerPath question binds its var to the container path (generators.js dockerEnvMap). Without var that binding never happens — reject rather than accept a question that silently emits a dead bind mount (dockerVolume) or a no-op (dockerPath).",
+          "if": { "required": ["dockerVolume"] },
+          "then": { "required": ["var"] }
+        },
+        {
+          "if": { "required": ["dockerPath"] },
+          "then": { "required": ["var"] }
         }
       ],
       "not": { "required": ["dockerVolume", "dockerPath"] }

--- a/docs/javascripts/config-wizard/wizard.js
+++ b/docs/javascripts/config-wizard/wizard.js
@@ -1,5 +1,5 @@
 import {
-  buildEnvMap, isVisible, generateDotenv, generateClaudeJson,
+  validateSpec, buildEnvMap, isVisible, generateDotenv, generateClaudeJson,
   generateDockerRun, generateCompose, generateSystemd,
 } from "./generators.js";
 
@@ -26,8 +26,12 @@ function writeUrlState(spec) {
   const qs = params.toString();
   try {
     history.replaceState(null, "", qs ? `#${qs}` : location.pathname + location.search);
-  } catch {
-    // history.replaceState throws in sandboxed iframes — safe to ignore.
+  } catch (e) {
+    // Benign in a sandboxed iframe (SecurityError, no allow-same-origin). But
+    // replaceState also throws SecurityError when its ~100-calls/10 s throttle
+    // is breached — a real signal the 300 ms debounce is insufficient — so log
+    // the cause at debug level rather than swallow it blind.
+    console.debug("config-wizard: history.replaceState failed", e);
   }
 }
 
@@ -151,10 +155,18 @@ function render() {
     copy.className = "cfg-copy";
     copy.textContent = "Copy";
     copy.addEventListener("click", () => {
-      if (navigator.clipboard) {
-        navigator.clipboard.writeText(text).catch(() => {});
-      } else {
-        // Fallback for non-secure contexts: select the block so Ctrl/Cmd-C works.
+      // Flash a transient affordance on the button, then restore its label.
+      const flash = (msg) => {
+        copy.textContent = msg;
+        setTimeout(() => {
+          copy.textContent = "Copy";
+        }, 1500);
+      };
+      // Select the block so the user can finish with Ctrl/Cmd-C themselves.
+      // Used both when the Clipboard API is absent (non-secure context) and when
+      // writeText rejects (permission/focus) — without it the empty catch left
+      // the user believing a failed copy had succeeded.
+      const selectFallback = () => {
         const range = document.createRange();
         range.selectNodeContents(pre);
         const sel = window.getSelection();
@@ -162,6 +174,12 @@ function render() {
           sel.removeAllRanges();
           sel.addRange(range);
         }
+        flash("Press Ctrl-C");
+      };
+      if (navigator.clipboard) {
+        navigator.clipboard.writeText(text).then(() => flash("Copied!"), selectFallback);
+      } else {
+        selectFallback();
       }
     });
     head.appendChild(copy);
@@ -218,15 +236,10 @@ async function init() {
     const resp = await fetch(specUrl);
     if (!resp.ok) throw new Error(`${resp.status} ${resp.statusText}`);
     const spec = await resp.json();
-    if (!spec || typeof spec !== "object" || !Array.isArray(spec.questions)) {
-      throw new Error("wizard-spec.json is malformed (missing questions array)");
-    }
-    if (!spec.meta || typeof spec.meta !== "object") {
-      // The generators read project identity from spec.meta; a spec missing it
-      // (e.g. mid-migration) must fail loudly here rather than throw an
-      // uncaught TypeError deep inside render().
-      throw new Error("wizard-spec.json is malformed (missing meta block)");
-    }
+    // The generators read project identity from spec.meta and dereference its
+    // required fields unconditionally; validateSpec fails loudly here rather
+    // than let render() emit undefined-laden output (see generators.js).
+    validateSpec(spec);
     SPEC = spec;
   } catch (e) {
     ROOT.textContent = `Failed to load the configuration generator: ${e.message}`;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,9 +17,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
 ]
 dependencies = [
-    # fastmcp + httpx + uvicorn come transitively via fastmcp-pvl-core;
-    # only list deps scholar uses DIRECTLY here.
-    "fastmcp-pvl-core>=3.2.0,<4",
+    "fastmcp-pvl-core>=4.0.0,<5",
     "typer>=0.12",
     # PROJECT-DEPS-START — domain dependencies; kept across copier update
     "httpx",

--- a/src/scholar_mcp/config.py
+++ b/src/scholar_mcp/config.py
@@ -27,6 +27,7 @@ class ProjectConfig:
     directly on this dataclass.
     """
 
+<<<<<<< before updating
     # CONFIG-FIELDS-START — scholar domain fields; kept across copier update
     server: ServerConfig = field(default_factory=ServerConfig)
     server_name: str | None = None
@@ -55,6 +56,24 @@ class ProjectConfig:
         """True when both EPO OPS credentials are set."""
         return (
             self.epo_consumer_key is not None and self.epo_consumer_secret is not None
+=======
+    # CONFIG-FIELDS-START — add domain fields below; kept across copier update
+    # (uncommenting the Path-typed examples below also requires adding
+    #  ``from pathlib import Path`` to the imports at the top of this file.)
+    # (example)
+    # vault_path: Path = Path("/data/vault")
+    # CONFIG-FIELDS-END
+
+    @classmethod
+    def from_env(cls) -> ProjectConfig:
+        """Load :class:`ProjectConfig` from ``SCHOLAR_MCP_*`` env vars."""
+        return cls(
+            server=ServerConfig.from_env(_ENV_PREFIX),
+            # CONFIG-FROM-ENV-START — populate domain fields below; kept across copier update
+            # (example)
+            # vault_path=Path(env(_ENV_PREFIX, "VAULT_PATH", "/data/vault")),
+            # CONFIG-FROM-ENV-END
+>>>>>>> after updating
         )
 
 

--- a/src/scholar_mcp/server.py
+++ b/src/scholar_mcp/server.py
@@ -207,22 +207,6 @@ def make_server(
 
     wire_middleware_stack(mcp)
 
-    # Optional: enable opt-in per-subject authorization on tools / resources /
-    # prompts.  See fastmcp-pvl-core's README "Authorization" section for the
-    # design.  Tools, resources, and prompts opt in by setting
-    # ``meta={"required_scope": "<scope>"}``; absence of the key means
-    # unrestricted.  The middleware is only installed when ``acl_path`` is set.
-    #
-    # from fastmcp_pvl_core import (
-    #     AuthorizationMiddleware,
-    #     load_acl,
-    #     make_acl_authorizer,
-    # )
-    #
-    # if config.acl_path is not None:
-    #     authorizer = make_acl_authorizer(load_acl(config.acl_path))
-    #     mcp.add_middleware(AuthorizationMiddleware(authorizer=authorizer))
-
     register_tools(mcp)
     register_resources(mcp)
     register_prompts(mcp)

--- a/tests/test_config_wizard_smoke.py
+++ b/tests/test_config_wizard_smoke.py
@@ -10,8 +10,9 @@ Two kinds of tests live here, both template-owned and spec-agnostic:
   every spec shares (the ``deployment`` question exists; output carries the
   project identity from ``meta``).
 * Generator unit tests import ``generators.js`` directly and feed it synthetic
-  specs, so they exercise ``dockerVolume`` / ``dockerPath`` behaviour without
-  depending on this project's questions.
+  specs, so they exercise generator behaviour (``dockerVolume`` / ``dockerPath``
+  mapping, ``validateSpec`` rejection of malformed specs) without depending on
+  this project's questions.
 
 Domain-specific assertions belong in ``test_config_wizard_domain.py``.
 """
@@ -113,6 +114,75 @@ def _eval_generators(page: Page, body: str) -> typing.Any:
         + ")(g); }"
     )
     return page.evaluate(script)
+
+
+def test_validate_spec_accepts_complete_spec(page: Page) -> None:
+    err = _eval_generators(
+        page,
+        """(g) => {
+          const spec = { version: 1,
+            meta: { projectName: 'demo', dockerImage: 'img:latest', envPrefix: 'DEMO' },
+            secretKeys: [],
+            questions: [{ id: 'deployment', label: 'W', type: 'select' }],
+            guards: [] };
+          try { g.validateSpec(spec); return null; } catch (e) { return e.message; }
+        }""",
+    )
+    assert err is None
+
+
+def test_validate_spec_rejects_missing_questions(page: Page) -> None:
+    err = _eval_generators(
+        page,
+        """(g) => {
+          const spec = { version: 1,
+            meta: { projectName: 'demo', dockerImage: 'img:latest', envPrefix: 'DEMO' } };
+          try { g.validateSpec(spec); return null; } catch (e) { return e.message; }
+        }""",
+    )
+    assert err is not None
+    assert "missing questions array" in err
+
+
+def test_validate_spec_rejects_missing_meta(page: Page) -> None:
+    err = _eval_generators(
+        page,
+        """(g) => {
+          const spec = { version: 1, questions: [{ id: 'deployment', label: 'W', type: 'select' }] };
+          try { g.validateSpec(spec); return null; } catch (e) { return e.message; }
+        }""",
+    )
+    assert err is not None
+    assert "missing meta block" in err
+
+
+def test_validate_spec_rejects_empty_meta(page: Page) -> None:
+    # meta is an object but lacks the fields the generators dereference: the
+    # exact gap the old `typeof meta === 'object'` guard let through.
+    err = _eval_generators(
+        page,
+        """(g) => {
+          const spec = { version: 1, meta: {},
+            questions: [{ id: 'deployment', label: 'W', type: 'select' }] };
+          try { g.validateSpec(spec); return null; } catch (e) { return e.message; }
+        }""",
+    )
+    assert err is not None
+    assert "meta.projectName missing or empty" in err
+
+
+def test_validate_spec_rejects_empty_meta_field(page: Page) -> None:
+    err = _eval_generators(
+        page,
+        """(g) => {
+          const spec = { version: 1,
+            meta: { projectName: 'demo', dockerImage: '', envPrefix: 'DEMO' },
+            questions: [{ id: 'deployment', label: 'W', type: 'select' }] };
+          try { g.validateSpec(spec); return null; } catch (e) { return e.message; }
+        }""",
+    )
+    assert err is not None
+    assert "meta.dockerImage missing or empty" in err
 
 
 def test_docker_volume_adds_mount_and_fixes_container_path(page: Page) -> None:

--- a/tests/test_config_wizard_spec_schema.py
+++ b/tests/test_config_wizard_spec_schema.py
@@ -141,6 +141,29 @@ def test_schema_accepts_dockervolume_alone(schema: dict[str, Any]) -> None:
     jsonschema.validate(spec, schema)
 
 
+def test_schema_rejects_dockervolume_without_var(schema: dict[str, Any]) -> None:
+    bad = _minimal_valid_spec()
+    bad["questions"].append(
+        {"id": "data_dir", "label": "Data", "type": "text", "dockerVolume": "/data/app"}
+    )
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(bad, schema)
+
+
+def test_schema_rejects_dockerpath_without_var(schema: dict[str, Any]) -> None:
+    bad = _minimal_valid_spec()
+    bad["questions"].append(
+        {
+            "id": "index_path",
+            "label": "Index",
+            "type": "text",
+            "dockerPath": "/data/state/index.db",
+        }
+    )
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(bad, schema)
+
+
 def test_schema_accepts_dockerpath_alone(schema: dict[str, Any]) -> None:
     spec = _minimal_valid_spec()
     spec["questions"].append(


### PR DESCRIPTION
## Template update: `v2.3.0` → `v2.5.1`

[Compare on GitHub](https://github.com/pvliesdonk/fastmcp-server-template/compare/v2.3.0...v2.5.1)

<details><summary>Release notes (v2.5.1)</summary>

- #183 feat(scaffold): document and enable clean detach from the template (closes #182)

</details>

<details><summary>Files changed (14)</summary>

```
 .copier-answers.yml                                |  3 +-
 .github/workflows/docs.yml                         |  8 +-
 CLAUDE.md                                          |  4 +
 FORKING.md                                         | 88 ++++++++++++++++++++++
 README.md                                          | 41 +---------
 docs/guides/authentication.md                      |  6 +-
 docs/javascripts/config-wizard/generators.js       | 22 ++++++
 .../config-wizard/wizard-spec-schema.json          |  9 +++
 docs/javascripts/config-wizard/wizard.js           | 45 +++++++----
 pyproject.toml                                     |  4 +-
 src/scholar_mcp/config.py                          | 19 +++++
 src/scholar_mcp/server.py                          | 16 ----
 tests/test_config_wizard_smoke.py                  | 74 +++++++++++++++++-
 tests/test_config_wizard_spec_schema.py            | 23 ++++++
 14 files changed, 280 insertions(+), 82 deletions(-)
```

</details>

### ⚠️ 4 file(s) with unresolved conflict markers

The `<<<<<<< before updating` markers **are committed to this branch** — resolve them before merging:

- `README.md`
- `docs/guides/authentication.md`
- `pyproject.toml`
- `src/scholar_mcp/config.py`

---

> **Note:** `--skip-answered` was passed, so any **new** template variables introduced since the last update were silently filled with their copier defaults. Skim `.copier-answers.yml` for unexpected new keys.

---

## Agent analysis

### 🔧 Conflict resolutions

**Auto-committed by claude-code** — VERIFY before merging:

- `pyproject.toml` (commit 7702922e528ee084ad333969ddbde817b88986ce): _Accept the template's updated version constraint `fastmcp-pvl-core>=4.0.0,<5` and drop the downstream-only comment (not inside any sentinel block); template body accepted as-is._
- `docs/guides/authentication.md` (commit 7702922e528ee084ad333969ddbde817b88986ce): _Remove the authorization cross-reference paragraph; the v2.5.1 template wraps it in `{% if enable_authorization %}` which renders empty because `enable_authorization: false` in `.copier-answers.yml`._
- `docs/guides/authentication.md` (commit 7702922e528ee084ad333969ddbde817b88986ce): _Accept the template's updated diagram line `Client → mcp-server → OIDC Provider`, dropping the downstream's server-name substitution (`scholar-mcp`) and the now-removed `(OIDCProxy)` annotation; template-owned content outside any sentinel block._
- `README.md` (commit 7702922e528ee084ad333969ddbde817b88986ce): _Accept the template's condensed one-sentence authentication overview; the old `## Authorization (opt-in)` block is template-owned content that v2.5.1 makes conditional on `enable_authorization` (which is `false`), so the section is correctly removed._

**Needs review** — conflict markers remain, operator must resolve:

- `src/scholar_mcp/config.py`: The template restructured `ProjectConfig` in three orthogonal ways simultaneously: (1) moved `server:` from inside CONFIG-FIELDS-START/END to outside it, colliding with the downstream's sentinel-ownership rule; (2) introduced a `from_env` classmethod inside the class while removing the standalone `load_config()` function, which may break callers in `server.py`/`cli.py` that call `load_config()` directly; (3) added `frozen=True` to `@dataclass`, a potential breaking change if mutable config is relied on. The downstream also has `@property epo_configured` (not in template) and a CONFIG-FROM-ENV-START/END block in `load_config()` that must move to `from_env()`. Resolving this requires operator judgment on whether to adopt the classmethod pattern fully, whether to keep `load_config()` as a shim, and whether `frozen=True` is safe — none of which can be determined from the template diff alone without inspecting callers.
  Recommended approach: Keep all downstream-owned domain fields (`server_name`, `read_only`, `s2_api_key`, `docling_url`, `vlm_api_url`, `vlm_api_key`, `vlm_model`, `cache_dir`, `contact_email`, `epo_consumer_key`, `epo_consumer_secret`, `google_books_api_key`, `github_token`, and the commented `acl_path`) inside the CONFIG-FIELDS-START/END sentinel alongside the template's new comment text. Move `server: ServerConfig` outside the sentinel (above CONFIG-FIELDS-START) to match the template's new structure. Accept the template's new `from_env` classmethod (replacing `load_config`) and relocate the CONFIG-FROM-ENV-START/END block from `load_config()` into `from_env()`, preserving all downstream env-load lines. Keep `@property epo_configured` as a domain method immediately after CONFIG-FIELDS-END. Retain `load_config()` as a backward-compatible shim (`return ProjectConfig.from_env()`) only if any callers outside `config.py` depend on it (check `server.py` and `cli.py`). Decide whether to add `frozen=True` to `@dataclass` — this is a breaking change if any code mutates the config object. Remove imports (`logging`, `os`, `parse_bool`) that become unused if `load_config()` is replaced by `from_env()`; add them back only if `load_config()` is kept as a shim.

### ✨ New features in this update

**Needs your attention** (action-required):

- #177 feat(scaffold): gate Authorization scaffold behind enable_authorization — needs opt-in.
  Adds a new copier boolean variable `enable_authorization` (default `false`) and gates the full five-surface authorization cluster on it: the README 'Authorization (opt-in)' section, the `acl_path` config stubs in `config.py`, the `AuthorizationMiddleware` block in `server.py`, the `*_ACL_PATH` line in `.env.example`, and the cross-link in `docs/guides/authentication.md`. This downstream has `enable_authorization: false` in `.copier-answers.yml`, so all authorization stubs have been **removed** from `config.py` and `server.py` by this update. If scholar-mcp needs per-caller scope gating, set `enable_authorization: true` in `.copier-answers.yml` and re-run `copier update` — that will re-render the full authorization cluster. The `.env.example` file is `_skip_if_exists` and will not be updated automatically regardless.
- #179 feat(scaffold): co-locate authentication + authorization — needs opt-in.
  Adds a new gated `docs/guides/authorization.md` guide (only rendered when `enable_authorization: true`) adjacent to the existing authentication guide, adds a `mkdocs.yml` nav entry for it, updates `docs/guides/authentication.md` with a cross-link, and adds brief README authentication + authorization pointer sections. The authentication guide and README changes ship automatically (both template-owned). The new authorization guide, its nav entry, and the README authorization section are conditional on `enable_authorization: true` — with this downstream set to `false`, those surfaces do not render. To get the full co-located authn/authz documentation set, set `enable_authorization: true`. The `docs/superpowers/` design and plan documents are in `_exclude` and do not flow to downstream.

**Ships through automatically** (informational):

- #174 fix(config-wizard): deep meta validation + dockerVolume/dockerPath var constraint — applied this run
- #181 feat(scaffold): migrate authorization to pvl-core v4 native AuthChecks — applied this run
- #183 feat(scaffold): document and enable clean detach from the template — applied this run

