### PR TITLE
feat: S2 API key liveness (keepalive + distinguishable 403 logging)

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,14 @@ All settings are controlled via environment variables with the `SCHOLAR_MCP_` pr
 | `SCHOLAR_MCP_CACHE_DIR` | `/data/scholar-mcp` | Directory for the SQLite cache database and downloaded PDFs |
 | `SCHOLAR_MCP_CONTACT_EMAIL` | — | Included in the OpenAlex User-Agent for [polite pool](https://docs.openalex.org/how-to-use-the-api/rate-limits-and-authentication#the-polite-pool) access (faster rate limits); also enables Unpaywall PDF lookups |
 
+Scholar-mcp pings Semantic Scholar once on startup and every 7 days
+thereafter to keep the configured key from being removed for inactivity
+(Semantic Scholar may remove keys unused for 60+ days). If S2 starts
+rejecting the key with `403 Forbidden`, this shows up in the server logs
+as `s2_key_forbidden` (on real tool calls) or `s2_keepalive_key_forbidden`
+(from the background keepalive) — grep for either to confirm a dead key
+versus a transient upstream issue.
+
 ### PDF Conversion (optional)
 
 | Variable | Default | Description |

--- a/src/scholar_mcp/_s2_client.py
+++ b/src/scholar_mcp/_s2_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -24,6 +25,50 @@ FIELD_SETS: dict[str, str] = {
         "abstract,tldr,openAccessPdf,fieldsOfStudy,referenceCount"
     ),
 }
+
+
+def log_s2_error(exc: httpx.HTTPStatusError) -> None:
+    """Log an S2 upstream HTTP error at a level and event name operators can alert on.
+
+    A 403 gets its own event name (``s2_key_forbidden``) distinct from the
+    ordinary 429 retry-path logging in ``_rate_limiter.py`` — it is a
+    non-retryable failure class, most commonly an S2 API key that has been
+    revoked or removed for inactivity.
+
+    Args:
+        exc: The HTTP error raised by the S2 client.
+    """
+    status = exc.response.status_code
+    detail = exc.response.text[:200]
+    if status == 403:
+        logger.warning("s2_key_forbidden status=403 detail=%s", detail)
+    else:
+        logger.warning("s2_upstream_error status=%s detail=%s", status, detail)
+
+
+def format_s2_error(exc: httpx.HTTPStatusError) -> str:
+    """Log and format an S2 upstream HTTP error as a caller-facing JSON string.
+
+    Logs full detail server-side via :func:`log_s2_error`. The returned
+    JSON intentionally omits the raw upstream response body — LLM callers
+    get a generic, non-leaking message; operators get full detail from the
+    log line.
+
+    Args:
+        exc: The HTTP error raised by the S2 client.
+
+    Returns:
+        JSON string: ``{"error": "upstream_error", "status": <code>,
+        "detail": <generic message>}``.
+    """
+    log_s2_error(exc)
+    return json.dumps(
+        {
+            "error": "upstream_error",
+            "status": exc.response.status_code,
+            "detail": "Semantic Scholar API request failed; see server logs for details",
+        }
+    )
 
 
 class S2Client:

--- a/src/scholar_mcp/_s2_client.py
+++ b/src/scholar_mcp/_s2_client.py
@@ -2,13 +2,19 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from typing import TYPE_CHECKING, Any
 
 import httpx
 
-from ._rate_limiter import RateLimiter, with_s2_retry, with_s2_try_once
+from ._rate_limiter import (
+    RateLimitedError,
+    RateLimiter,
+    with_s2_retry,
+    with_s2_try_once,
+)
 
 if TYPE_CHECKING:
     from ._record_types import PaperRecord
@@ -25,6 +31,13 @@ FIELD_SETS: dict[str, str] = {
         "abstract,tldr,openAccessPdf,fieldsOfStudy,referenceCount"
     ),
 }
+
+KEEPALIVE_PAPER_ID = (
+    "ARXIV:1706.03762"  # "Attention Is All You Need" — stable, well-known
+)
+KEEPALIVE_INTERVAL_SECONDS = (
+    7 * 24 * 60 * 60
+)  # 7 days; well under S2's 60-day key-inactivity window
 
 
 def log_s2_error(exc: httpx.HTTPStatusError) -> None:
@@ -360,3 +373,36 @@ class S2Client:
         if retry:
             return await with_s2_retry(_call, self._limiter)  # type: ignore[no-any-return]
         return await with_s2_try_once(_call, self._limiter)  # type: ignore[no-any-return]
+
+
+async def run_keepalive(client: S2Client) -> None:
+    """Ping S2 periodically to keep the API key from being removed for inactivity.
+
+    Semantic Scholar may remove API keys that see no traffic for 60 days.
+    This loop fires an immediate cheap call on startup, then repeats every
+    :data:`KEEPALIVE_INTERVAL_SECONDS`. Each iteration's failure is caught
+    and logged so one bad cycle never stops future ones; only
+    ``asyncio.CancelledError`` (server shutdown) propagates out.
+
+    Args:
+        client: The S2 client to ping.
+    """
+    while True:
+        try:
+            await client.get_paper(KEEPALIVE_PAPER_ID, fields="paperId", retry=False)
+        except RateLimitedError:
+            # get_paper(retry=False) raises this (not HTTPStatusError) on a
+            # 429 — transient, try again next cycle.
+            logger.warning("s2_keepalive_rate_limited")
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 403:
+                logger.error("s2_keepalive_key_forbidden", exc_info=True)
+            else:
+                logger.warning(
+                    "s2_keepalive_failed status=%s", exc.response.status_code
+                )
+        except httpx.HTTPError:
+            logger.warning("s2_keepalive_failed status=network_error")
+        else:
+            logger.debug("s2_keepalive_ok")
+        await asyncio.sleep(KEEPALIVE_INTERVAL_SECONDS)

--- a/src/scholar_mcp/_s2_client.py
+++ b/src/scholar_mcp/_s2_client.py
@@ -399,10 +399,12 @@ async def run_keepalive(client: S2Client) -> None:
                 logger.error("s2_keepalive_key_forbidden", exc_info=True)
             else:
                 logger.warning(
-                    "s2_keepalive_failed status=%s", exc.response.status_code
+                    "s2_keepalive_failed status=%s",
+                    exc.response.status_code,
+                    exc_info=True,
                 )
         except httpx.HTTPError:
-            logger.warning("s2_keepalive_failed status=network_error")
+            logger.warning("s2_keepalive_failed status=network_error", exc_info=True)
         else:
             logger.debug("s2_keepalive_ok")
         await asyncio.sleep(KEEPALIVE_INTERVAL_SECONDS)

--- a/src/scholar_mcp/_server_deps.py
+++ b/src/scholar_mcp/_server_deps.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import logging
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
@@ -24,7 +26,7 @@ from ._google_books_client import GoogleBooksClient
 from ._openalex_client import OpenAlexClient
 from ._openlibrary_client import OpenLibraryClient
 from ._rate_limiter import RateLimiter
-from ._s2_client import S2Client
+from ._s2_client import S2Client, run_keepalive
 from ._standards_client import StandardsClient
 from ._task_queue import TaskQueue
 from .config import ProjectConfig, load_config
@@ -95,6 +97,25 @@ def _build_enrichment_pipeline() -> EnrichmentPipeline:
     )
 
 
+def _start_s2_keepalive(
+    client: S2Client, *, api_key: str | None
+) -> asyncio.Task[None] | None:
+    """Start the S2 keepalive background task if an API key is configured.
+
+    Args:
+        client: The S2 client to keep alive.
+        api_key: The configured S2 API key, or None.
+
+    Returns:
+        The created task, or None if no API key is configured.
+    """
+    if not api_key:
+        logger.info("s2_keepalive_not_started reason=no_api_key")
+        return None
+    logger.info("s2_keepalive_started interval_days=7")
+    return asyncio.create_task(run_keepalive(client))
+
+
 @asynccontextmanager
 async def make_service_lifespan(
     app: FastMCP,
@@ -111,6 +132,7 @@ async def make_service_lifespan(
     config.cache_dir.mkdir(parents=True, exist_ok=True)
 
     s2 = S2Client(api_key=config.s2_api_key)
+    s2_keepalive_task = _start_s2_keepalive(s2, api_key=config.s2_api_key)
     ua = "scholar-mcp/0.1"
     if config.contact_email:
         ua = f"{ua} (mailto:{config.contact_email})"
@@ -199,6 +221,10 @@ async def make_service_lifespan(
     try:
         yield {"bundle": bundle}
     finally:
+        if s2_keepalive_task is not None:
+            s2_keepalive_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await s2_keepalive_task
         await s2.aclose()
         await openalex_http.aclose()
         await crossref_http.aclose()

--- a/src/scholar_mcp/_server_deps.py
+++ b/src/scholar_mcp/_server_deps.py
@@ -132,7 +132,6 @@ async def make_service_lifespan(
     config.cache_dir.mkdir(parents=True, exist_ok=True)
 
     s2 = S2Client(api_key=config.s2_api_key)
-    s2_keepalive_task = _start_s2_keepalive(s2, api_key=config.s2_api_key)
     ua = "scholar-mcp/0.1"
     if config.contact_email:
         ua = f"{ua} (mailto:{config.contact_email})"
@@ -203,6 +202,8 @@ async def make_service_lifespan(
     standards = StandardsClient(standards_http, cache_dir=config.cache_dir, cache=cache)
 
     enrichment = _build_enrichment_pipeline()
+
+    s2_keepalive_task = _start_s2_keepalive(s2, api_key=config.s2_api_key)
 
     bundle = ServiceBundle(
         s2=s2,

--- a/src/scholar_mcp/_server_deps.py
+++ b/src/scholar_mcp/_server_deps.py
@@ -26,7 +26,7 @@ from ._google_books_client import GoogleBooksClient
 from ._openalex_client import OpenAlexClient
 from ._openlibrary_client import OpenLibraryClient
 from ._rate_limiter import RateLimiter
-from ._s2_client import S2Client, run_keepalive
+from ._s2_client import KEEPALIVE_INTERVAL_SECONDS, S2Client, run_keepalive
 from ._standards_client import StandardsClient
 from ._task_queue import TaskQueue
 from .config import ProjectConfig, load_config
@@ -112,7 +112,9 @@ def _start_s2_keepalive(
     if not api_key:
         logger.info("s2_keepalive_not_started reason=no_api_key")
         return None
-    logger.info("s2_keepalive_started interval_days=7")
+    logger.info(
+        "s2_keepalive_started interval_days=%s", KEEPALIVE_INTERVAL_SECONDS // 86400
+    )
     return asyncio.create_task(run_keepalive(client))
 
 

--- a/src/scholar_mcp/_tools_citation.py
+++ b/src/scholar_mcp/_tools_citation.py
@@ -12,7 +12,7 @@ from fastmcp.dependencies import Depends
 
 from ._citation_formatter import format_bibtex, format_csl_json, format_ris
 from ._rate_limiter import RateLimitedError
-from ._s2_client import FIELD_SETS
+from ._s2_client import FIELD_SETS, format_s2_error
 from ._server_deps import ServiceBundle, get_bundle
 
 if TYPE_CHECKING:
@@ -79,13 +79,7 @@ def register_citation_tools(mcp: FastMCP) -> None:
                     paper_ids, fields=FIELD_SETS["full"], retry=retry
                 )
             except httpx.HTTPStatusError as exc:
-                return json.dumps(
-                    {
-                        "error": "upstream_error",
-                        "status": exc.response.status_code,
-                        "detail": exc.response.text[:200],
-                    }
-                )
+                return format_s2_error(exc)
 
             papers: list[PaperRecord] = []
             errors: list[dict[str, Any]] = []

--- a/src/scholar_mcp/_tools_graph.py
+++ b/src/scholar_mcp/_tools_graph.py
@@ -12,7 +12,7 @@ from fastmcp import FastMCP
 from fastmcp.dependencies import Depends
 
 from ._rate_limiter import RateLimitedError
-from ._s2_client import FIELD_SETS
+from ._s2_client import FIELD_SETS, format_s2_error, log_s2_error
 from ._server_deps import ServiceBundle, get_bundle
 
 logger = logging.getLogger(__name__)
@@ -122,12 +122,7 @@ def register_graph_tools(mcp: FastMCP) -> None:
                                     "identifier": identifier,
                                 }
                             )
-                        return json.dumps(
-                            {
-                                "error": "upstream_error",
-                                "status": exc.response.status_code,
-                            }
-                        )
+                        return format_s2_error(exc)
                     data = page.get("data") or []
                     for item in data:
                         cc = item.get("citingPaper", {}).get("citationCount")
@@ -175,12 +170,7 @@ def register_graph_tools(mcp: FastMCP) -> None:
             except httpx.HTTPStatusError as exc:
                 if exc.response.status_code == 404:
                     return json.dumps({"error": "not_found", "identifier": identifier})
-                return json.dumps(
-                    {
-                        "error": "upstream_error",
-                        "status": exc.response.status_code,
-                    }
-                )
+                return format_s2_error(exc)
             data_list: list[dict[str, Any]] = result.get("data") or []  # type: ignore[assignment]
             citing_papers = [
                 item.get("citingPaper", {})
@@ -239,9 +229,7 @@ def register_graph_tools(mcp: FastMCP) -> None:
             except httpx.HTTPStatusError as exc:
                 if exc.response.status_code == 404:
                     return json.dumps({"error": "not_found", "identifier": identifier})
-                return json.dumps(
-                    {"error": "upstream_error", "status": exc.response.status_code}
-                )
+                return format_s2_error(exc)
             papers = [
                 item.get("citedPaper", {})
                 for item in result.get("data") or []
@@ -573,7 +561,8 @@ def register_graph_tools(mcp: FastMCP) -> None:
                                 if item.get("citedPaper", {}).get("paperId")
                             ]
                             await bundle.cache.set_references(paper_id, cached)
-                        except httpx.HTTPStatusError:
+                        except httpx.HTTPStatusError as exc:
+                            log_s2_error(exc)
                             cached = []
                     neighbours.extend(cached)
                 if direction in ("citations", "both"):
@@ -593,7 +582,8 @@ def register_graph_tools(mcp: FastMCP) -> None:
                                 if item.get("citingPaper", {}).get("paperId")
                             ]
                             await bundle.cache.set_citations(paper_id, cached_cit)
-                        except httpx.HTTPStatusError:
+                        except httpx.HTTPStatusError as exc:
+                            log_s2_error(exc)
                             cached_cit = []
                     neighbours.extend(cached_cit)
                 return neighbours

--- a/src/scholar_mcp/_tools_graph.py
+++ b/src/scholar_mcp/_tools_graph.py
@@ -315,7 +315,9 @@ def register_graph_tools(mcp: FastMCP) -> None:
                     fields=FIELD_SETS["compact"],
                     retry=retry,
                 )
-            except (httpx.HTTPError, ValueError):
+            except (httpx.HTTPError, ValueError) as exc:
+                if isinstance(exc, httpx.HTTPStatusError):
+                    log_s2_error(exc)
                 seed_results = [None] * len(seed_batch)
 
             for seed_id, seed_data in zip(seed_batch, seed_results, strict=False):
@@ -410,6 +412,8 @@ def register_graph_tools(mcp: FastMCP) -> None:
                             s2_off += len(data)
                             if len(data) < batch or min_citations is None:
                                 break
+                    except httpx.HTTPStatusError as exc:
+                        log_s2_error(exc)
                     except httpx.HTTPError:
                         pass
 
@@ -457,6 +461,8 @@ def register_graph_tools(mcp: FastMCP) -> None:
                                     "direction": "cites",
                                 }
                             )
+                    except httpx.HTTPStatusError as exc:
+                        log_s2_error(exc)
                     except httpx.HTTPError:
                         pass
 

--- a/src/scholar_mcp/_tools_pdf.py
+++ b/src/scholar_mcp/_tools_pdf.py
@@ -14,6 +14,7 @@ from fastmcp.dependencies import Depends
 
 from ._pdf_url_resolver import ResolvedPdf, resolve_alternative_pdf
 from ._rate_limiter import RateLimitedError
+from ._s2_client import format_s2_error
 from ._server_deps import ServiceBundle, get_bundle
 
 if TYPE_CHECKING:
@@ -134,12 +135,7 @@ def register_pdf_tools(mcp: FastMCP) -> None:
                         return json.dumps(
                             {"error": "not_found", "identifier": identifier}
                         )
-                    return json.dumps(
-                        {
-                            "error": "upstream_error",
-                            "status": exc.response.status_code,
-                        }
-                    )
+                    return format_s2_error(exc)
                 return await _download(p)
 
             task_id = bundle.tasks.submit(
@@ -155,12 +151,7 @@ def register_pdf_tools(mcp: FastMCP) -> None:
         except httpx.HTTPStatusError as exc:
             if exc.response.status_code == 404:
                 return json.dumps({"error": "not_found", "identifier": identifier})
-            return json.dumps(
-                {
-                    "error": "upstream_error",
-                    "status": exc.response.status_code,
-                }
-            )
+            return format_s2_error(exc)
 
         oa_pdf = paper.get("openAccessPdf") or {}
         url = oa_pdf.get("url")
@@ -343,12 +334,7 @@ def register_pdf_tools(mcp: FastMCP) -> None:
             except httpx.HTTPStatusError as exc:
                 if exc.response.status_code == 404:
                     return json.dumps({"error": "not_found", "identifier": identifier})
-                return json.dumps(
-                    {
-                        "error": "upstream_error",
-                        "status": exc.response.status_code,
-                    }
-                )
+                return format_s2_error(exc)
 
             oa_pdf = paper.get("openAccessPdf") or {}
             url = oa_pdf.get("url")

--- a/src/scholar_mcp/_tools_recommendations.py
+++ b/src/scholar_mcp/_tools_recommendations.py
@@ -11,7 +11,7 @@ from fastmcp import FastMCP
 from fastmcp.dependencies import Depends
 
 from ._rate_limiter import RateLimitedError
-from ._s2_client import FIELD_SETS
+from ._s2_client import FIELD_SETS, format_s2_error
 from ._server_deps import ServiceBundle, get_bundle
 
 logger = logging.getLogger(__name__)
@@ -67,13 +67,7 @@ def register_recommendation_tools(mcp: FastMCP) -> None:
                     retry=retry,
                 )
             except httpx.HTTPStatusError as exc:
-                return json.dumps(
-                    {
-                        "error": "upstream_error",
-                        "status": exc.response.status_code,
-                        "detail": exc.response.text[:200],
-                    }
-                )
+                return format_s2_error(exc)
             return json.dumps(result)
 
         try:

--- a/src/scholar_mcp/_tools_search.py
+++ b/src/scholar_mcp/_tools_search.py
@@ -11,7 +11,7 @@ from fastmcp import FastMCP
 from fastmcp.dependencies import Depends
 
 from ._rate_limiter import RateLimitedError
-from ._s2_client import FIELD_SETS
+from ._s2_client import FIELD_SETS, format_s2_error
 from ._server_deps import ServiceBundle, get_bundle
 
 logger = logging.getLogger(__name__)
@@ -93,13 +93,7 @@ def register_search_tools(mcp: FastMCP) -> None:
             except httpx.HTTPStatusError as exc:
                 if exc.response.status_code == 404:
                     return json.dumps({"error": "not_found", "identifier": query})
-                return json.dumps(
-                    {
-                        "error": "upstream_error",
-                        "status": exc.response.status_code,
-                        "detail": exc.response.text[:200],
-                    }
-                )
+                return format_s2_error(exc)
             return json.dumps(result)
 
         try:
@@ -146,13 +140,7 @@ def register_search_tools(mcp: FastMCP) -> None:
             except httpx.HTTPStatusError as exc:
                 if exc.response.status_code == 404:
                     return json.dumps({"error": "not_found", "identifier": identifier})
-                return json.dumps(
-                    {
-                        "error": "upstream_error",
-                        "status": exc.response.status_code,
-                        "detail": exc.response.text[:200],
-                    }
-                )
+                return format_s2_error(exc)
 
             paper_id: str = fetched.get("paperId") or ""
             if paper_id:
@@ -218,9 +206,7 @@ def register_search_tools(mcp: FastMCP) -> None:
                         return json.dumps(
                             {"error": "not_found", "identifier": identifier}
                         )
-                    return json.dumps(
-                        {"error": "upstream_error", "status": exc.response.status_code}
-                    )
+                    return format_s2_error(exc)
                 if offset == 0:
                     await bundle.cache.set_author(identifier, data)
                 return json.dumps(data)
@@ -243,9 +229,7 @@ def register_search_tools(mcp: FastMCP) -> None:
                     identifier, limit=5, retry=retry
                 )
             except httpx.HTTPStatusError as exc:
-                return json.dumps(
-                    {"error": "upstream_error", "status": exc.response.status_code}
-                )
+                return format_s2_error(exc)
             return json.dumps({"candidates": candidates})
 
         try:

--- a/src/scholar_mcp/_tools_utility.py
+++ b/src/scholar_mcp/_tools_utility.py
@@ -17,7 +17,7 @@ from ._epo_client import EpoRateLimitedError
 from ._openlibrary_client import normalize_book
 from ._patent_numbers import is_patent_number, normalize
 from ._rate_limiter import RateLimitedError
-from ._s2_client import FIELD_SETS, format_s2_error
+from ._s2_client import FIELD_SETS, format_s2_error, log_s2_error
 from ._server_deps import ServiceBundle, get_bundle
 
 if TYPE_CHECKING:
@@ -266,7 +266,8 @@ def register_utility_tools(mcp: FastMCP) -> None:
                         identifier, fields="externalIds,paperId", retry=retry
                     )
                     doi = (paper.get("externalIds") or {}).get("DOI")
-                except httpx.HTTPStatusError:
+                except httpx.HTTPStatusError as exc:
+                    log_s2_error(exc)
                     return json.dumps({"error": "not_found", "identifier": identifier})
 
             if not doi:

--- a/src/scholar_mcp/_tools_utility.py
+++ b/src/scholar_mcp/_tools_utility.py
@@ -17,7 +17,7 @@ from ._epo_client import EpoRateLimitedError
 from ._openlibrary_client import normalize_book
 from ._patent_numbers import is_patent_number, normalize
 from ._rate_limiter import RateLimitedError
-from ._s2_client import FIELD_SETS
+from ._s2_client import FIELD_SETS, format_s2_error
 from ._server_deps import ServiceBundle, get_bundle
 
 if TYPE_CHECKING:
@@ -112,12 +112,7 @@ def register_utility_tools(mcp: FastMCP) -> None:
                         paper_ids, fields=FIELD_SETS[fields], retry=retry
                     )
                 except httpx.HTTPStatusError as exc:
-                    return json.dumps(
-                        {
-                            "error": "upstream_error",
-                            "status": exc.response.status_code,
-                        }
-                    )
+                    return format_s2_error(exc)
 
             async def _resolve_paper(
                 idx: int, raw: str, s2_data: PaperRecord | None

--- a/tests/test_s2_client.py
+++ b/tests/test_s2_client.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 
@@ -6,9 +7,12 @@ import pytest
 
 from scholar_mcp._s2_client import (
     FIELD_SETS,
+    KEEPALIVE_INTERVAL_SECONDS,
+    KEEPALIVE_PAPER_ID,
     S2Client,
     format_s2_error,
     log_s2_error,
+    run_keepalive,
 )
 
 S2_BASE = "https://api.semanticscholar.org/graph/v1"
@@ -121,3 +125,112 @@ def test_format_s2_error_non_403_status_preserved():
     assert result["error"] == "upstream_error"
     assert result["status"] == 500
     assert "Internal Server Error" not in result["detail"]
+
+
+@pytest.mark.respx(base_url=S2_BASE)
+async def test_run_keepalive_calls_immediately_then_on_interval(
+    respx_mock, client, caplog, monkeypatch
+):
+    """First call happens before any sleep; loop continues after success."""
+    route = respx_mock.get(f"/paper/{KEEPALIVE_PAPER_ID}").mock(
+        return_value=httpx.Response(200, json={"paperId": "x"})
+    )
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+        if len(sleep_calls) >= 2:
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr("scholar_mcp._s2_client.asyncio.sleep", fake_sleep)
+    with (
+        caplog.at_level(logging.DEBUG, logger="scholar_mcp._s2_client"),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await run_keepalive(client)
+
+    assert route.call_count == 2
+    assert sleep_calls == [KEEPALIVE_INTERVAL_SECONDS, KEEPALIVE_INTERVAL_SECONDS]
+    assert "s2_keepalive_ok" in caplog.text
+
+
+@pytest.mark.respx(base_url=S2_BASE)
+async def test_run_keepalive_403_logs_and_continues(
+    respx_mock, client, caplog, monkeypatch
+):
+    """A 403 mid-loop logs s2_keepalive_key_forbidden but does not kill the loop."""
+    route = respx_mock.get(f"/paper/{KEEPALIVE_PAPER_ID}").mock(
+        side_effect=[
+            httpx.Response(403, json={"message": "Forbidden"}),
+            httpx.Response(200, json={"paperId": "x"}),
+        ]
+    )
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+        if len(sleep_calls) >= 1:
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr("scholar_mcp._s2_client.asyncio.sleep", fake_sleep)
+    with (
+        caplog.at_level(logging.DEBUG, logger="scholar_mcp._s2_client"),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await run_keepalive(client)
+
+    assert route.call_count == 1
+    assert "s2_keepalive_key_forbidden" in caplog.text
+
+
+@pytest.mark.respx(base_url=S2_BASE)
+async def test_run_keepalive_other_failure_logs_warning_and_continues(
+    respx_mock, client, caplog, monkeypatch
+):
+    """A non-403 failure logs s2_keepalive_failed but does not kill the loop."""
+    route = respx_mock.get(f"/paper/{KEEPALIVE_PAPER_ID}").mock(
+        return_value=httpx.Response(500, text="boom")
+    )
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+        if len(sleep_calls) >= 1:
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr("scholar_mcp._s2_client.asyncio.sleep", fake_sleep)
+    with (
+        caplog.at_level(logging.DEBUG, logger="scholar_mcp._s2_client"),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await run_keepalive(client)
+
+    assert route.call_count == 1
+    assert "s2_keepalive_failed" in caplog.text
+
+
+@pytest.mark.respx(base_url=S2_BASE)
+async def test_run_keepalive_rate_limited_logs_and_continues(
+    respx_mock, client, caplog, monkeypatch
+):
+    """A 429 (RateLimitedError, since get_paper is called with retry=False)
+    logs s2_keepalive_rate_limited but does not kill the loop."""
+    route = respx_mock.get(f"/paper/{KEEPALIVE_PAPER_ID}").mock(
+        return_value=httpx.Response(429, text="slow down")
+    )
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+        if len(sleep_calls) >= 1:
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr("scholar_mcp._s2_client.asyncio.sleep", fake_sleep)
+    with (
+        caplog.at_level(logging.DEBUG, logger="scholar_mcp._s2_client"),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await run_keepalive(client)
+
+    assert route.call_count == 1
+    assert "s2_keepalive_rate_limited" in caplog.text

--- a/tests/test_s2_client.py
+++ b/tests/test_s2_client.py
@@ -1,7 +1,15 @@
+import json
+import logging
+
 import httpx
 import pytest
 
-from scholar_mcp._s2_client import FIELD_SETS, S2Client
+from scholar_mcp._s2_client import (
+    FIELD_SETS,
+    S2Client,
+    format_s2_error,
+    log_s2_error,
+)
 
 S2_BASE = "https://api.semanticscholar.org/graph/v1"
 
@@ -71,3 +79,45 @@ def test_field_sets_exist():
     for preset in ("compact", "standard", "full"):
         assert preset in FIELD_SETS
         assert "title" in FIELD_SETS[preset]
+
+
+def _make_error(status_code: int, text: str = "boom") -> httpx.HTTPStatusError:
+    request = httpx.Request("GET", "https://api.semanticscholar.org/graph/v1/paper/x")
+    response = httpx.Response(status_code, text=text, request=request)
+    return httpx.HTTPStatusError(
+        f"{status_code} error", request=request, response=response
+    )
+
+
+def test_log_s2_error_403_logs_key_forbidden(caplog):
+    exc = _make_error(403, text='{"message":"Forbidden"}')
+    with caplog.at_level(logging.WARNING, logger="scholar_mcp._s2_client"):
+        log_s2_error(exc)
+    assert "s2_key_forbidden" in caplog.text
+    assert '{"message":"Forbidden"}' in caplog.text
+
+
+def test_log_s2_error_non_403_logs_upstream_error(caplog):
+    exc = _make_error(500, text="Internal Server Error")
+    with caplog.at_level(logging.WARNING, logger="scholar_mcp._s2_client"):
+        log_s2_error(exc)
+    assert "s2_upstream_error" in caplog.text
+    assert "s2_key_forbidden" not in caplog.text
+    assert "Internal Server Error" in caplog.text
+
+
+def test_format_s2_error_returns_generic_detail_and_status():
+    exc = _make_error(403, text='{"message":"Forbidden"}')
+    result = json.loads(format_s2_error(exc))
+    assert result["error"] == "upstream_error"
+    assert result["status"] == 403
+    assert "Forbidden" not in result["detail"]
+    assert "message" not in result["detail"]
+
+
+def test_format_s2_error_non_403_status_preserved():
+    exc = _make_error(500, text="Internal Server Error")
+    result = json.loads(format_s2_error(exc))
+    assert result["error"] == "upstream_error"
+    assert result["status"] == 500
+    assert "Internal Server Error" not in result["detail"]

--- a/tests/test_s2_client.py
+++ b/tests/test_s2_client.py
@@ -234,3 +234,30 @@ async def test_run_keepalive_rate_limited_logs_and_continues(
 
     assert route.call_count == 1
     assert "s2_keepalive_rate_limited" in caplog.text
+
+
+@pytest.mark.respx(base_url=S2_BASE)
+async def test_run_keepalive_network_error_logs_and_continues(
+    respx_mock, client, caplog, monkeypatch
+):
+    """A network-level failure (httpx.HTTPError, not HTTPStatusError) logs
+    s2_keepalive_failed status=network_error but does not kill the loop."""
+    route = respx_mock.get(f"/paper/{KEEPALIVE_PAPER_ID}").mock(
+        side_effect=httpx.ConnectError("connection refused")
+    )
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+        if len(sleep_calls) >= 1:
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr("scholar_mcp._s2_client.asyncio.sleep", fake_sleep)
+    with (
+        caplog.at_level(logging.DEBUG, logger="scholar_mcp._s2_client"),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await run_keepalive(client)
+
+    assert route.call_count == 1
+    assert "s2_keepalive_failed status=network_error" in caplog.text

--- a/tests/test_server_deps.py
+++ b/tests/test_server_deps.py
@@ -1,7 +1,12 @@
 """Tests for _server_deps module."""
 
+import asyncio
+
+import pytest
+
 from scholar_mcp._enrichment import EnrichmentPipeline
-from scholar_mcp._server_deps import _build_enrichment_pipeline
+from scholar_mcp._s2_client import S2Client
+from scholar_mcp._server_deps import _build_enrichment_pipeline, _start_s2_keepalive
 
 
 def test_build_enrichment_pipeline() -> None:
@@ -10,3 +15,21 @@ def test_build_enrichment_pipeline() -> None:
     assert isinstance(pipeline, EnrichmentPipeline)
     # Should have enrichers in at least two phases (0 and 1)
     assert len(pipeline._phases) >= 2
+
+
+async def test_start_s2_keepalive_returns_none_without_key():
+    """No keepalive task is created when no S2 API key is configured."""
+    client = S2Client(api_key=None, delay=0.0)
+    task = _start_s2_keepalive(client, api_key=None)
+    assert task is None
+
+
+async def test_start_s2_keepalive_creates_task_with_key():
+    """A keepalive task is created and cancellable when an S2 API key is configured."""
+    client = S2Client(api_key="fake-key", delay=0.0)
+    task = _start_s2_keepalive(client, api_key="fake-key")
+    assert task is not None
+    assert isinstance(task, asyncio.Task)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task

--- a/tests/test_server_deps.py
+++ b/tests/test_server_deps.py
@@ -1,12 +1,18 @@
 """Tests for _server_deps module."""
 
 import asyncio
+from pathlib import Path
 
 import pytest
+from fastmcp import FastMCP
 
 from scholar_mcp._enrichment import EnrichmentPipeline
 from scholar_mcp._s2_client import S2Client
-from scholar_mcp._server_deps import _build_enrichment_pipeline, _start_s2_keepalive
+from scholar_mcp._server_deps import (
+    _build_enrichment_pipeline,
+    _start_s2_keepalive,
+    make_service_lifespan,
+)
 
 
 def test_build_enrichment_pipeline() -> None:
@@ -33,3 +39,52 @@ async def test_start_s2_keepalive_creates_task_with_key():
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
         await task
+
+
+async def test_lifespan_starts_and_cancels_keepalive_with_key(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Entering/exiting the real lifespan starts and cleanly cancels the
+    keepalive task end-to-end when an S2 API key is configured."""
+    monkeypatch.setenv("SCHOLAR_MCP_S2_API_KEY", "fake-key")
+    monkeypatch.setenv("SCHOLAR_MCP_CACHE_DIR", str(tmp_path))
+    app = FastMCP(name="test")
+
+    with caplog.at_level("INFO", logger="scholar_mcp._server_deps"):
+        async with make_service_lifespan(app) as ctx:
+            bundle = ctx["bundle"]
+            assert bundle.s2 is not None
+            tasks_while_open = {
+                t
+                for t in asyncio.all_tasks()
+                if t.get_coro().__qualname__ == "run_keepalive"
+            }
+            assert len(tasks_while_open) == 1
+
+    assert "s2_keepalive_started interval_days=7" in caplog.text
+    tasks_after_close = {
+        t for t in asyncio.all_tasks() if t.get_coro().__qualname__ == "run_keepalive"
+    }
+    assert not tasks_after_close
+
+
+async def test_lifespan_does_not_start_keepalive_without_key(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Entering the real lifespan with no S2 API key configured starts no
+    keepalive task."""
+    monkeypatch.delenv("SCHOLAR_MCP_S2_API_KEY", raising=False)
+    monkeypatch.setenv("SCHOLAR_MCP_CACHE_DIR", str(tmp_path))
+    app = FastMCP(name="test")
+
+    with caplog.at_level("INFO", logger="scholar_mcp._server_deps"):
+        async with make_service_lifespan(app) as ctx:
+            assert ctx["bundle"].s2 is not None
+            tasks_while_open = {
+                t
+                for t in asyncio.all_tasks()
+                if t.get_coro().__qualname__ == "run_keepalive"
+            }
+            assert not tasks_while_open
+
+    assert "s2_keepalive_not_started reason=no_api_key" in caplog.text

--- a/tests/test_tools_graph.py
+++ b/tests/test_tools_graph.py
@@ -1314,6 +1314,89 @@ async def test_get_citation_graph_null_data_references(
     assert data["nodes"][0]["id"] == "p1"
 
 
+# --- get_citation_graph logs S2 403s at previously-silent sites (#232) ---
+
+
+@pytest.mark.respx(base_url=S2_BASE)
+async def test_get_citation_graph_seed_resolution_403_logs_key_forbidden(
+    respx_mock: respx.MockRouter, mcp: FastMCP, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A 403 resolving seed metadata logs s2_key_forbidden but doesn't fail
+    the whole call — seeds fall back to title/year=None as before."""
+    respx_mock.post("/paper/batch").mock(
+        return_value=httpx.Response(403, json={"message": "Forbidden"})
+    )
+    respx_mock.get("/paper/p1/citations").mock(
+        return_value=httpx.Response(200, json={"data": []})
+    )
+    with caplog.at_level("WARNING", logger="scholar_mcp._s2_client"):
+        async with Client(mcp) as client:
+            result = await client.call_tool(
+                "get_citation_graph",
+                {"seed_ids": ["p1"], "direction": "citations", "depth": 1},
+            )
+    data = json.loads(result.content[0].text)
+    assert data["nodes"][0]["id"] == "p1"
+    assert data["nodes"][0]["title"] is None
+    assert "s2_key_forbidden" in caplog.text
+
+
+@pytest.mark.respx(base_url=S2_BASE)
+async def test_get_citation_graph_citation_expansion_403_logs_key_forbidden(
+    respx_mock: respx.MockRouter, mcp: FastMCP, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A 403 expanding citations logs s2_key_forbidden but doesn't fail the
+    whole call — that node's expansion is silently skipped as before."""
+    respx_mock.post("/paper/batch").mock(
+        return_value=httpx.Response(
+            200,
+            json=[
+                {"paperId": "p1", "title": "Seed", "year": 2020, "citationCount": 10}
+            ],
+        )
+    )
+    respx_mock.get("/paper/p1/citations").mock(
+        return_value=httpx.Response(403, json={"message": "Forbidden"})
+    )
+    with caplog.at_level("WARNING", logger="scholar_mcp._s2_client"):
+        async with Client(mcp) as client:
+            result = await client.call_tool(
+                "get_citation_graph",
+                {"seed_ids": ["p1"], "direction": "citations", "depth": 1},
+            )
+    data = json.loads(result.content[0].text)
+    assert data["stats"]["total_nodes"] == 1
+    assert "s2_key_forbidden" in caplog.text
+
+
+@pytest.mark.respx(base_url=S2_BASE)
+async def test_get_citation_graph_reference_expansion_403_logs_key_forbidden(
+    respx_mock: respx.MockRouter, mcp: FastMCP, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A 403 expanding references logs s2_key_forbidden but doesn't fail the
+    whole call — that node's expansion is silently skipped as before."""
+    respx_mock.post("/paper/batch").mock(
+        return_value=httpx.Response(
+            200,
+            json=[
+                {"paperId": "p1", "title": "Seed", "year": 2020, "citationCount": 10}
+            ],
+        )
+    )
+    respx_mock.get("/paper/p1/references").mock(
+        return_value=httpx.Response(403, json={"message": "Forbidden"})
+    )
+    with caplog.at_level("WARNING", logger="scholar_mcp._s2_client"):
+        async with Client(mcp) as client:
+            result = await client.call_tool(
+                "get_citation_graph",
+                {"seed_ids": ["p1"], "direction": "references", "depth": 1},
+            )
+    data = json.loads(result.content[0].text)
+    assert data["stats"]["total_nodes"] == 1
+    assert "s2_key_forbidden" in caplog.text
+
+
 # --- Bug fix: get_citations applies min_citations client-side (#37) ---
 
 

--- a/tests/test_tools_search.py
+++ b/tests/test_tools_search.py
@@ -221,7 +221,7 @@ async def test_get_paper_upstream_error_non_404(
     data = json.loads(result.content[0].text)
     assert data["error"] == "upstream_error"
     assert data["status"] == 500
-    assert "Server Error" in data["detail"]
+    assert "Server Error" not in data["detail"]
 
 
 @pytest.mark.respx(base_url=S2_BASE)


### PR DESCRIPTION
## Summary

- Add an in-process keepalive task that pings Semantic Scholar once on
  startup and every 7 days thereafter, to prevent the API key from being
  removed for 60-day inactivity (root cause of a recent production
  incident on ai-scholar-mcp).
- Route all S2-related tool call sites (16 total) through shared
  `format_s2_error`/`log_s2_error` helpers so a 403 (dead/revoked key)
  is logged with a distinct, greppable event name
  (`s2_key_forbidden`/`s2_keepalive_key_forbidden`), separate from
  ordinary 429 rate-limit retries. LLM-facing error JSON now returns a
  generic `detail` message instead of raw upstream response text — full
  detail is available in the server logs.
- Document the new keepalive/logging behavior in README.md.

Deferred to separate tracking issues (not in scope here):
- #229 — surfacing S2 key health via `get_server_info` (no external
  monitoring currently polls this server, so it'd be inert today).
- #230 — a pre-existing, repo-wide lifespan-startup-exception resource
  leak (predates this branch; needs an `AsyncExitStack` refactor across
  all ~10 lifespan resources, not just S2).

Closes #228

## Test plan

- [x] `uv run pytest -x -q` — 1054 passed, 2 skipped (pre-existing/unrelated), 4 deselected
- [x] `uv run ruff check --fix . && uv run ruff format . && uv run ruff format --check .`
- [x] `uv run mypy src/ tests/` — no issues
- [x] `uv run pre-commit run --all-files` — all hooks pass
- [x] All 4 `run_keepalive` failure branches (rate-limited, 403, other HTTP status, network error) covered by dedicated tests
- [x] Whole-branch code review completed (1 Important + 3 Minor findings, all fixed)
- [ ] Deploy to `ai-scholar-mcp` after S2 key rotation and confirm
      `s2_keepalive_started` appears in `docker logs` on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)