### PR TITLE
chore: update copier template to v2.2.0 (config wizard)

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by `copier update`.
-_commit: v2.2.0
+_commit: v2.2.1
 _src_path: https://github.com/pvliesdonk/fastmcp-server-template
 docker_registry: ghcr.io/pvliesdonk
 domain_description: FastMCP server for Semantic Scholar with OpenAlex enrichment and

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by `copier update`.
-_commit: v2.1.2
+_commit: v2.2.0
 _src_path: https://github.com/pvliesdonk/fastmcp-server-template
 docker_registry: ghcr.io/pvliesdonk
 domain_description: FastMCP server for Semantic Scholar with OpenAlex enrichment and

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,6 +44,15 @@ jobs:
       - name: Build documentation
         run: uv run mkdocs build --strict
 
+      - name: Install browser test deps
+        run: uv sync --no-default-groups --all-extras --group docs --group browser --frozen
+
+      - name: Install Chromium
+        run: uv run playwright install --with-deps chromium
+
+      - name: Run config-wizard smoke test
+        run: uv run pytest tests/test_config_wizard_smoke.py -v -m browser
+
   deploy:
     # Publish versioned docs with mike, serving from the gh-pages branch:
     #   stable release (prerelease=false) -> version <major.minor> + `latest` alias (default)

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,13 @@ site/
 .claude/worktrees/
 .claude/settings.local.json
 docs/superpowers/
+.repowise/
+
+# Vale downloaded styles (fetched by `vale sync`; not checked in)
+.vale/styles/Google/
+.vale/styles/ai-tells/
+.vale/styles/proselint/
+.vale/styles/write-good/
 
 # --- Scholar-specific local artifacts
 *.npy

--- a/docs/configuration-generator.md
+++ b/docs/configuration-generator.md
@@ -1,0 +1,11 @@
+# Configuration Generator
+
+Answer a few questions and copy a ready-to-use configuration for your exact
+deployment. Everything runs in your browser; nothing you type is sent anywhere.
+Secret fields (tokens, keys) are never included in the shareable link; replace
+the `<YOUR_...>` placeholders if you leave them blank.
+
+<!-- The relative path relies on MkDocs' default use_directory_urls: true -->
+<div id="cfg-wizard" data-spec-url="../javascripts/config-wizard/wizard-spec.json">
+  Loading the configuration generator…
+</div>

--- a/docs/javascripts/config-wizard/generators.js
+++ b/docs/javascripts/config-wizard/generators.js
@@ -77,7 +77,7 @@ function dockerEnvMap(map) {
 // value and would silently truncate the value on load).
 const dotenvQuote = (v) => {
   const s = String(v);
-  if (!/[#"'\\\s]/.test(s)) return s;
+  if (!/[#"'\\\s$]/.test(s)) return s;
   return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\$/g, '\\$')}"`;
 };
 

--- a/docs/javascripts/config-wizard/generators.js
+++ b/docs/javascripts/config-wizard/generators.js
@@ -1,0 +1,143 @@
+// Pure config-output generators. No DOM, no spec knowledge beyond the emit map.
+
+const IMAGE = "ghcr.io/pvliesdonk/scholar-mcp:latest";
+
+// Vars whose value is fixed to a container path in Docker/Compose output.
+const CONTAINER_PATHS = {
+  // PROJECT-WIZARD-CONTAINER-PATHS-START — add container paths below; kept across copier update
+  // PROJECT-WIZARD-CONTAINER-PATHS-END
+};
+
+const SECRET_PLACEHOLDER = (key) => `<YOUR_${key.replace(/^SCHOLAR_MCP_/, "")}>`;
+
+// Single-quote a value for a POSIX shell `-e KEY=value` argument, but only when
+// it contains characters outside the shell-safe set (keeps clean output tidy).
+const shellQuote = (v) => {
+  const s = String(v);
+  return /^[A-Za-z0-9_@%+=:,./-]+$/.test(s) ? s : `'${s.replace(/'/g, "'\\''")}'`;
+};
+
+// Quote a YAML scalar only when it contains characters that would otherwise
+// break parsing (or has surrounding whitespace, or is empty).
+const yamlScalar = (v) => {
+  const s = String(v);
+  return /[\n:#[\]{}&*?|<>=!%@,`"']|^\s|\s$|^$/.test(s) ? JSON.stringify(s) : s;
+};
+
+// A systemd `Environment=` line. systemd does NOT expand `$` in Environment=
+// values (expansion only happens in ExecXYZ= directives), so `$` is left
+// literal. It DOES resolve `%` specifiers (escaped as `%%`) and process
+// C-style `\`/`"` escapes (systemd/systemd#36488), so those are escaped, and
+// the assignment is wrapped in quotes when it contains whitespace, a quote, or
+// a backslash.
+const systemdLine = (k, v) => {
+  const s = String(v).replace(/%/g, "%%");
+  if (!/[\s"\\]/.test(s)) return `Environment=${k}=${s}`;
+  const escaped = s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  return `Environment="${k}=${escaped}"`;
+};
+
+// Build {VAR: value} from the spec + answers. Empty non-secret answers are
+// dropped; a visible secret left empty becomes a placeholder so the artifact is
+// still complete and signals "replace me".
+export function buildEnvMap(spec, answers) {
+  const secrets = new Set(spec.secretKeys);
+  const map = {};
+  for (const q of spec.questions) {
+    if (!isVisible(q, answers)) continue;
+    if (q.options) {
+      const chosen = q.options.find((o) => o.value === answers[q.id]);
+      if (chosen && chosen.emit) Object.assign(map, chosen.emit);
+    }
+    if (q.var) {
+      const raw = answers[q.id];
+      if (raw !== undefined && raw !== "") map[q.var] = raw;
+      else if (secrets.has(q.var)) map[q.var] = SECRET_PLACEHOLDER(q.var);
+    }
+  }
+  return map;
+}
+
+export function isVisible(q, answers) {
+  if (!q.showIf) return true;
+  return Object.entries(q.showIf).every(([k, allowed]) => allowed.includes(answers[k]));
+}
+
+function dockerEnvMap(map) {
+  const out = { ...map };
+  for (const [k, v] of Object.entries(CONTAINER_PATHS)) {
+    if (k in out) out[k] = v;
+  }
+  out.FASTMCP_HOME = "/data/state/fastmcp";
+  return out;
+}
+
+// Quote a .env value when it contains characters that common dotenv parsers
+// treat specially (notably `#`, which starts an inline comment in an unquoted
+// value and would silently truncate the value on load).
+const dotenvQuote = (v) => {
+  const s = String(v);
+  if (!/[#"'\\\s]/.test(s)) return s;
+  return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\$/g, '\\$')}"`;
+};
+
+export function generateDotenv(map) {
+  return Object.entries(map).map(([k, v]) => `${k}=${dotenvQuote(v)}`).join("\n") + "\n";
+}
+
+export function generateClaudeJson(map) {
+  return JSON.stringify(
+    { mcpServers: { "scholar-mcp": { command: "scholar-mcp", args: ["serve"], env: map } } },
+    null, 2,
+  );
+}
+
+export function generateDockerRun(map) {
+  const env = dockerEnvMap(map);
+  const lines = [
+    "docker run -d --name scholar-mcp",
+    "  -p 8000:8000",
+    "  -v state-data:/data/state",
+  ];
+  for (const [k, v] of Object.entries(env)) lines.push(`  -e ${k}=${shellQuote(v)}`);
+  lines.push(`  ${IMAGE}`);
+  return lines.join(" \\\n");
+}
+
+export function generateCompose(map) {
+  const env = dockerEnvMap(map);
+  const envLines = Object.entries(env).map(([k, v]) => `      ${k}: ${yamlScalar(v)}`).join("\n");
+  return [
+    "services:",
+    "  scholar-mcp:",
+    `    image: ${IMAGE}`,
+    "    ports:",
+    '      - "8000:8000"',
+    "    volumes:",
+    "      - state-data:/data/state",
+    "    environment:",
+    envLines,
+    "volumes:",
+    "  state-data:",
+  ].join("\n");
+}
+
+export function generateSystemd(map) {
+  const envLines = Object.entries(map).map(([k, v]) => systemdLine(k, v)).join("\n");
+  return [
+    "[Unit]",
+    "Description=scholar-mcp",
+    "After=network.target",
+    "",
+    "[Service]",
+    "Type=simple",
+    "# Create this user first: sudo useradd --system --no-create-home scholar-mcp",
+    "User=scholar-mcp",
+    "ExecStart=/opt/scholar-mcp/venv/bin/scholar-mcp serve --transport http",
+    envLines,
+    "Restart=on-failure",
+    "",
+    "[Install]",
+    "WantedBy=multi-user.target",
+  ].join("\n");
+}

--- a/docs/javascripts/config-wizard/generators.js
+++ b/docs/javascripts/config-wizard/generators.js
@@ -77,7 +77,7 @@ function dockerEnvMap(map) {
 // value and would silently truncate the value on load).
 const dotenvQuote = (v) => {
   const s = String(v);
-  if (!/[#"'\\\s$]/.test(s)) return s;
+  if (!/[#"'\\\s]/.test(s)) return s;
   return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\$/g, '\\$')}"`;
 };
 

--- a/docs/javascripts/config-wizard/wizard-spec.json
+++ b/docs/javascripts/config-wizard/wizard-spec.json
@@ -6,9 +6,7 @@
     "SCHOLAR_MCP_EPO_CONSUMER_KEY",
     "SCHOLAR_MCP_EPO_CONSUMER_SECRET",
     "SCHOLAR_MCP_GOOGLE_BOOKS_API_KEY",
-    "SCHOLAR_MCP_VLM_API_KEY",
-    "SCHOLAR_MCP_OIDC_CLIENT_SECRET",
-    "SCHOLAR_MCP_OIDC_JWT_SIGNING_KEY"
+    "SCHOLAR_MCP_VLM_API_KEY"
   ],
   "questions": [
     {
@@ -40,8 +38,7 @@
       "label": "Read-only mode",
       "help": "When enabled, PDF download and conversion tools are hidden. Recommended for shared or untrusted deployments.",
       "type": "bool",
-      "var": "SCHOLAR_MCP_READ_ONLY",
-      "default": true
+      "var": "SCHOLAR_MCP_READ_ONLY"
     },
     {
       "id": "bearer_token",
@@ -118,6 +115,7 @@
     {
       "id": "log_level",
       "label": "Log level",
+      "help": "Verbosity level: DEBUG, INFO, WARNING (default), or ERROR.",
       "type": "text",
       "var": "FASTMCP_LOG_LEVEL",
       "advancedGroup": "Logging"

--- a/docs/javascripts/config-wizard/wizard-spec.json
+++ b/docs/javascripts/config-wizard/wizard-spec.json
@@ -1,0 +1,135 @@
+{
+  "version": 1,
+  "secretKeys": [
+    "SCHOLAR_MCP_BEARER_TOKEN",
+    "SCHOLAR_MCP_S2_API_KEY",
+    "SCHOLAR_MCP_EPO_CONSUMER_KEY",
+    "SCHOLAR_MCP_EPO_CONSUMER_SECRET",
+    "SCHOLAR_MCP_GOOGLE_BOOKS_API_KEY",
+    "SCHOLAR_MCP_VLM_API_KEY",
+    "SCHOLAR_MCP_OIDC_CLIENT_SECRET",
+    "SCHOLAR_MCP_OIDC_JWT_SIGNING_KEY"
+  ],
+  "questions": [
+    {
+      "id": "deployment",
+      "label": "Where will the server run?",
+      "help": "Local stdio for Claude Desktop/Code, or an HTTP server for Docker/systemd.",
+      "type": "select",
+      "options": [
+        { "value": "local", "label": "Local (Claude Desktop / Claude Code, stdio)" },
+        { "value": "server", "label": "Server (HTTP — Docker / Compose / systemd)" }
+      ]
+    },
+    {
+      "id": "s2_api_key",
+      "label": "Semantic Scholar API key",
+      "help": "Strongly recommended. Unauthenticated requests are rate-limited to ~1 req/s; authenticated requests get ~10 req/s. Get one at semanticscholar.org/product/api.",
+      "type": "text",
+      "var": "SCHOLAR_MCP_S2_API_KEY"
+    },
+    {
+      "id": "contact_email",
+      "label": "Contact email",
+      "help": "Sent in the OpenAlex User-Agent header for polite-pool access. Also enables Unpaywall PDF lookups.",
+      "type": "text",
+      "var": "SCHOLAR_MCP_CONTACT_EMAIL"
+    },
+    {
+      "id": "read_only",
+      "label": "Read-only mode",
+      "help": "When enabled, PDF download and conversion tools are hidden. Recommended for shared or untrusted deployments.",
+      "type": "bool",
+      "var": "SCHOLAR_MCP_READ_ONLY",
+      "default": true
+    },
+    {
+      "id": "bearer_token",
+      "label": "Bearer token",
+      "help": "Static token for HTTP auth. Any non-empty string enables bearer auth. Browser-only — never included in shareable links.",
+      "type": "text",
+      "var": "SCHOLAR_MCP_BEARER_TOKEN",
+      "showIf": { "deployment": ["server"] }
+    },
+    {
+      "id": "epo_consumer_key",
+      "label": "EPO OPS consumer key",
+      "help": "Required for patent search tools. Register at developers.epo.org.",
+      "type": "text",
+      "var": "SCHOLAR_MCP_EPO_CONSUMER_KEY",
+      "advancedGroup": "Patents"
+    },
+    {
+      "id": "epo_consumer_secret",
+      "label": "EPO OPS consumer secret",
+      "help": "Required alongside the consumer key for EPO OPS access.",
+      "type": "text",
+      "var": "SCHOLAR_MCP_EPO_CONSUMER_SECRET",
+      "advancedGroup": "Patents"
+    },
+    {
+      "id": "docling_url",
+      "label": "Docling URL",
+      "help": "Base URL of a running docling-serve instance (e.g. http://localhost:5001). Required for PDF conversion.",
+      "type": "text",
+      "var": "SCHOLAR_MCP_DOCLING_URL",
+      "advancedGroup": "PDF Conversion"
+    },
+    {
+      "id": "vlm_api_url",
+      "label": "VLM API URL",
+      "help": "OpenAI-compatible endpoint for formula/figure enrichment during PDF conversion.",
+      "type": "text",
+      "var": "SCHOLAR_MCP_VLM_API_URL",
+      "advancedGroup": "PDF Conversion"
+    },
+    {
+      "id": "vlm_api_key",
+      "label": "VLM API key",
+      "help": "API key for the VLM endpoint.",
+      "type": "text",
+      "var": "SCHOLAR_MCP_VLM_API_KEY",
+      "advancedGroup": "PDF Conversion"
+    },
+    {
+      "id": "vlm_model",
+      "label": "VLM model",
+      "help": "Model name used with the VLM endpoint.",
+      "type": "text",
+      "var": "SCHOLAR_MCP_VLM_MODEL",
+      "advancedGroup": "PDF Conversion"
+    },
+    {
+      "id": "google_books_api_key",
+      "label": "Google Books API key",
+      "help": "Optional. Unlocks higher rate limits for the Google Books enricher. Without it, the enricher works at 1000 requests/day.",
+      "type": "text",
+      "var": "SCHOLAR_MCP_GOOGLE_BOOKS_API_KEY",
+      "advancedGroup": "Books"
+    },
+    {
+      "id": "cache_dir",
+      "label": "Cache directory",
+      "help": "Path for the SQLite database and downloaded PDFs.",
+      "type": "text",
+      "var": "SCHOLAR_MCP_CACHE_DIR",
+      "advancedGroup": "Advanced"
+    },
+    {
+      "id": "log_level",
+      "label": "Log level",
+      "type": "text",
+      "var": "FASTMCP_LOG_LEVEL",
+      "advancedGroup": "Logging"
+    },
+    {
+      "id": "rich_logging",
+      "label": "Rich logging",
+      "help": "Disable for plain/JSON output suitable for log aggregators (Loki, Datadog, Splunk).",
+      "type": "bool",
+      "var": "FASTMCP_ENABLE_RICH_LOGGING",
+      "advancedGroup": "Logging"
+    }
+  ],
+  "guards": []
+}

--- a/docs/javascripts/config-wizard/wizard.js
+++ b/docs/javascripts/config-wizard/wizard.js
@@ -1,0 +1,221 @@
+import {
+  buildEnvMap, isVisible, generateDotenv, generateClaudeJson,
+  generateDockerRun, generateCompose, generateSystemd,
+} from "./generators.js";
+
+const MOUNT_ID = "cfg-wizard";
+const answers = {};
+
+function readUrlState(spec) {
+  const hash = new URLSearchParams(location.hash.slice(1));
+  const secrets = new Set(spec.secretKeys);
+  for (const q of spec.questions) {
+    if (secrets.has(q.var)) continue; // never hydrate secrets from URL
+    const v = hash.get(q.id);
+    if (v !== null) answers[q.id] = v;
+  }
+}
+
+function writeUrlState(spec) {
+  const secrets = new Set(spec.secretKeys);
+  const params = new URLSearchParams();
+  for (const q of spec.questions) {
+    if (secrets.has(q.var)) continue;
+    if (answers[q.id] !== undefined && answers[q.id] !== "") params.set(q.id, answers[q.id]);
+  }
+  const qs = params.toString();
+  history.replaceState(null, "", qs ? `#${qs}` : location.pathname + location.search);
+}
+
+function field(q, secrets) {
+  const wrap = document.createElement("label");
+  wrap.className = "cfg-field";
+  wrap.dataset.qid = q.id;
+  const title = document.createElement("span");
+  title.className = "cfg-label";
+  title.textContent = q.label;
+  wrap.appendChild(title);
+  if (q.help) {
+    const help = document.createElement("small");
+    help.className = "cfg-help";
+    help.textContent = q.help;
+    wrap.appendChild(help);
+  }
+  let input;
+  if (q.type === "select") {
+    input = document.createElement("select");
+    for (const opt of q.options) {
+      const o = document.createElement("option");
+      o.value = opt.value;
+      o.textContent = opt.label;
+      input.appendChild(o);
+    }
+  } else if (q.type === "bool") {
+    input = document.createElement("select");
+    for (const v of ["", "true", "false"]) {
+      const o = document.createElement("option");
+      o.value = v;
+      o.textContent = v || "(default)";
+      input.appendChild(o);
+    }
+  } else {
+    input = document.createElement("input");
+    input.type = q.type === "number" ? "number" : "text";
+  }
+  if (secrets.has(q.var)) wrap.classList.add("cfg-secret");
+  if (answers[q.id] !== undefined) input.value = answers[q.id];
+  // One listener per control: selects/bools settle on "change"; text/number
+  // fields update live on "input". Avoids the double render + double
+  // history.replaceState that "input"+"change" both firing on <select> causes.
+  const evt = q.type === "select" || q.type === "bool" ? "change" : "input";
+  input.addEventListener(evt, () => {
+    answers[q.id] = input.value;
+    render();
+  });
+  wrap.appendChild(input);
+  return wrap;
+}
+
+let SPEC = null;
+let ROOT = null;
+
+function render() {
+  const spec = SPEC;
+  const secrets = new Set(spec.secretKeys);
+  // Capture focus + caret so a full re-render (replaceChildren) doesn't drop
+  // the user mid-keystroke in a text field.
+  const active = document.activeElement;
+  const activeQid =
+    active && active.closest ? active.closest(".cfg-field")?.dataset.qid : null;
+  let selStart = null;
+  let selEnd = null;
+  try {
+    selStart = active.selectionStart;
+    selEnd = active.selectionEnd;
+  } catch {
+    // selects / number inputs do not expose a text selection
+  }
+  const core = document.createElement("div");
+  core.className = "cfg-core";
+  const advanced = {};
+  for (const q of spec.questions) {
+    if (!isVisible(q, answers)) continue;
+    const el = field(q, secrets);
+    if (q.advancedGroup) {
+      (advanced[q.advancedGroup] ??= []).push(el);
+    } else {
+      core.appendChild(el);
+    }
+  }
+  const drawer = document.createElement("details");
+  drawer.className = "cfg-advanced";
+  const sum = document.createElement("summary");
+  sum.textContent = "Advanced tuning";
+  drawer.appendChild(sum);
+  for (const [group, els] of Object.entries(advanced)) {
+    const h = document.createElement("h4");
+    h.textContent = group;
+    drawer.appendChild(h);
+    els.forEach((e) => drawer.appendChild(e));
+  }
+
+  const map = buildEnvMap(spec, answers);
+  const local = answers.deployment !== "server";
+  const tabs = local
+    ? [["Claude config", generateClaudeJson(map)], [".env", generateDotenv(map)]]
+    : [
+        ["docker run", generateDockerRun(map)],
+        ["compose", generateCompose(map)],
+        ["systemd", generateSystemd(map)],
+        [".env", generateDotenv(map)],
+      ];
+  const out = document.createElement("div");
+  out.className = "cfg-output";
+  for (const [name, text] of tabs) {
+    const block = document.createElement("div");
+    block.className = "cfg-tab";
+    const head = document.createElement("div");
+    head.className = "cfg-tab-head";
+    head.textContent = name;
+    const pre = document.createElement("pre");
+    pre.className = "cfg-pre";
+    pre.textContent = text;
+    const copy = document.createElement("button");
+    copy.type = "button";
+    copy.className = "cfg-copy";
+    copy.textContent = "Copy";
+    copy.addEventListener("click", () => {
+      if (navigator.clipboard) {
+        navigator.clipboard.writeText(text).catch(() => {});
+      } else {
+        // Fallback for non-secure contexts: select the block so Ctrl/Cmd-C works.
+        const range = document.createRange();
+        range.selectNodeContents(pre);
+        const sel = window.getSelection();
+        if (sel) {
+          sel.removeAllRanges();
+          sel.addRange(range);
+        }
+      }
+    });
+    head.appendChild(copy);
+    block.appendChild(head);
+    block.appendChild(pre);
+    out.appendChild(block);
+  }
+
+  const warnings = document.createElement("div");
+  warnings.className = "cfg-warnings";
+  for (const g of spec.guards) {
+    if (Object.entries(g.when).every(([k, vals]) => vals.includes(answers[k]))) {
+      const w = document.createElement("div");
+      w.className = `cfg-${g.level}`;
+      w.textContent = g.message;
+      warnings.appendChild(w);
+    }
+  }
+
+  ROOT.replaceChildren(core, drawer, warnings, out);
+  writeUrlState(spec);
+
+  // Restore focus + caret to the field the user was editing.
+  if (activeQid) {
+    const restored = ROOT.querySelector(
+      `.cfg-field[data-qid="${activeQid}"] input, .cfg-field[data-qid="${activeQid}"] select`,
+    );
+    if (restored) {
+      restored.focus();
+      if (selStart !== null && restored.tagName === "INPUT" && restored.type !== "number") {
+        try {
+          restored.setSelectionRange(selStart, selEnd);
+        } catch {
+          // input type does not support text selection
+        }
+      }
+    }
+  }
+}
+
+async function init() {
+  ROOT = document.getElementById(MOUNT_ID);
+  if (!ROOT) return;
+  const specUrl = ROOT.dataset.specUrl;
+  try {
+    const resp = await fetch(specUrl);
+    if (!resp.ok) throw new Error(`${resp.status} ${resp.statusText}`);
+    SPEC = await resp.json();
+  } catch (e) {
+    ROOT.textContent = `Failed to load the configuration generator: ${e.message}`;
+    return;
+  }
+  readUrlState(SPEC);
+  for (const q of SPEC.questions) {
+    if (answers[q.id] === undefined && q.type === "select" && q.options?.length) {
+      answers[q.id] = q.options[0].value;
+    }
+  }
+  render();
+}
+
+if (document.readyState !== "loading") init();
+else document.addEventListener("DOMContentLoaded", init);

--- a/docs/javascripts/config-wizard/wizard.js
+++ b/docs/javascripts/config-wizard/wizard.js
@@ -24,7 +24,11 @@ function writeUrlState(spec) {
     if (answers[q.id] !== undefined && answers[q.id] !== "") params.set(q.id, answers[q.id]);
   }
   const qs = params.toString();
-  history.replaceState(null, "", qs ? `#${qs}` : location.pathname + location.search);
+  try {
+    history.replaceState(null, "", qs ? `#${qs}` : location.pathname + location.search);
+  } catch {
+    // history.replaceState throws in sandboxed iframes — safe to ignore.
+  }
 }
 
 function field(q, secrets) {
@@ -78,6 +82,7 @@ function field(q, secrets) {
 
 let SPEC = null;
 let ROOT = null;
+let _writeTimer = null;
 
 function render() {
   const spec = SPEC;
@@ -166,7 +171,7 @@ function render() {
 
   const warnings = document.createElement("div");
   warnings.className = "cfg-warnings";
-  for (const g of spec.guards) {
+  for (const g of (spec.guards ?? [])) {
     if (Object.entries(g.when).every(([k, vals]) => vals.includes(answers[k]))) {
       const w = document.createElement("div");
       w.className = `cfg-${g.level}`;
@@ -175,13 +180,21 @@ function render() {
     }
   }
 
-  ROOT.replaceChildren(core, drawer, warnings, out);
-  writeUrlState(spec);
+  if (Object.keys(advanced).length > 0) {
+    ROOT.replaceChildren(core, drawer, warnings, out);
+  } else {
+    ROOT.replaceChildren(core, warnings, out);
+  }
+  // Debounce URL writes: browsers throttle history.replaceState to ~100
+  // calls/10 s, and URL sync is a "share" feature, not live feedback.
+  clearTimeout(_writeTimer);
+  _writeTimer = setTimeout(() => writeUrlState(spec), 300);
 
   // Restore focus + caret to the field the user was editing.
   if (activeQid) {
+    const escaped = CSS.escape(activeQid);
     const restored = ROOT.querySelector(
-      `.cfg-field[data-qid="${activeQid}"] input, .cfg-field[data-qid="${activeQid}"] select`,
+      `.cfg-field[data-qid="${escaped}"] input, .cfg-field[data-qid="${escaped}"] select`,
     );
     if (restored) {
       restored.focus();
@@ -203,15 +216,26 @@ async function init() {
   try {
     const resp = await fetch(specUrl);
     if (!resp.ok) throw new Error(`${resp.status} ${resp.statusText}`);
-    SPEC = await resp.json();
+    const spec = await resp.json();
+    if (!spec || typeof spec !== "object" || !Array.isArray(spec.questions)) {
+      throw new Error("wizard-spec.json is malformed (missing questions array)");
+    }
+    SPEC = spec;
   } catch (e) {
     ROOT.textContent = `Failed to load the configuration generator: ${e.message}`;
     return;
   }
   readUrlState(SPEC);
+  // Initialize all answers so guards that match [""] fire on the first render.
+  // Secrets are excluded from URL hydration (readUrlState skips them) so they
+  // also need this default, ensuring guards referencing secret question IDs
+  // evaluate correctly before the user has typed anything.
   for (const q of SPEC.questions) {
-    if (answers[q.id] === undefined && q.type === "select" && q.options?.length) {
+    if (answers[q.id] !== undefined) continue;
+    if (q.type === "select" && q.options?.length) {
       answers[q.id] = q.options[0].value;
+    } else {
+      answers[q.id] = "";
     }
   }
   render();

--- a/docs/javascripts/config-wizard/wizard.js
+++ b/docs/javascripts/config-wizard/wizard.js
@@ -78,6 +78,7 @@ function field(q, secrets) {
 
 let SPEC = null;
 let ROOT = null;
+let _writeTimer = null;
 
 function render() {
   const spec = SPEC;
@@ -176,7 +177,10 @@ function render() {
   }
 
   ROOT.replaceChildren(core, drawer, warnings, out);
-  writeUrlState(spec);
+  // Debounce URL writes: browsers throttle history.replaceState to ~100
+  // calls/10 s, and URL sync is a "share" feature, not live feedback.
+  clearTimeout(_writeTimer);
+  _writeTimer = setTimeout(() => writeUrlState(spec), 300);
 
   // Restore focus + caret to the field the user was editing.
   if (activeQid) {

--- a/docs/javascripts/config-wizard/wizard.js
+++ b/docs/javascripts/config-wizard/wizard.js
@@ -24,11 +24,7 @@ function writeUrlState(spec) {
     if (answers[q.id] !== undefined && answers[q.id] !== "") params.set(q.id, answers[q.id]);
   }
   const qs = params.toString();
-  try {
-    history.replaceState(null, "", qs ? `#${qs}` : location.pathname + location.search);
-  } catch {
-    // SecurityError in sandboxed iframes — URL state is best-effort.
-  }
+  history.replaceState(null, "", qs ? `#${qs}` : location.pathname + location.search);
 }
 
 function field(q, secrets) {
@@ -82,7 +78,6 @@ function field(q, secrets) {
 
 let SPEC = null;
 let ROOT = null;
-let _writeTimer = null;
 
 function render() {
   const spec = SPEC;
@@ -171,7 +166,7 @@ function render() {
 
   const warnings = document.createElement("div");
   warnings.className = "cfg-warnings";
-  for (const g of (spec.guards ?? [])) {
+  for (const g of spec.guards) {
     if (Object.entries(g.when).every(([k, vals]) => vals.includes(answers[k]))) {
       const w = document.createElement("div");
       w.className = `cfg-${g.level}`;
@@ -181,10 +176,7 @@ function render() {
   }
 
   ROOT.replaceChildren(core, drawer, warnings, out);
-  // Debounce URL writes: browsers throttle history.replaceState to ~100
-  // calls/10 s, and URL sync is a "share" feature, not live feedback.
-  clearTimeout(_writeTimer);
-  _writeTimer = setTimeout(() => writeUrlState(spec), 300);
+  writeUrlState(spec);
 
   // Restore focus + caret to the field the user was editing.
   if (activeQid) {
@@ -211,11 +203,7 @@ async function init() {
   try {
     const resp = await fetch(specUrl);
     if (!resp.ok) throw new Error(`${resp.status} ${resp.statusText}`);
-    const spec = await resp.json();
-    if (!spec || typeof spec !== "object" || !Array.isArray(spec.questions)) {
-      throw new Error("wizard-spec.json is malformed (missing questions array)");
-    }
-    SPEC = spec;
+    SPEC = await resp.json();
   } catch (e) {
     ROOT.textContent = `Failed to load the configuration generator: ${e.message}`;
     return;

--- a/docs/javascripts/config-wizard/wizard.js
+++ b/docs/javascripts/config-wizard/wizard.js
@@ -24,7 +24,11 @@ function writeUrlState(spec) {
     if (answers[q.id] !== undefined && answers[q.id] !== "") params.set(q.id, answers[q.id]);
   }
   const qs = params.toString();
-  history.replaceState(null, "", qs ? `#${qs}` : location.pathname + location.search);
+  try {
+    history.replaceState(null, "", qs ? `#${qs}` : location.pathname + location.search);
+  } catch {
+    // SecurityError in sandboxed iframes — URL state is best-effort.
+  }
 }
 
 function field(q, secrets) {
@@ -207,7 +211,11 @@ async function init() {
   try {
     const resp = await fetch(specUrl);
     if (!resp.ok) throw new Error(`${resp.status} ${resp.statusText}`);
-    SPEC = await resp.json();
+    const spec = await resp.json();
+    if (!spec || typeof spec !== "object" || !Array.isArray(spec.questions)) {
+      throw new Error("wizard-spec.json is malformed (missing questions array)");
+    }
+    SPEC = spec;
   } catch (e) {
     ROOT.textContent = `Failed to load the configuration generator: ${e.message}`;
     return;

--- a/docs/javascripts/config-wizard/wizard.js
+++ b/docs/javascripts/config-wizard/wizard.js
@@ -171,7 +171,7 @@ function render() {
 
   const warnings = document.createElement("div");
   warnings.className = "cfg-warnings";
-  for (const g of spec.guards) {
+  for (const g of (spec.guards ?? [])) {
     if (Object.entries(g.when).every(([k, vals]) => vals.includes(answers[k]))) {
       const w = document.createElement("div");
       w.className = `cfg-${g.level}`;

--- a/docs/stylesheets/config-wizard.css
+++ b/docs/stylesheets/config-wizard.css
@@ -14,6 +14,8 @@
 .cfg-tab-head { display: flex; justify-content: space-between; align-items: center; font-weight: 600; }
 .cfg-copy { cursor: pointer; padding: 0.2rem 0.6rem; border-radius: 4px; border: 1px solid var(--md-default-fg-color--lighter); background: var(--md-default-bg-color); }
 .cfg-pre { background: var(--md-code-bg-color); padding: 0.75rem; border-radius: 6px; overflow-x: auto; white-space: pre; }
-.cfg-warn { color: #b26a00; }
-[data-md-color-scheme="slate"] .cfg-warn { color: #e0a83a; }
+.cfg-warning { color: #b26a00; }
+[data-md-color-scheme="slate"] .cfg-warning { color: #e0a83a; }
+.cfg-error { color: #c0392b; }
+[data-md-color-scheme="slate"] .cfg-error { color: #e74c3c; }
 .cfg-info { color: var(--md-default-fg-color--light); }

--- a/docs/stylesheets/config-wizard.css
+++ b/docs/stylesheets/config-wizard.css
@@ -1,0 +1,19 @@
+#cfg-wizard { display: flex; flex-direction: column; gap: 1rem; }
+.cfg-core { display: grid; gap: 0.75rem; }
+.cfg-field { display: flex; flex-direction: column; gap: 0.25rem; }
+.cfg-label { font-weight: 600; }
+.cfg-help { color: var(--md-default-fg-color--light); }
+.cfg-field input, .cfg-field select {
+  padding: 0.4rem 0.5rem; border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 4px; background: var(--md-default-bg-color); color: var(--md-default-fg-color);
+}
+.cfg-secret input { border-color: var(--md-accent-fg-color); }
+.cfg-advanced { border: 1px solid var(--md-default-fg-color--lightest); border-radius: 6px; padding: 0.5rem 1rem; }
+.cfg-advanced h4 { margin: 0.75rem 0 0.25rem; }
+.cfg-output { display: grid; gap: 1rem; }
+.cfg-tab-head { display: flex; justify-content: space-between; align-items: center; font-weight: 600; }
+.cfg-copy { cursor: pointer; padding: 0.2rem 0.6rem; border-radius: 4px; border: 1px solid var(--md-default-fg-color--lighter); background: var(--md-default-bg-color); }
+.cfg-pre { background: var(--md-code-bg-color); padding: 0.75rem; border-radius: 6px; overflow-x: auto; white-space: pre; }
+.cfg-warn { color: #b26a00; }
+[data-md-color-scheme="slate"] .cfg-warn { color: #e0a83a; }
+.cfg-info { color: var(--md-default-fg-color--light); }

--- a/docs/stylesheets/config-wizard.css
+++ b/docs/stylesheets/config-wizard.css
@@ -16,4 +16,6 @@
 .cfg-pre { background: var(--md-code-bg-color); padding: 0.75rem; border-radius: 6px; overflow-x: auto; white-space: pre; }
 .cfg-warn { color: #b26a00; }
 [data-md-color-scheme="slate"] .cfg-warn { color: #e0a83a; }
+.cfg-error { color: #c0392b; }
+[data-md-color-scheme="slate"] .cfg-error { color: #e74c3c; }
 .cfg-info { color: var(--md-default-fg-color--light); }

--- a/docs/stylesheets/config-wizard.css
+++ b/docs/stylesheets/config-wizard.css
@@ -16,6 +16,4 @@
 .cfg-pre { background: var(--md-code-bg-color); padding: 0.75rem; border-radius: 6px; overflow-x: auto; white-space: pre; }
 .cfg-warn { color: #b26a00; }
 [data-md-color-scheme="slate"] .cfg-warn { color: #e0a83a; }
-.cfg-error { color: #c0392b; }
-[data-md-color-scheme="slate"] .cfg-error { color: #e74c3c; }
 .cfg-info { color: var(--md-default-fg-color--light); }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,13 @@ extra:
     provider: mike
     default: latest
 
+extra_javascript:
+  - path: javascripts/config-wizard/wizard.js
+    type: module
+
+extra_css:
+  - stylesheets/config-wizard.css
+
 plugins:
   - search
   # Generates llms.txt + llms-full.txt for the README badge.
@@ -58,6 +65,7 @@ plugins:
           - index.md: Overview — features, architecture, and quick start
           - installation.md: Installation from PyPI, uv, Docker, or Linux packages
           - configuration.md: All environment variables with types and defaults
+          - configuration-generator.md: Browser-based configuration generator
         Guides:
           - guides/index.md: Guide overview — which guide to read
           - guides/claude-desktop.md: Claude Desktop setup (basic, API key, PDF, OpenAlex)
@@ -113,8 +121,10 @@ nav:
   # update. Keep aligned with the `llmstxt` plugin's sentinel-protected
   # `sections:` block above.
   - Home: index.md
-  - Installation: installation.md
-  - Configuration: configuration.md
+  - Getting Started:
+      - Installation: installation.md
+      - Configuration: configuration.md
+      - Configuration Generator: configuration-generator.md
   - Guides:
       - Overview: guides/index.md
       - Claude Code Plugin: guides/claude-code-plugin.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,10 @@ docs = [
     "mkdocs-llmstxt>=0.5",
 ]
 
+browser = [
+    "pytest-playwright>=0.5",
+]
+
 [project.scripts]
 scholar-mcp = "scholar_mcp.cli:main"
 
@@ -143,6 +147,7 @@ asyncio_mode = "auto"
 log_level = "WARNING"
 markers = [
     "live: tests that hit real network services; opt-in via `pytest -m live`",
+    "browser: end-to-end test that drives a headless browser (requires the 'browser' dependency group + 'playwright install chromium')",
 ]
 
 [tool.coverage.run]
@@ -189,6 +194,11 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = ["yaml"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+# Optional browser-test dep; only installed in the `browser` dependency group.
+module = ["playwright", "playwright.*"]
 ignore_missing_imports = true
 
 # Tests use pytest idioms (untyped fixtures, monkey-patching, ad-hoc stubs,

--- a/tests/test_config_wizard_smoke.py
+++ b/tests/test_config_wizard_smoke.py
@@ -1,0 +1,81 @@
+"""Browser smoke test for the built config-wizard page.
+
+Marked ``browser``; requires the ``browser`` dependency group and
+``playwright install chromium``. Runs against the built ``site/`` directory, so
+``mkdocs build`` must have run first.
+"""
+
+from __future__ import annotations
+
+import functools
+import http.server
+import socketserver
+import threading
+import typing
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("playwright.sync_api")
+
+if typing.TYPE_CHECKING:
+    from playwright.sync_api import Browser, Page
+
+SITE = Path(__file__).resolve().parent.parent / "site"
+
+pytestmark = pytest.mark.browser
+
+
+@pytest.fixture(scope="module")
+def site_url() -> typing.Iterator[str]:
+    if not (SITE / "configuration-generator" / "index.html").exists():
+        pytest.skip("site/ not built -- run `uv run mkdocs build` first")
+    handler = functools.partial(
+        http.server.SimpleHTTPRequestHandler, directory=str(SITE)
+    )
+    with socketserver.TCPServer(("127.0.0.1", 0), handler) as httpd:
+        port = httpd.server_address[1]
+        thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+        thread.start()
+        try:
+            yield f"http://127.0.0.1:{port}"
+        finally:
+            httpd.shutdown()
+
+
+@pytest.fixture(scope="module")
+def browser(site_url: str) -> typing.Iterator[Browser]:
+    # Depend on site_url so its "site not built" skip runs BEFORE we try to
+    # launch Chromium. In the main CI test lane (no built site, no installed
+    # browser) this makes the smoke tests skip cleanly instead of erroring.
+    from playwright.sync_api import sync_playwright
+
+    with sync_playwright() as p:
+        b = p.chromium.launch()
+        yield b
+        b.close()
+
+
+@pytest.fixture
+def page(browser: Browser, site_url: str) -> typing.Iterator[Page]:
+    # Fresh page per test: the wizard keeps answer state in a module-level JS
+    # object, so each test must start from a clean load to stay order-independent.
+    pg = browser.new_page()
+    pg.goto(f"{site_url}/configuration-generator/")
+    pg.wait_for_selector("#cfg-wizard select")
+    yield pg
+    pg.close()
+
+
+def test_local_path_emits_claude_json(page: Page) -> None:
+    page.select_option('[data-qid="deployment"] select', "local")
+    text = page.inner_text(".cfg-output")
+    assert "scholar-mcp" in text
+
+
+def test_server_docker_path_emits_image(page: Page) -> None:
+    page.select_option('[data-qid="deployment"] select', "server")
+    page.fill('[data-qid="bearer_token"] input', "secret-token")
+    text = page.inner_text("#cfg-wizard")
+    assert "ghcr.io/pvliesdonk/scholar-mcp:latest" in text
+    assert "SCHOLAR_MCP_BEARER_TOKEN" in text

--- a/uv.lock
+++ b/uv.lock
@@ -921,6 +921,83 @@ wheels = [
 ]
 
 [[package]]
+name = "greenlet"
+version = "3.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dd/8b/befc3cb36965f397d87e86fb3b00e3ec0dc67c1ecb0986d7f54ee528f018/greenlet-3.5.2.tar.gz", hash = "sha256:c1b906220d83c140361cdd12eef970fb5881a168b98ee58a43786426173da14c", size = 199243, upload-time = "2026-06-17T20:19:01.317Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/68/371ee6dad168be3386c46030bedaa8e3e7e3cf3d203621d4529e78ff36ef/greenlet-3.5.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:d7792398872f89466c6671d5d193537eff163ecf7fac78d82e6ddc25017fb4f5", size = 286925, upload-time = "2026-06-17T17:33:17.928Z" },
+    { url = "https://files.pythonhosted.org/packages/26/16/ed5706c26b4d26f3fabceb79abca992654eac8b0fa435def2ac6dbd92122/greenlet-3.5.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:711028c953cd6ce5dc01bbb5a1747e3ad6bd8b2f7ded73778bb936e8dab9e3b6", size = 606036, upload-time = "2026-06-17T18:07:18.538Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/32/f9c77093af9f5f96615922b7e3fe3690a9faff02adb89f1d74e21578b147/greenlet-3.5.2-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5eba55076d79e8a5176e6925295cfb901ebc95dae493342ede22230f75d8bee2", size = 617821, upload-time = "2026-06-17T18:29:41.317Z" },
+    { url = "https://files.pythonhosted.org/packages/27/f5/a963a939039aa5acafc2f9535f6cc8958ad30afe1478e2e37ab5098af74d/greenlet-3.5.2-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1724499fc08388208408681c53c5062e9803c334e5a0bdaeb616228ba882aac8", size = 625675, upload-time = "2026-06-17T18:39:25.767Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/d4/642833e778c17d32b5cabb793e14ce7364c55952462fc506fecdee55d485/greenlet-3.5.2-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c1c1e5ad80f1f38ea479b83b39dccb20874cfe9ad5e52f87225fa294ba4d39a1", size = 616877, upload-time = "2026-06-17T17:39:26.564Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/c8/995a898ebbf44e3da0b7ea6fbc1631518c185fb83467a5d6cf408d6d3ced/greenlet-3.5.2-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:e976f9f6941f57d87a194c91868622c8b22a142a741d2fde31655c319133ade6", size = 420572, upload-time = "2026-06-17T18:41:18.035Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/cc/7120f83e78b8be3cf7acbe2306b3b7bd2cbf99f5ad12e85e2f05d7b31961/greenlet-3.5.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:9e194b996aa1b89d933cfe136e5eb39b22a8b72ba59d376ef39a55bca4dbf47f", size = 1577274, upload-time = "2026-06-17T18:22:10.692Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/d8/05a0074ee485dd51c320fd706fd7ed48006b9cad3443092d7df1a655f0d2/greenlet-3.5.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4e554809538bd4867f24421b43abde170f9c9b8192149b30df5e164bcac6124f", size = 1643566, upload-time = "2026-06-17T17:40:05.452Z" },
+    { url = "https://files.pythonhosted.org/packages/35/fe/9fe2060bdeece682e38d381184ae66045b48ed183c107ab3f88b9886a630/greenlet-3.5.2-cp311-cp311-win_amd64.whl", hash = "sha256:e063263ce9047878480d7e536012fc8b7c8e1922989eb5f03b9ab998a2ee7b7e", size = 238643, upload-time = "2026-06-17T17:37:03.039Z" },
+    { url = "https://files.pythonhosted.org/packages/41/13/a9db72f5b6b700977ebd371d6a1f2984a08838357de924fcd5571607b1bf/greenlet-3.5.2-cp311-cp311-win_arm64.whl", hash = "sha256:a3f76a94e2d6e1fee8f302265679d8cc47d71a203936dd03c6e2ace0f9cfd46d", size = 237135, upload-time = "2026-06-17T17:34:34.14Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/7a/6bc2a7835731387ed303b9390ce68a116ab053df05450a59181239200454/greenlet-3.5.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:76dae33e97b52743a19210931ee3e78a88fe1438bc2fc4ee5e7512d289bfad4f", size = 288351, upload-time = "2026-06-17T17:36:17.019Z" },
+    { url = "https://files.pythonhosted.org/packages/57/1b/bd98062fcef6d0e9d0873ab6f2d029772e6ea342972ae43275bd6177900f/greenlet-3.5.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:30252d191d6959df1d040b559a38fc017139606c5ecc2ad00416557c0355d742", size = 604273, upload-time = "2026-06-17T18:07:20.296Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e6/fe392c522bf45d976abe7db2793f6ef4e87b053ebb869deeaae46aeb54da/greenlet-3.5.2-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1adc23c50f22b0f5979521909a8360ab4a3d3bef8b641ce633a04cf1b1c967ea", size = 616536, upload-time = "2026-06-17T18:29:43.205Z" },
+    { url = "https://files.pythonhosted.org/packages/42/df/cdb1f75f07214f13110e7e3879531f11c26083bd480a56a9474c430ec44c/greenlet-3.5.2-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:87359c23eb4e8f1b16da68faad29bf5aeb80e3628d7d8e4aa2e41c36879ddedd", size = 621843, upload-time = "2026-06-17T18:39:27.507Z" },
+    { url = "https://files.pythonhosted.org/packages/68/4a/399ff81fa93a19d6a9df394cef0355f082dbc19ad41aba9593cd0ad444e2/greenlet-3.5.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1f052fff492c52fdfa99bd3b3c1389a53de37dae76a0562741417f0d018f02b3", size = 613749, upload-time = "2026-06-17T17:39:28.148Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/25/36a3628a7edcfeefddd3101dc88039c79721c5f8d688db7ebed1cbaaa789/greenlet-3.5.2-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:f4d67c1684db3f9782c37ee4bade3f86f5a23a8fcf3f8359224106018ca40728", size = 424889, upload-time = "2026-06-17T18:41:19.469Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/75/f519593f12ad43d08e28c03a95cfe2eeae011707dbc9dab0c4a263ce90f9/greenlet-3.5.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:120b77c2a18ebf629c3a7886f68c6d01e065654844ad468f15bb93ace66f2094", size = 1573725, upload-time = "2026-06-17T18:22:12.023Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/bc/bc1ea4b0754c6c51bbf9d94677b0b1f7fbda8cbb404e44a896854fc0a940/greenlet-3.5.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a850f6224088ef7dcc70f1a545cb6b3d119c35d6dca63b925b9f35da0635cdad", size = 1638132, upload-time = "2026-06-17T17:40:06.971Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c0/f0f5a34247df60de285f75f22e57f14027f4b3c43820981854b5b643ca6d/greenlet-3.5.2-cp312-cp312-win_amd64.whl", hash = "sha256:89da99ee8345b458ea2f16831dad31c88ddcdec454b48704d569a0b8fb28f146", size = 239393, upload-time = "2026-06-17T17:33:47.09Z" },
+    { url = "https://files.pythonhosted.org/packages/09/17/a8544e165445f30aea67a8d9cf2786d2bb0eb1b0e0d224b4d9bd80e2d587/greenlet-3.5.2-cp312-cp312-win_arm64.whl", hash = "sha256:ca92411942154023c65851e6077d8ca0d00f19de5fa80bb2c6f196ff6c920ba9", size = 237723, upload-time = "2026-06-17T17:36:47.776Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/3c/bb37b9d40d65b0741a8b040ca5c307034d0a9822994dff5f825c88dd7a6b/greenlet-3.5.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:0629377725977252159de1ebd3c6e49c170a63856e585446797bb3d66d4d9c34", size = 287178, upload-time = "2026-06-17T17:35:25.132Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/a6/0c5902393f492f8ceb19d0b5cf139284e3a11b333a049739643b1036b6f8/greenlet-3.5.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2ddf9eddc617681108dd071b3feabf3f4a4cd64846254aec4d4ceda098b639a", size = 606900, upload-time = "2026-06-17T18:07:21.692Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/7c/42899c31d4b87148ae4e3f87f63e13398824be6241f4dde42ded95768a34/greenlet-3.5.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f41feb9f2b59e2e61ac9bea4e344ddd9396bf3cacb2583f73a3595ed7df6f8e7", size = 619265, upload-time = "2026-06-17T18:29:44.837Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/7e/28f991affb413b232b1e7d768db24c37b3f4d5daecc3f19b455d40bd2dea/greenlet-3.5.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9dc23f0e5ad76415457212a4b947d22ebe4dc80baf02adf7dd5647a90f38bb4e", size = 625044, upload-time = "2026-06-17T18:39:29.046Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/52/4ff8c98d3cfe62b4515f8584ae14510a58f35c549cc5292b78d9b7a40b70/greenlet-3.5.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:09201fa698768db245920b00fdc86ee3e73540f01ca6db162be9632642e1a473", size = 616187, upload-time = "2026-06-17T17:39:29.473Z" },
+    { url = "https://files.pythonhosted.org/packages/29/05/0cc9ec660e7acff85f93b0a048b6654371c822c884add44c02a465cf70e0/greenlet-3.5.2-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:423167363c510a75b649f5cd58d873c29498ea03598b9e4b1c3b73e0f899f3d5", size = 427322, upload-time = "2026-06-17T18:41:20.892Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/a6/269c8bf9aefc13361ce1088f0e392b154cb21005de7862e42b5d782b81fd/greenlet-3.5.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a1759fa4f14c398508cf20dc8037de55cc23ae8bd14c185c2718257837195ca5", size = 1573778, upload-time = "2026-06-17T18:22:13.497Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/9b/391d015cbc6323e81b14c02cf825fdca7e0049c9bb489bf4ac72883118ba/greenlet-3.5.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b9318cdeb9abdbfdd8bc8464ee4a06dffde2c7846e1def138365a6240ab2c9a5", size = 1638092, upload-time = "2026-06-17T17:40:08.163Z" },
+    { url = "https://files.pythonhosted.org/packages/49/53/5b4df711f4356c62e85d9f819d87966d526d1cfb32bae49a8f7d6fc36ea4/greenlet-3.5.2-cp313-cp313-win_amd64.whl", hash = "sha256:2c3b3311af72b3d3b03cc0f1ffd11f072e834be5d0444105cf715fc44434e39c", size = 239352, upload-time = "2026-06-17T17:38:51.593Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/b6/18efc3a329ec035c3f344b8f2b60356451950ddf9b7b64ff00023778a1dd/greenlet-3.5.2-cp313-cp313-win_arm64.whl", hash = "sha256:f9bbd6216c45a563c2a61e478e038b439d9f248bde44f775ea37d339da643af4", size = 237635, upload-time = "2026-06-17T17:35:36.632Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/89/aaafc8e14de4ac882e02ccb963225329b0e8578aba4365e71eb678e45722/greenlet-3.5.2-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:1c31219badba285858ba8ed117f403dea7fafee6bade9a1991875aae530c3ceb", size = 287676, upload-time = "2026-06-17T17:33:31.514Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/fc/2308249206c12ac70de7b9a00970f84f07d10b3cd60e05d2fbcaa84124e8/greenlet-3.5.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6f96ed6f4adc1066954ae95f45717657cb67468ef3b89e9a3632e14a625a8f39", size = 653552, upload-time = "2026-06-17T18:07:23.493Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/24/47730d1f8f1336b9b089237521ed7a26eee997065dcb4cab81cdca333abc/greenlet-3.5.2-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5795e883e915333c0d5648faaa691857fbc7180136883edc377f50f0d509c2a8", size = 665756, upload-time = "2026-06-17T18:29:46.616Z" },
+    { url = "https://files.pythonhosted.org/packages/23/5c/2664d290cbd1fef9eb3f69b5d3bc5aa91b6fa907519298ca6af93a90c6cb/greenlet-3.5.2-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6e9e49d732ee92a189bb7035e293029244aeba648297a9b856dc733d17ca7f0d", size = 669989, upload-time = "2026-06-17T18:39:30.79Z" },
+    { url = "https://files.pythonhosted.org/packages/99/69/d6c99db15dc0b5e892ac3cc7b942c8b21f4a9cc3bd9ea0bc3b0f339ffbd4/greenlet-3.5.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:26aed8d9503ca78889141a9739d71b383efea5f472a7c522b5410f7eb2a1b163", size = 663228, upload-time = "2026-06-17T17:39:31.073Z" },
+    { url = "https://files.pythonhosted.org/packages/42/d4/fcb53fa9847d7fbd4723fbed9469c3869b9e3544c4e001d9d5aa2f66162d/greenlet-3.5.2-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:537c5c4f30395020bb9f48f53146070e3b997c3c75da14011ab732aaa19ce3ef", size = 472888, upload-time = "2026-06-17T18:41:22.511Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/88/9e603f448e2bc107c883e95817b980fb9b45ba6aea0299b2e9978124bea2/greenlet-3.5.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:dbebc038fcdda8f8f21cce985fd04e34e0f42007e7fc7ab7ad285caf77974b95", size = 1620723, upload-time = "2026-06-17T18:22:14.817Z" },
+    { url = "https://files.pythonhosted.org/packages/11/91/26da17e3777858c16fdb8d020a4c68f3a03cb92f238de8f5351d5d5186e9/greenlet-3.5.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a207023f1cf8695fd82580b8099c09c5809be18bc2282362cdfb965dd884a317", size = 1684227, upload-time = "2026-06-17T17:40:09.536Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/44/b3a11f7aa34cb38f1b7f3df8bcd9fcd09bac9d342c2a2c9b8686c804bcd2/greenlet-3.5.2-cp314-cp314-win_amd64.whl", hash = "sha256:c674a1dd4fe41f6a93febe7ab366ceabf15080ea31a9307811c56dac5f435f73", size = 240257, upload-time = "2026-06-17T17:35:23.359Z" },
+    { url = "https://files.pythonhosted.org/packages/de/e3/3b62145fe917311732041a258adb218248add00542e3131c48bd047fbed5/greenlet-3.5.2-cp314-cp314-win_arm64.whl", hash = "sha256:3c417cd6c593bbbef6f7aa31a79f37d3db7d18832fc56b694a2150130bde784e", size = 239038, upload-time = "2026-06-17T17:37:56.792Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ac/d3bad483e9f6cd1848604fdffa32cac25846dd6dfcec0e6f81c790185518/greenlet-3.5.2-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:a96457a30384de52d9c5d2fd33abf6c1daae3db392cd556738f408b1a79a1cf0", size = 295668, upload-time = "2026-06-17T17:36:02.293Z" },
+    { url = "https://files.pythonhosted.org/packages/00/e9/3a7e557b895fd0469b00cd0b2bd498ba950e8bfdf6d7adeecf2c5e4130a6/greenlet-3.5.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e4af5d4961818ab651d09c1448a03b1ba2a1726a076266ebb62330bab9f3238c", size = 652820, upload-time = "2026-06-17T18:07:24.95Z" },
+    { url = "https://files.pythonhosted.org/packages/78/67/6225d5c5e4afc04be0fd161eec82e4b72017e8a100d222f25d7b42b0140d/greenlet-3.5.2-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a1789a6244ea1ba61fd4386c9a6a31873e9b0234762103364be98ef87dcb19f3", size = 658697, upload-time = "2026-06-17T18:29:48.365Z" },
+    { url = "https://files.pythonhosted.org/packages/35/ad/9b3058f999b81750a9c6d9ec424f509462d232b58002086fe2ba63b66407/greenlet-3.5.2-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2ee6288f1933d698b4f098127ed17bda2910a75d2807915bd16294a972055d6c", size = 658945, upload-time = "2026-06-17T18:39:32.509Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/99/6324b8ef916dcaddccb340b304c992ca3f947614ce0f2685d438187300b8/greenlet-3.5.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3be00501fb4a8c37f6b4b3c4773808ceb26ea65c7ea64fd5735d0f330b3786de", size = 656436, upload-time = "2026-06-17T17:39:32.509Z" },
+    { url = "https://files.pythonhosted.org/packages/92/75/1b6ecd8c027b69ab1b6798a84094df79aab5e69ac7e249c78b9d361dd1fa/greenlet-3.5.2-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:b4cad42662c796334c2d24607c411e3ed82481c1fb4e1e8ec3a5a8416060092e", size = 490529, upload-time = "2026-06-17T18:41:23.954Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/ee/f5bf9daac27c5e1b011965f64b5630a32b415daf7381b312943629e12c2a/greenlet-3.5.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1d554cd96841a68d464d75a3736f8e87408a7b02b1930a75fa32feb408ad62f8", size = 1617193, upload-time = "2026-06-17T18:22:16.252Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/21/b05d5b12715bda92ce27c118d64971d21e9b8f3563ed959a7d271e2d4223/greenlet-3.5.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3dff6cd3aac35f6cd3fc23460105acf576f5faf6c378de0bc088bf37c913864a", size = 1677512, upload-time = "2026-06-17T17:40:10.771Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/97/1b8f1314b868041b327dc1051603e8142b826480cb0ecb8a7b7632aee9c4/greenlet-3.5.2-cp314-cp314t-win_amd64.whl", hash = "sha256:36cfea2aa075d544617176b2e84450480f0797070ad8799a8c41ada2fe449d32", size = 243145, upload-time = "2026-06-17T17:34:37.502Z" },
+    { url = "https://files.pythonhosted.org/packages/36/07/1b5311775e04c718a118c504d7a3a312430e2a1bd1347226aff4774e4549/greenlet-3.5.2-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:a0314aa832c94633355dc6f3ee54f195159533355a323f26926fc63b98b2ccbb", size = 288315, upload-time = "2026-06-17T17:34:34.04Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/cc/6abcd2a486b58b9f77b7a93b690d59cb2c11a5906ed2ad4c63c7b9c1113d/greenlet-3.5.2-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:24c59cb7db9d5c694cb8fd0c76eef8e456b2123afdfa7e4b8f2a67a0860d7682", size = 659130, upload-time = "2026-06-17T18:07:26.354Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/12/f4aaad6d3d383233f700ab322568a4f29f2c701a4861d85f4811d99689b2/greenlet-3.5.2-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7bb811753703739ad318112f16eccfaabdac050037b6d092debaa8b23566b4ce", size = 669724, upload-time = "2026-06-17T18:29:50.13Z" },
+    { url = "https://files.pythonhosted.org/packages/53/e0/4ce3a046b51e53934eae93d7f9c13975a97285741e9e1fcadf8751314c37/greenlet-3.5.2-cp315-cp315-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2debcd0ef9455b7d4879589903efc8e497d4b8fb8c0ae772309e44d1ca5e957f", size = 673494, upload-time = "2026-06-17T18:39:34.196Z" },
+    { url = "https://files.pythonhosted.org/packages/91/2a/a089811fc31c6bf8742f40a4e73470d6d401cef18e4314eb20dc399b377c/greenlet-3.5.2-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6d78b5c1c178dad90447f1b8452262709d3eef4c98f825569e74c9d0b2260ac9", size = 668089, upload-time = "2026-06-17T17:39:33.808Z" },
+    { url = "https://files.pythonhosted.org/packages/52/e0/9c18721e63445dce02ee67e4c81c0f281626604ff55ae6f7b7f4354d7129/greenlet-3.5.2-cp315-cp315-manylinux_2_39_riscv64.whl", hash = "sha256:9558cae989faeab6fbb425cd98a0cfa4190a47fba6443973fbee0a1eb0b0b6c3", size = 479721, upload-time = "2026-06-17T18:41:25.726Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/1c/2f47c7d5fcfa98a62b705bf9a0505d86f4563c0d81cab1f7159ff1e743b7/greenlet-3.5.2-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:0977af2df83136f81c1f76e76d4e2fe7d0dc56ea9c101a86af26a95190b9ca32", size = 1625684, upload-time = "2026-06-17T18:22:17.664Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/bf/661dd24624f70b7b32972d7693d0344ecde10278f647d7b828baf739899c/greenlet-3.5.2-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:f9ed777c6891d8253e54468576f55e27f8fc1a662a664f946a191003574c0a74", size = 1688043, upload-time = "2026-06-17T17:40:12.403Z" },
+    { url = "https://files.pythonhosted.org/packages/60/49/d9bde1d15a21296b3b521fe083eb8aabd54ac05d15de9832918f3d639543/greenlet-3.5.2-cp315-cp315-win_amd64.whl", hash = "sha256:c0ea4eb3de23f0bac1d75205e10ccfa9b418b17b01a2d7bf19e3b69dda08900a", size = 240531, upload-time = "2026-06-17T17:35:47.448Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/4d/86d7768bd53e9907de0333df215c2018cd01a593b3715cbd79aa82dd94b7/greenlet-3.5.2-cp315-cp315-win_arm64.whl", hash = "sha256:7a7bfc200be40d04961d7e80e8337d726c0c1a50777e588123c3ed8ba731dcb9", size = 239579, upload-time = "2026-06-17T17:39:39.954Z" },
+    { url = "https://files.pythonhosted.org/packages/92/15/907be5e8900901039bae752fa9a31c03a3c1e064833f35a4e49449184581/greenlet-3.5.2-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:98a52d6a50d4deaba304331d83ee3e10ebbdc1517fcca40b2715d1de4534065c", size = 296697, upload-time = "2026-06-17T17:37:15.887Z" },
+    { url = "https://files.pythonhosted.org/packages/95/5c/08c57be575c3d6a3c023bbf22144a1c7dc6ed4d134527bb36ded4dbf04a8/greenlet-3.5.2-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1587ff8b58fdf806993ed1490a06ac19c22d47b219c68b30954380029045d8d4", size = 656710, upload-time = "2026-06-17T18:07:28.046Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d0/749f917bdc9fc90fceea4aa65fbf6556e617a50714d1496bdc8ad190bb36/greenlet-3.5.2-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:feb721811d2754bfd16b48de151dd6b1f222c048e625151f2ca44cfdfd69f59c", size = 662629, upload-time = "2026-06-17T18:29:51.728Z" },
+    { url = "https://files.pythonhosted.org/packages/55/87/10776cd88df54d0f563e9e21e98363f2d6af94bedc553b1da0972fa87f80/greenlet-3.5.2-cp315-cp315t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a9476cbead736dc48ce89e3cd97acff95ecc48cbf21273603a438f9870c4a014", size = 663191, upload-time = "2026-06-17T18:39:35.639Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/a5/68cefae3a07f6d0093a490cf28ab604f14578f3e60205a2a2b2d5cd70af2/greenlet-3.5.2-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7fe6062b1f35534e1e8fb28dfed406cf4eeff3e0bca3a0d9f8ff69f20a4abb00", size = 660147, upload-time = "2026-06-17T17:39:35.068Z" },
+    { url = "https://files.pythonhosted.org/packages/02/aa/26ddf92826a99d87bfb8fdb8f3a262a6f16495a5d8e579737baa92fb4543/greenlet-3.5.2-cp315-cp315t-manylinux_2_39_riscv64.whl", hash = "sha256:5930d3946ecae99fa7fc0e3f3ae515426ad85058ebd9bfc6c00cca8016e6206b", size = 498199, upload-time = "2026-06-17T18:41:27.464Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/6b/b9156d8397e4750220f54c7c5c34650f1e740a8d2f66eab9cfd1b7b53b69/greenlet-3.5.2-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:b4ac902af825cbac8e9b2fccab8122236fd2ba6c8b71a080116d2c2ec72671b1", size = 1621675, upload-time = "2026-06-17T18:22:18.873Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/e3/d3250f4fa01c211a93d04e34fded63187e648dbec17b9b1a14d388040593/greenlet-3.5.2-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:6f1e473c06ae8be00c9034c2bb10fa277b08a93287e3111c395b839f01d27e1f", size = 1680577, upload-time = "2026-06-17T17:40:14.055Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ba/eaee8bda4419770d7096b5a009ebff0ab20a2a28cdd83c4b591bfdf36fa9/greenlet-3.5.2-cp315-cp315t-win_amd64.whl", hash = "sha256:3c2315045f9983e2e50d7e89d95405c21bddb8745f2da4487bc080ab3525f904", size = 243482, upload-time = "2026-06-17T17:37:34.741Z" },
+    { url = "https://files.pythonhosted.org/packages/37/45/f794a81c91e9942c61f9110bd1f9a38a0ea565eab57f8b08cd53d3131e48/greenlet-3.5.2-cp315-cp315t-win_arm64.whl", hash = "sha256:db548d5ab6c2a8ead82c013f875090d79b5d7d2b67fc513934ce6cf66492ad7f", size = 242062, upload-time = "2026-06-17T17:35:39.814Z" },
+]
+
+[[package]]
 name = "griffelib"
 version = "2.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1923,6 +2000,25 @@ wheels = [
 ]
 
 [[package]]
+name = "playwright"
+version = "1.60.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/f0/832bd9677194908da118064eef20082f2791e3d18215cc6d9391ee2c5a67/playwright-1.60.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:6a8cd0fec171fb3089e95e898c8bc8a6f35dea0b78b399e12fcc19427e91b1d7", size = 43474635, upload-time = "2026-05-18T12:00:31.969Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7b/e1d32ae8a3ed937ec2be3721c5f728b13d731a0b7c6442e0b3bec5094ac0/playwright-1.60.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:39b5420ba6145045b69ced4c5c47d4d9fe5bddfc8ff816c518913afcb25ec7a5", size = 42261327, upload-time = "2026-05-18T12:00:35.638Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/bc/23de499ded6411c188a20c5a0dea6f0cd4ed5d2b3cc6042a5dbd3ed609aa/playwright-1.60.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:2581d0e6a3392c71f91b27460c7fd093356818dc430f48153896c8aeeaef7705", size = 43474636, upload-time = "2026-05-18T12:00:39.294Z" },
+    { url = "https://files.pythonhosted.org/packages/22/7b/1d679f4fced4ea94efadd17103856d8c565384f68382a1681264e46f5925/playwright-1.60.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:1c2bfae7884fb3fb05b853290eab8f343d524e5016f2f1def702acbbdf14c93e", size = 47467220, upload-time = "2026-05-18T12:00:43.179Z" },
+    { url = "https://files.pythonhosted.org/packages/84/c2/1528d267d4442bd2c6b8eaeab819dd52c2030bf80e89293f0ba1f687473b/playwright-1.60.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:43e66564125ee31b07a58cefb21e256d62d67d8d1713e6858df7a3019d8ed353", size = 47154856, upload-time = "2026-05-18T12:00:46.715Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/4e/b008b6440a7a1624378041da94829956d4b8f7ab9ef5aad22d0dc3f2e26d/playwright-1.60.0-py3-none-win32.whl", hash = "sha256:ec94e416ea320711e0ad4bf185dcbf41833672961e90773e1885255d7db7b7e7", size = 37902157, upload-time = "2026-05-18T12:00:50.374Z" },
+    { url = "https://files.pythonhosted.org/packages/55/f0/0541524133104f9cc20bf900870ff4a736b76a23483f3a55295ddfa58409/playwright-1.60.0-py3-none-win_amd64.whl", hash = "sha256:9566821ce6030a1f9e7146a24e19355ab0d98805fd0f9be50bb3d8fef1750c02", size = 37902159, upload-time = "2026-05-18T12:00:53.728Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c8/210f282d278e4709cdd71b12a31af45a30a22ab3207b387e29b37e478713/playwright-1.60.0-py3-none-win_arm64.whl", hash = "sha256:6e4f6700a4c2250efff8e690a81d66e3855754fb587b6b87cf5c784014f91537", size = 34037981, upload-time = "2026-05-18T12:00:57.584Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1966,6 +2062,9 @@ mcp = [
 ]
 
 [package.dev-dependencies]
+browser = [
+    { name = "pytest-playwright" },
+]
 dev = [
     { name = "diff-cover" },
     { name = "mypy" },
@@ -1999,6 +2098,7 @@ requires-dist = [
 provides-extras = ["mcp", "debug", "all"]
 
 [package.metadata.requires-dev]
+browser = [{ name = "pytest-playwright", specifier = ">=0.5" }]
 dev = [
     { name = "diff-cover", specifier = ">=9.0" },
     { name = "mypy", specifier = ">=1.0" },
@@ -2226,6 +2326,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2309,6 +2421,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-base-url"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/1a/b64ac368de6b993135cb70ca4e5d958a5c268094a3a2a4cac6f0021b6c4f/pytest_base_url-2.1.0.tar.gz", hash = "sha256:02748589a54f9e63fcbe62301d6b0496da0d10231b753e950c63e03aee745d45", size = 6702, upload-time = "2024-01-31T22:43:00.81Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/1c/b00940ab9eb8ede7897443b771987f2f4a76f06be02f1b3f01eb7567e24a/pytest_base_url-2.1.0-py3-none-any.whl", hash = "sha256:3ad15611778764d451927b2a53240c1a7a591b521ea44cebfe45849d2d2812e6", size = 5302, upload-time = "2024-01-31T22:42:58.897Z" },
+]
+
+[[package]]
 name = "pytest-cov"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2320,6 +2445,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-playwright"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "playwright" },
+    { name = "pytest" },
+    { name = "pytest-base-url" },
+    { name = "python-slugify" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/ef/172eb8e23c80491fc72f1401c72f9305663873649351306a38b18406b0c9/pytest_playwright-0.8.0.tar.gz", hash = "sha256:7888d4a2443160c82e0c506c437076679f86b36d1910427250d90fbf1843a981", size = 17132, upload-time = "2026-05-18T10:16:15.919Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/71/1c545fac6a9054b52b3771238fb2dc6e8f1d0ccec116e1c7786ec191887c/pytest_playwright-0.8.0-py3-none-any.whl", hash = "sha256:856aae6efd4bc055f2ef229c647768760bcaad5cd3a5983c314ac260a974a933", size = 17143, upload-time = "2026-05-18T10:16:18.226Z" },
 ]
 
 [[package]]
@@ -2374,6 +2514,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
+]
+
+[[package]]
+name = "python-slugify"
+version = "8.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "text-unidecode" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/c7/5e1547c44e31da50a460df93af11a535ace568ef89d7a811069ead340c4a/python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856", size = 10921, upload-time = "2024-02-08T18:32:45.488Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8", size = 10051, upload-time = "2024-02-08T18:32:43.911Z" },
 ]
 
 [[package]]
@@ -2797,6 +2949,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e9/88/35e4d27d9177d7df76d060e0a18f69c6c5794c96960c94042e20a12c8ba2/stevedore-5.8.0.tar.gz", hash = "sha256:b49867b32ca3016e94100e68dbf26e72aa7b8708d0a3f73c08aeb220370ac715", size = 514710, upload-time = "2026-05-18T09:15:27.731Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f5/ac/19f9941c74add59d17694930ec8105d5eddeee4ce56dd8632b765ca16d6c/stevedore-5.8.0-py3-none-any.whl", hash = "sha256:88eede9e66ca80e34085b9174e2327da2c61ac91f24f70e41c3ad76e4bb4872b", size = 54553, upload-time = "2026-05-18T09:15:25.82Z" },
+]
+
+[[package]]
+name = "text-unidecode"
+version = "1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #216

## Summary

- Adopts fastmcp-server-template v2.2.0, which adds the in-browser configuration generator
- Expanded `wizard-spec.json` with all scholar-mcp domain env vars (S2 API key, EPO credentials, docling/VLM, Google Books, cache dir, logging)
- Incidental: `.gitignore` gains `.repowise/` and `.vale/styles/*` (untracked dirs were tripping copier's dirty-repo guard); `pyproject.toml` gets a mypy override for the optional `playwright` dep

## Test plan

- [ ] CI passes (pytest 1032+, ruff, mypy, Vale, MkDocs strict)
- [ ] docs.yml smoke test step (Playwright / Chromium) passes in CI
- [ ] Configuration Generator page renders in the built docs
- [ ] Local path generates a Claude Desktop JSON snippet containing `scholar-mcp`
- [ ] Server path generates a Docker snippet containing `SCHOLAR_MCP_BEARER_TOKEN` placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._